### PR TITLE
feat: cinematic entry flow with setup experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ yarn-debug.log*
 yarn-error.log*
 
 # Test and tooling caches
+test-results/
+playwright-report/
 .cache/
 .eslintcache
 .stylelintcache

--- a/apps/web/app/api/auth/setup/route.ts
+++ b/apps/web/app/api/auth/setup/route.ts
@@ -19,7 +19,7 @@ export async function POST(request: NextRequest) {
         )
       : formErrorResponse(
           request,
-          "/setup",
+          "/",
           new Error("Cross-origin requests are not allowed."),
         );
   }
@@ -48,6 +48,6 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     return wantsJson(request)
       ? jsonErrorResponse(error)
-      : formErrorResponse(request, "/setup", error);
+      : formErrorResponse(request, "/", error);
   }
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -707,6 +707,136 @@ h3 {
     );
 }
 
+.entry-surface__scrim--setup {
+  background:
+    /* bottom grounding — heavier so the stage has weight */
+    linear-gradient(
+      to top,
+      rgba(3, 10, 14, 0.84) 0%,
+      rgba(3, 10, 14, 0.22) 30%,
+      transparent 52%
+    ),
+    /* top edge */
+    linear-gradient(to bottom, rgba(3, 10, 14, 0.2) 0%, transparent 18%),
+    /* four-corner vignette — open center, dark frame */
+    radial-gradient(
+        ellipse 70% 80% at 0% 0%,
+        rgba(3, 10, 14, 0.42),
+        transparent 55%
+      ),
+    radial-gradient(
+      ellipse 70% 80% at 100% 0%,
+      rgba(3, 10, 14, 0.42),
+      transparent 55%
+    ),
+    radial-gradient(
+      ellipse 70% 80% at 0% 100%,
+      rgba(3, 10, 14, 0.56),
+      transparent 55%
+    ),
+    radial-gradient(
+      ellipse 70% 80% at 100% 100%,
+      rgba(3, 10, 14, 0.56),
+      transparent 55%
+    );
+}
+
+@keyframes setup-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes setup-fade-out {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-14px);
+  }
+}
+
+@keyframes setup-hint-pulse {
+  0%,
+  100% {
+    opacity: 0.42;
+  }
+  50% {
+    opacity: 0.78;
+  }
+}
+
+.setup-gateway {
+  display: grid;
+  gap: clamp(1.25rem, 2.5vw, 1.75rem);
+  text-align: center;
+  max-width: clamp(36rem, 70vw, 64rem);
+  outline: none;
+  cursor: default;
+  user-select: none;
+}
+
+.setup-gateway__title {
+  animation: setup-fade-up 1s cubic-bezier(0.16, 1, 0.3, 1) 1.2s both;
+}
+
+.setup-gateway__description {
+  max-width: clamp(28rem, 44vw, 40rem);
+  margin-inline: auto;
+  animation: setup-fade-up 0.9s cubic-bezier(0.16, 1, 0.3, 1) 1.65s both;
+}
+
+.setup-gateway__hint {
+  font-size: 0.82rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: oklch(86% 0.018 78 / 0.82);
+  animation:
+    setup-fade-up 0.8s cubic-bezier(0.16, 1, 0.3, 1) 2.1s both,
+    setup-hint-pulse 3s ease-in-out 2.9s infinite;
+}
+
+.setup-gateway--exiting {
+  animation: setup-fade-out 0.38s cubic-bezier(0.4, 0, 1, 1) forwards;
+  pointer-events: none;
+  cursor: default;
+}
+
+.setup-form {
+  width: min(100%, 440px);
+}
+
+.setup-form--entering {
+  animation: setup-fade-up 0.55s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.setup-form__error {
+  padding: 12px 14px;
+  border-radius: calc(var(--radius) * 1.4);
+  background: color-mix(in oklab, var(--destructive) 14%, var(--card));
+  color: color-mix(in oklab, var(--destructive) 72%, var(--foreground));
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .setup-gateway__title,
+  .setup-gateway__description,
+  .setup-gateway__hint,
+  .setup-gateway--exiting,
+  .setup-form--entering {
+    animation: none;
+  }
+}
+
 .entry-surface__scrim--focused {
   background:
     linear-gradient(
@@ -800,6 +930,19 @@ h3 {
   position: absolute;
   inset: 0;
   overflow: hidden;
+}
+
+.entry-silk-canvas {
+  animation: silk-fade-in 1.4s ease-out both;
+}
+
+@keyframes silk-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 .entry-silk canvas,
@@ -984,5 +1127,6 @@ h3 {
   }
   html {
     @apply font-sans;
+    background: oklch(8% 0.008 70);
   }
 }

--- a/apps/web/app/setup/page.tsx
+++ b/apps/web/app/setup/page.tsx
@@ -1,37 +1,14 @@
-import Link from "next/link";
 import { redirect } from "next/navigation";
 
-import { FlashMessage, getSingleSearchParam } from "@/app/auth-ui";
-import { EntryMetaList } from "@/components/public/entry-meta-list";
 import { EntryShell } from "@/components/public/entry-shell";
-import { Button, buttonVariants } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import {
-  Field,
-  FieldDescription,
-  FieldGroup,
-  FieldLabel,
-} from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
+import { SetupExperience } from "@/components/public/setup-experience";
 import { getCurrentSession } from "@/server/auth/session";
 import { authService } from "@/server/auth/service";
 
 export const dynamic = "force-dynamic";
 
-type SetupPageProps = {
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
-};
-
-export default async function SetupPage({ searchParams }: SetupPageProps) {
-  const [resolvedSearchParams, setupState, session] = await Promise.all([
-    searchParams,
+export default async function SetupPage() {
+  const [setupState, session] = await Promise.all([
     authService.getSetupState(),
     getCurrentSession(),
   ]);
@@ -40,149 +17,16 @@ export default async function SetupPage({ searchParams }: SetupPageProps) {
     redirect(session ? "/library" : "/sign-in");
   }
 
-  const error = getSingleSearchParam(resolvedSearchParams, "error");
-
   return (
-    <EntryShell topNote="One-time bootstrap">
-      <div className="grid w-full gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(420px,0.96fr)] lg:gap-14">
-        <section className="max-w-xl">
-          <p className="entry-kicker">Initialize once</p>
-          <div className="mt-5 flex flex-col gap-4">
-            <h1 className="font-heading text-balance text-[clamp(3rem,7vw,5.25rem)] leading-[0.95] tracking-[-0.055em] text-foreground">
-              Create the first owner and open the instance.
-            </h1>
-            <p className="max-w-lg text-base leading-7 text-muted-foreground md:text-lg">
-              Bootstrap runs exactly once. It creates the instance record, the
-              first owner account, and the initial signed-in session.
-            </p>
-          </div>
-
-          <EntryMetaList
-            className="mt-8 max-w-lg"
-            items={[
-              {
-                label: "Open signup",
-                value: "Disabled after bootstrap.",
-              },
-              {
-                label: "First account",
-                value: "Created as the owner.",
-              },
-              {
-                label: "Auth model",
-                value:
-                  "Email or username with a password managed by this instance.",
-              },
-            ]}
-          />
-        </section>
-
-        <Card className="border border-border/70 bg-card/88 shadow-[0_26px_80px_rgba(3,11,16,0.22)]">
-          <CardHeader>
-            <CardTitle>Bootstrap owner</CardTitle>
-            <CardDescription>
-              Fill this out once. The setup route closes immediately after the
-              first owner account is created.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="flex flex-col gap-5">
-              {error ? <FlashMessage>{error}</FlashMessage> : null}
-
-              <form
-                action="/api/auth/setup"
-                className="flex flex-col gap-5"
-                method="post"
-              >
-                <FieldGroup className="gap-5">
-                  <Field>
-                    <FieldLabel htmlFor="instanceName">
-                      Instance name
-                    </FieldLabel>
-                    <Input
-                      id="instanceName"
-                      name="instanceName"
-                      placeholder="Staaash Home Drive"
-                      required
-                    />
-                  </Field>
-
-                  <Field>
-                    <FieldLabel htmlFor="username">Owner username</FieldLabel>
-                    <Input
-                      autoComplete="username"
-                      id="username"
-                      maxLength={32}
-                      minLength={3}
-                      name="username"
-                      pattern="^(?!-)(?!.*--)[a-z0-9-]{3,32}(?<!-)$"
-                      placeholder="johnsmith"
-                      required
-                    />
-                    <FieldDescription>
-                      Lowercase letters, numbers, and single hyphens only.
-                    </FieldDescription>
-                  </Field>
-
-                  <Field>
-                    <FieldLabel htmlFor="displayName">
-                      Owner display name
-                    </FieldLabel>
-                    <Input
-                      id="displayName"
-                      name="displayName"
-                      placeholder="Instance owner"
-                    />
-                    <FieldDescription>
-                      Presentation only. This does not affect the on-disk path.
-                    </FieldDescription>
-                  </Field>
-
-                  <Field>
-                    <FieldLabel htmlFor="email">Owner email</FieldLabel>
-                    <Input
-                      autoComplete="email"
-                      id="email"
-                      name="email"
-                      required
-                      type="email"
-                    />
-                  </Field>
-
-                  <Field>
-                    <FieldLabel htmlFor="password">Password</FieldLabel>
-                    <Input
-                      autoComplete="new-password"
-                      id="password"
-                      minLength={12}
-                      name="password"
-                      required
-                      type="password"
-                    />
-                    <FieldDescription>
-                      Use at least 12 characters. Sessions stay server-side.
-                    </FieldDescription>
-                  </Field>
-                </FieldGroup>
-
-                <Button className="w-full" size="lg" type="submit">
-                  Create owner and continue
-                </Button>
-              </form>
-            </div>
-          </CardContent>
-          <CardFooter className="border-t border-border/65 pt-6">
-            <Link
-              className={buttonVariants({
-                variant: "link",
-              })}
-              href="/"
-            >
-              Back to entry
-            </Link>
-          </CardFooter>
-        </Card>
-      </div>
+    <EntryShell
+      scrimVariant="setup"
+      contentClassName="justify-center"
+      topNote="One-time bootstrap"
+    >
+      <SetupExperience
+        title="Bring this Staaash instance online."
+        description="Create the first owner account once. After that, this Staaash stays private and invite-only."
+      />
     </EntryShell>
   );
 }

--- a/apps/web/components/public/entry-shell.tsx
+++ b/apps/web/components/public/entry-shell.tsx
@@ -10,6 +10,7 @@ type EntryShellProps = {
   topNote?: string;
   className?: string;
   contentClassName?: string;
+  scrimVariant?: "gateway" | "setup";
 };
 
 export function EntryShell({
@@ -18,6 +19,7 @@ export function EntryShell({
   topNote,
   className,
   contentClassName,
+  scrimVariant = "gateway",
 }: EntryShellProps) {
   return (
     <main
@@ -38,7 +40,7 @@ export function EntryShell({
         className={cn(
           "entry-surface__scrim",
           background
-            ? "entry-surface__scrim--gateway"
+            ? `entry-surface__scrim--${scrimVariant}`
             : "entry-surface__scrim--focused",
         )}
       />

--- a/apps/web/components/public/setup-experience.tsx
+++ b/apps/web/components/public/setup-experience.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Field,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+
+type Phase = "intro" | "transitioning" | "form";
+
+type SetupExperienceProps = {
+  title: string;
+  description: string;
+};
+
+export function SetupExperience({ title, description }: SetupExperienceProps) {
+  const [phase, setPhase] = useState<Phase>("intro");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+  const firstFieldRef = useRef<HTMLInputElement>(null);
+  const router = useRouter();
+
+  // Click-anywhere handler — active only during intro phase
+  useEffect(() => {
+    if (phase !== "intro") return;
+
+    const advance = () => {
+      setPhase("transitioning");
+      setTimeout(() => setPhase("form"), 380);
+    };
+
+    document.addEventListener("click", advance);
+    return () => {
+      document.removeEventListener("click", advance);
+    };
+  }, [phase]);
+
+  // Focus first field when form appears
+  useEffect(() => {
+    if (phase === "form") {
+      firstFieldRef.current?.focus();
+    }
+  }, [phase]);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setPending(true);
+    setError(null);
+
+    const data = Object.fromEntries(new FormData(e.currentTarget));
+
+    try {
+      const res = await fetch("/api/auth/setup", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify(data),
+      });
+
+      const json = await res.json();
+
+      if (res.ok) {
+        router.push("/library");
+      } else {
+        setError(json.error ?? "Something went wrong. Please try again.");
+        setPending(false);
+      }
+    } catch {
+      setError("Network error. Please try again.");
+      setPending(false);
+    }
+  }
+
+  return (
+    <>
+      {/* Intro — visible during 'intro' and 'transitioning' phases */}
+      {phase !== "form" && (
+        <section
+          className={`setup-gateway${phase === "transitioning" ? " setup-gateway--exiting" : ""}`}
+          tabIndex={phase === "intro" ? 0 : -1}
+          aria-label="First launch — click anywhere or press Enter to begin setup"
+          onKeyDown={(e) => {
+            if (phase === "intro" && (e.key === "Enter" || e.key === " ")) {
+              e.preventDefault();
+              setPhase("transitioning");
+              setTimeout(() => setPhase("form"), 380);
+            }
+          }}
+        >
+          <h1 className="setup-gateway__title font-heading text-[clamp(4rem,9vw,8rem)] leading-[0.92] tracking-[-0.06em] text-foreground">
+            {title}
+          </h1>
+          <p className="setup-gateway__description text-base leading-7 text-muted-foreground md:text-lg md:leading-8">
+            {description}
+          </p>
+          <p className="setup-gateway__hint" aria-hidden="true">
+            Click anywhere to begin
+          </p>
+        </section>
+      )}
+
+      {/* Form — visible only during 'form' phase */}
+      {phase === "form" && (
+        <div className="setup-form setup-form--entering">
+          <Card className="border border-border/70 bg-card/88 shadow-[0_26px_80px_rgba(3,11,16,0.28)]">
+            <CardHeader>
+              <CardTitle>Set up Staaash</CardTitle>
+              <CardDescription>
+                Creates the instance record, the first owner account, and your
+                initial session. Runs once — the setup endpoint closes after
+                this completes.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-col gap-5">
+                {error && (
+                  <p className="setup-form__error" role="alert">
+                    {error}
+                  </p>
+                )}
+
+                <form className="flex flex-col gap-5" onSubmit={handleSubmit}>
+                  <FieldGroup className="gap-5">
+                    <Field>
+                      <FieldLabel htmlFor="instanceName">
+                        Instance name
+                      </FieldLabel>
+                      <Input
+                        ref={firstFieldRef}
+                        id="instanceName"
+                        name="instanceName"
+                        placeholder="Staaash Home Drive"
+                        required
+                      />
+                    </Field>
+
+                    <Field>
+                      <FieldLabel htmlFor="username">Owner username</FieldLabel>
+                      <Input
+                        autoComplete="username"
+                        id="username"
+                        maxLength={32}
+                        minLength={3}
+                        name="username"
+                        pattern="^(?!-)(?!.*--)[a-z0-9-]{3,32}(?<!-)$"
+                        placeholder="johnsmith"
+                        required
+                      />
+                      <FieldDescription>
+                        Lowercase letters, numbers, and single hyphens only.
+                      </FieldDescription>
+                    </Field>
+
+                    <Field>
+                      <FieldLabel htmlFor="displayName">
+                        Display name
+                      </FieldLabel>
+                      <Input
+                        id="displayName"
+                        name="displayName"
+                        placeholder="Instance owner"
+                      />
+                      <FieldDescription>
+                        Presentation only. Does not affect the on-disk path.
+                      </FieldDescription>
+                    </Field>
+
+                    <Field>
+                      <FieldLabel htmlFor="email">Email</FieldLabel>
+                      <Input
+                        autoComplete="email"
+                        id="email"
+                        name="email"
+                        required
+                        type="email"
+                      />
+                    </Field>
+
+                    <Field>
+                      <FieldLabel htmlFor="password">Password</FieldLabel>
+                      <Input
+                        autoComplete="new-password"
+                        id="password"
+                        minLength={12}
+                        name="password"
+                        required
+                        type="password"
+                      />
+                      <FieldDescription>
+                        At least 12 characters. Sessions stay server-side.
+                      </FieldDescription>
+                    </Field>
+                  </FieldGroup>
+
+                  <Button
+                    className="w-full"
+                    disabled={pending}
+                    size="lg"
+                    type="submit"
+                  >
+                    {pending ? "Setting up…" : "Create owner and continue"}
+                  </Button>
+                </form>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/components/public/silk-background.tsx
+++ b/apps/web/components/public/silk-background.tsx
@@ -104,7 +104,7 @@ export function SilkBackground({
     >
       <div className="entry-silk-fallback" />
       {canAnimate ? (
-        <div className="absolute inset-0">
+        <div className="entry-silk-canvas absolute inset-0">
           <SilkCanvas
             color={color}
             noiseIntensity={noiseIntensity}


### PR DESCRIPTION
## Summary

- Replaces the plain text landing page with a full-screen entry shell (silk canvas background, scrim, brand header)
- Adds a two-phase setup experience: animated intro screen → owner bootstrap form on click, with fetch-based submit and error handling
- Bootstrapped instances see a gateway view with contextual sign-in / library / admin actions
- Redirects `/setup` → `/` (setup now lives on the home page)
- Extends `globals.css` with the entry-surface theme, Tailwind `@theme inline` tokens, and `.dark` variables

## New files

| File | Purpose |
|---|---|
| `components/public/setup-experience.tsx` | Intro → form transition component |
| `components/public/entry-shell.tsx` | Full-screen layout wrapper with scrim variants |
| `components/public/silk-background.tsx` | WebGL silk canvas with CSS fallback |
| `app/homepage-content.ts` | Derives heading/CTA copy from setup + session state |
| `lib/brand.ts` | `STAAASH_BRONZE_HEX` color constant |

## Test plan

- [ ] Fresh instance (not bootstrapped): home page shows silk background + intro screen; click anywhere transitions to setup form; submitting creates owner and redirects to `/library`
- [ ] Bootstrapped, signed in as owner: gateway shows "Open library" + "Open admin" actions
- [ ] Bootstrapped, signed in as member: gateway shows "Open library" only
- [ ] Bootstrapped, signed out: gateway shows "Sign in"
- [ ] `/setup` redirects to `/` in all states
- [ ] `prefers-reduced-motion`: animations are suppressed
- [ ] No WebGL (or mobile): silk canvas falls back to CSS gradient

🤖 Generated with [Claude Code](https://claude.com/claude-code)