### PR TITLE
feat: unified cinematic entry experience at /

### DIFF
--- a/apps/web/app/api/auth/sign-out/route.ts
+++ b/apps/web/app/api/auth/sign-out/route.ts
@@ -30,10 +30,7 @@ export async function POST(request: NextRequest) {
   }
 
   const body = await readRequestBody(request);
-  const next = getSafeRedirectTarget(
-    body.next,
-    "/sign-in?success=Signed%20out.",
-  );
+  const next = getSafeRedirectTarget(body.next, "/");
 
   try {
     await authService.revokeSession(

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -651,7 +651,6 @@ h3 {
   padding: 0;
   overflow-x: hidden;
   overflow-y: auto;
-  scrollbar-gutter: stable;
   color-scheme: dark;
   color: var(--foreground);
 }
@@ -773,67 +772,213 @@ h3 {
   }
 }
 
-.setup-gateway {
+/* ---- Entry Experience — intro + form + success ---- */
+
+.entry-intro {
   display: grid;
-  gap: clamp(1.25rem, 2.5vw, 1.75rem);
+  gap: clamp(1rem, 2vw, 1.4rem);
   text-align: center;
-  max-width: clamp(36rem, 70vw, 64rem);
+  max-width: clamp(22rem, 50vw, 44rem);
   outline: none;
   cursor: default;
   user-select: none;
 }
 
-.setup-gateway__title {
-  animation: setup-fade-up 1s cubic-bezier(0.16, 1, 0.3, 1) 1.2s both;
+.entry-intro__title {
+  font-size: clamp(2.8rem, 5.2vw, 4.8rem);
+  line-height: 1.02;
+  letter-spacing: -0.04em;
+  color: var(--foreground);
+  animation: setup-fade-up 0.9s cubic-bezier(0.16, 1, 0.3, 1) 1.1s both;
 }
 
-.setup-gateway__description {
-  max-width: clamp(28rem, 44vw, 40rem);
+.entry-intro__description {
+  font-size: 1rem;
+  line-height: 1.72;
+  color: var(--muted-foreground);
+  max-width: 30rem;
   margin-inline: auto;
-  animation: setup-fade-up 0.9s cubic-bezier(0.16, 1, 0.3, 1) 1.65s both;
+  animation: setup-fade-up 0.8s cubic-bezier(0.16, 1, 0.3, 1) 1.5s both;
 }
 
-.setup-gateway__hint {
-  font-size: 0.82rem;
+.entry-intro__hint {
+  font-size: 0.72rem;
   font-weight: 500;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: oklch(86% 0.018 78 / 0.82);
-  animation:
-    setup-fade-up 0.8s cubic-bezier(0.16, 1, 0.3, 1) 2.1s both,
-    setup-hint-pulse 3s ease-in-out 2.9s infinite;
+  color: oklch(86% 0.018 78 / 0.42);
+  margin-top: 0.25rem;
+  animation: setup-fade-up 0.7s cubic-bezier(0.16, 1, 0.3, 1) 1.9s both;
 }
 
-.setup-gateway--exiting {
-  animation: setup-fade-out 0.38s cubic-bezier(0.4, 0, 1, 1) forwards;
+.entry-intro--exiting {
+  animation: setup-fade-out 0.36s cubic-bezier(0.4, 0, 1, 1) forwards;
   pointer-events: none;
-  cursor: default;
 }
 
-.setup-form {
-  width: min(100%, 440px);
+/* Prevent child fill-mode from snapping to opacity:0 during exit */
+.entry-intro--exiting .entry-intro__title,
+.entry-intro--exiting .entry-intro__description,
+.entry-intro--exiting .entry-intro__hint {
+  animation: none;
 }
 
-.setup-form--entering {
-  animation: setup-fade-up 0.55s cubic-bezier(0.16, 1, 0.3, 1) both;
+/* Returning from form — quick staggered fade, no long initial delays */
+.entry-intro--returning .entry-intro__title {
+  animation: setup-fade-up 0.5s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
-.setup-form__error {
-  padding: 12px 14px;
-  border-radius: calc(var(--radius) * 1.4);
-  background: color-mix(in oklab, var(--destructive) 14%, var(--card));
-  color: color-mix(in oklab, var(--destructive) 72%, var(--foreground));
-  font-size: 0.875rem;
+.entry-intro--returning .entry-intro__description {
+  animation: setup-fade-up 0.5s cubic-bezier(0.16, 1, 0.3, 1) 0.07s both;
+}
+
+.entry-intro--returning .entry-intro__hint {
+  animation: setup-fade-up 0.5s cubic-bezier(0.16, 1, 0.3, 1) 0.14s both;
+}
+
+/* Floating form — no card, no container box */
+
+.entry-form {
+  width: min(100%, 380px);
+  display: grid;
+  gap: 0;
+}
+
+.entry-form--entering {
+  animation: setup-fade-up 0.5s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.entry-form--exiting {
+  animation: setup-fade-out 0.3s cubic-bezier(0.4, 0, 1, 1) forwards;
+  pointer-events: none;
+}
+
+.entry-form__fields {
+  display: grid;
+  gap: 18px;
+}
+
+.entry-form__error {
+  margin-bottom: 14px;
+  font-size: 0.825rem;
   line-height: 1.5;
+  text-align: center;
+  color: color-mix(in oklab, var(--destructive) 82%, var(--foreground));
+}
+
+.entry-form__field {
+  display: grid;
+  gap: 6px;
+}
+
+.entry-form__label {
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  color: oklch(72% 0.014 76);
+}
+
+.entry-form__input {
+  width: 100%;
+  padding: 11px 14px;
+  background: oklch(18% 0.01 72 / 0.65);
+  border: 1px solid oklch(40% 0.012 76 / 0.45);
+  border-radius: 8px;
+  color: var(--foreground);
+  font-family: var(--font-switzer), "Segoe UI", sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  -webkit-appearance: none;
+  appearance: none;
+  transition:
+    border-color 150ms ease-out,
+    background 150ms ease-out;
+}
+
+.entry-form__input::placeholder {
+  color: oklch(55% 0.01 76 / 0.65);
+}
+
+.entry-form__input:focus {
+  outline: none;
+  border-color: oklch(74% 0.08 78 / 0.65);
+  background: oklch(20% 0.01 72 / 0.75);
+}
+
+.entry-form__input:focus-visible {
+  outline: 2px solid oklch(74% 0.08 78 / 0.32);
+  outline-offset: 2px;
+}
+
+.entry-form__help {
+  font-size: 0.75rem;
+  line-height: 1.5;
+  color: oklch(62% 0.01 76 / 0.75);
+}
+
+.entry-form__submit {
+  width: 100%;
+  min-height: 44px;
+  padding: 0 20px;
+  margin-top: 6px;
+  background: oklch(74% 0.08 78);
+  color: oklch(18% 0.015 72);
+  border: none;
+  border-radius: 8px;
+  font-family: var(--font-switzer), "Segoe UI", sans-serif;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 150ms ease-out;
+}
+
+.entry-form__submit:hover:not(:disabled) {
+  opacity: 0.88;
+}
+
+.entry-form__submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.entry-form__submit:focus-visible {
+  outline: 2px solid oklch(74% 0.08 78 / 0.5);
+  outline-offset: 3px;
+}
+
+/* ---- Success ---- */
+
+.entry-success {
+  display: grid;
+  place-items: center;
+}
+
+.entry-success__message {
+  font-size: clamp(2.8rem, 5.2vw, 4.8rem);
+  font-family: var(--font-cabinet), "Arial Narrow", "Segoe UI", sans-serif;
+  line-height: 1.02;
+  letter-spacing: -0.04em;
+  color: var(--foreground);
+  animation: setup-fade-up 0.9s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .setup-gateway__title,
-  .setup-gateway__description,
-  .setup-gateway__hint,
-  .setup-gateway--exiting,
-  .setup-form--entering {
+  .entry-intro__title,
+  .entry-intro__description,
+  .entry-intro__hint,
+  .entry-intro--exiting,
+  .entry-intro--returning .entry-intro__title,
+  .entry-intro--returning .entry-intro__description,
+  .entry-intro--returning .entry-intro__hint,
+  .entry-form--entering,
+  .entry-form--exiting,
+  .entry-success__message {
     animation: none;
+  }
+
+  .entry-form__input,
+  .entry-form__submit {
+    transition: none;
   }
 }
 
@@ -858,6 +1003,11 @@ h3 {
   line-height: 1;
   letter-spacing: -0.05em;
   text-wrap: balance;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
 }
 
 .entry-top-note {
@@ -957,17 +1107,18 @@ h3 {
   background:
     radial-gradient(
       circle at 24% 26%,
-      rgba(206, 176, 116, 0.34),
-      transparent 28%
+      rgba(206, 176, 116, 0.72),
+      transparent 38%
     ),
     radial-gradient(
       circle at 72% 38%,
-      rgba(150, 112, 66, 0.24),
-      transparent 24%
+      rgba(150, 112, 66, 0.52),
+      transparent 34%
     ),
-    linear-gradient(140deg, rgba(11, 23, 29, 0.14), rgba(11, 23, 29, 0.36));
-  filter: blur(12px);
-  opacity: 0.88;
+    radial-gradient(circle at 50% 80%, rgba(90, 64, 28, 0.38), transparent 42%),
+    linear-gradient(160deg, oklch(16% 0.018 72), oklch(10% 0.01 70));
+  filter: blur(18px);
+  opacity: 1;
   transform: scale(1.08);
 }
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { redirect } from "next/navigation";
 
 import { EntryRoot } from "@/components/public/entry-root";

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,14 +1,8 @@
-import React from "react";
-import Link from "next/link";
 import { redirect } from "next/navigation";
 
-import { EntryShell } from "@/components/public/entry-shell";
-import { SilkBackground } from "@/components/public/silk-background";
-import { buttonVariants } from "@/components/ui/button";
-import { getHomePageContent } from "@/app/homepage-content";
-import { STAAASH_BRONZE_HEX } from "@/lib/brand";
-import { getCurrentSession } from "@/server/auth/session";
+import { EntryRoot } from "@/components/public/entry-root";
 import { authService } from "@/server/auth/service";
+import { getCurrentSession } from "@/server/auth/session";
 
 export const dynamic = "force-dynamic";
 
@@ -22,66 +16,10 @@ export default async function HomePage() {
     redirect("/library");
   }
 
-  const content = getHomePageContent({
-    isBootstrapped: setupState.isBootstrapped,
-    role: null,
-  });
-
   return (
-    <EntryShell
-      background={
-        <SilkBackground
-          color={STAAASH_BRONZE_HEX}
-          noiseIntensity={1.1}
-          opacity={0.56}
-          rotation={0.1}
-          scale={1.08}
-          speed={4.2}
-        />
-      }
-    >
-      <section className="entry-gateway">
-        <div className="entry-gateway__copy">
-          <h1 className="entry-gateway__title font-heading text-[clamp(3.5rem,7.6vw,6.6rem)] leading-[0.94] tracking-[-0.06em] text-foreground">
-            {content.title}
-          </h1>
-          <p className="entry-gateway__description text-base leading-7 text-muted-foreground md:text-lg md:leading-8">
-            {content.description}
-          </p>
-
-          <div className="entry-gateway__actions">
-            <Link
-              className={buttonVariants({
-                size: "lg",
-                className:
-                  "entry-gateway__primary-action h-12 px-6 text-[0.95rem] font-semibold",
-              })}
-              href={content.primaryAction.href}
-            >
-              {content.primaryAction.label}
-            </Link>
-
-            {content.secondaryAction ? (
-              <Link
-                className={buttonVariants({
-                  size: "lg",
-                  variant: "link",
-                  className: "entry-gateway__secondary-action",
-                })}
-                href={content.secondaryAction.href}
-              >
-                {content.secondaryAction.label}
-              </Link>
-            ) : null}
-          </div>
-
-          {content.supportNote ? (
-            <p className="entry-gateway__support text-sm leading-6 text-[color:var(--entry-muted-soft)] sm:text-[0.95rem]">
-              {content.supportNote}
-            </p>
-          ) : null}
-        </div>
-      </section>
-    </EntryShell>
+    <EntryRoot
+      mode={setupState.isBootstrapped ? "signin" : "setup"}
+      instanceName={setupState.instanceName ?? undefined}
+    />
   );
 }

--- a/apps/web/app/setup/page.tsx
+++ b/apps/web/app/setup/page.tsx
@@ -1,32 +1,7 @@
 import { redirect } from "next/navigation";
 
-import { EntryShell } from "@/components/public/entry-shell";
-import { SetupExperience } from "@/components/public/setup-experience";
-import { getCurrentSession } from "@/server/auth/session";
-import { authService } from "@/server/auth/service";
-
 export const dynamic = "force-dynamic";
 
-export default async function SetupPage() {
-  const [setupState, session] = await Promise.all([
-    authService.getSetupState(),
-    getCurrentSession(),
-  ]);
-
-  if (setupState.isBootstrapped) {
-    redirect(session ? "/library" : "/sign-in");
-  }
-
-  return (
-    <EntryShell
-      scrimVariant="setup"
-      contentClassName="justify-center"
-      topNote="One-time bootstrap"
-    >
-      <SetupExperience
-        title="Bring this Staaash instance online."
-        description="Create the first owner account once. After that, this Staaash stays private and invite-only."
-      />
-    </EntryShell>
-  );
+export default function SetupPage() {
+  redirect("/");
 }

--- a/apps/web/components/public/entry-experience.tsx
+++ b/apps/web/components/public/entry-experience.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
+export type Phase =
+  | "intro"
+  | "intro-return"
+  | "transitioning"
+  | "form"
+  | "exiting-to-intro"
+  | "success";
+
+type EntryExperienceProps = {
+  mode: "setup" | "signin";
+  phase: Phase;
+  setPhase: (phase: Phase) => void;
+  instanceName?: string;
+};
+
+const config = {
+  setup: {
+    title: "Bring your Staaash online.",
+    description:
+      "Create the first owner account. After this, your instance is private and invite-only.",
+    endpoint: "/api/auth/setup",
+    successMessage: "Welcome to your Staaash.",
+  },
+  signin: {
+    title: "Your Staaash.",
+    description: "Sign in to open your files.",
+    endpoint: "/api/auth/sign-in",
+    successMessage: "Welcome back.",
+  },
+} as const;
+
+export function EntryExperience({
+  mode,
+  phase,
+  setPhase,
+  instanceName,
+}: EntryExperienceProps) {
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+  const firstFieldRef = useRef<HTMLInputElement>(null);
+  const router = useRouter();
+
+  const { description, endpoint, successMessage } = config[mode];
+  const title =
+    mode === "signin" && instanceName ? instanceName : config[mode].title;
+
+  // Click-anywhere handler — active during intro and intro-return phases
+  useEffect(() => {
+    if (phase !== "intro" && phase !== "intro-return") return;
+
+    const advance = (e: MouseEvent) => {
+      if ((e.target as Element).closest(".entry-brand")) return;
+      setPhase("transitioning");
+      setTimeout(() => setPhase("form"), 360);
+    };
+
+    document.addEventListener("click", advance);
+    return () => document.removeEventListener("click", advance);
+  }, [phase]);
+
+  // Focus first field when form appears
+  useEffect(() => {
+    if (phase === "form") {
+      firstFieldRef.current?.focus();
+    }
+  }, [phase]);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setPending(true);
+    setError(null);
+
+    const data = Object.fromEntries(new FormData(e.currentTarget));
+
+    try {
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify(data),
+      });
+
+      const json = await res.json();
+
+      if (res.ok) {
+        setPhase("success");
+        setTimeout(() => router.push("/library"), 1600);
+      } else {
+        setError(json.error ?? "Something went wrong. Please try again.");
+        setPending(false);
+      }
+    } catch {
+      setError("Network error. Please try again.");
+      setPending(false);
+    }
+  }
+
+  // Intro (initial load, return from form, and transitioning to form)
+  if (
+    phase === "intro" ||
+    phase === "intro-return" ||
+    phase === "transitioning"
+  ) {
+    const isExiting = phase === "transitioning";
+    const isReturning = phase === "intro-return";
+    const isActive = phase === "intro" || phase === "intro-return";
+
+    return (
+      <section
+        className={[
+          "entry-intro",
+          isReturning && "entry-intro--returning",
+          isExiting && "entry-intro--exiting",
+        ]
+          .filter(Boolean)
+          .join(" ")}
+        tabIndex={isActive ? 0 : -1}
+        aria-label={
+          mode === "setup"
+            ? "First launch — click anywhere or press Enter to begin setup"
+            : "Sign in — click anywhere or press Enter to continue"
+        }
+        onKeyDown={(e) => {
+          if (isActive && (e.key === "Enter" || e.key === " ")) {
+            e.preventDefault();
+            setPhase("transitioning");
+            setTimeout(() => setPhase("form"), 360);
+          }
+        }}
+      >
+        <h1 className="entry-intro__title">{title}</h1>
+        <p className="entry-intro__description">{description}</p>
+        <p className="entry-intro__hint" aria-hidden="true">
+          Click anywhere to begin
+        </p>
+      </section>
+    );
+  }
+
+  // Success
+  if (phase === "success") {
+    return (
+      <div className="entry-success">
+        <p className="entry-success__message">{successMessage}</p>
+      </div>
+    );
+  }
+
+  // Form (including exiting-to-intro state)
+  return (
+    <div
+      className={`entry-form ${phase === "exiting-to-intro" ? "entry-form--exiting" : "entry-form--entering"}`}
+    >
+      {error && (
+        <p className="entry-form__error" role="alert">
+          {error}
+        </p>
+      )}
+
+      <form className="entry-form__fields" onSubmit={handleSubmit}>
+        {mode === "setup" ? (
+          <>
+            <div className="entry-form__field">
+              <label className="entry-form__label" htmlFor="instanceName">
+                Instance name
+              </label>
+              <input
+                ref={firstFieldRef}
+                className="entry-form__input"
+                id="instanceName"
+                name="instanceName"
+                placeholder="Staaash Home Drive"
+                required
+              />
+            </div>
+
+            <div className="entry-form__field">
+              <label className="entry-form__label" htmlFor="username">
+                Username
+              </label>
+              <input
+                className="entry-form__input"
+                id="username"
+                name="username"
+                autoComplete="username"
+                maxLength={32}
+                minLength={3}
+                pattern="^(?!-)(?!.*--)[a-z0-9-]{3,32}(?<!-)$"
+                placeholder="johndoe"
+                required
+              />
+              <span className="entry-form__help">
+                Lowercase letters, numbers, and single hyphens.
+              </span>
+            </div>
+
+            <div className="entry-form__field">
+              <label className="entry-form__label" htmlFor="displayName">
+                Display name
+              </label>
+              <input
+                className="entry-form__input"
+                id="displayName"
+                name="displayName"
+                placeholder="John Doe"
+              />
+            </div>
+
+            <div className="entry-form__field">
+              <label className="entry-form__label" htmlFor="email">
+                Email
+              </label>
+              <input
+                className="entry-form__input"
+                id="email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                placeholder="john@example.com"
+                required
+              />
+            </div>
+
+            <div className="entry-form__field">
+              <label className="entry-form__label" htmlFor="password">
+                Password
+              </label>
+              <input
+                className="entry-form__input"
+                id="password"
+                name="password"
+                type="password"
+                autoComplete="new-password"
+                minLength={12}
+                required
+              />
+              <span className="entry-form__help">At least 12 characters.</span>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="entry-form__field">
+              <label className="entry-form__label" htmlFor="identifier">
+                Username or email
+              </label>
+              <input
+                ref={firstFieldRef}
+                className="entry-form__input"
+                id="identifier"
+                name="identifier"
+                autoComplete="username"
+                required
+              />
+            </div>
+
+            <div className="entry-form__field">
+              <label className="entry-form__label" htmlFor="password">
+                Password
+              </label>
+              <input
+                className="entry-form__input"
+                id="password"
+                name="password"
+                type="password"
+                autoComplete="current-password"
+                required
+              />
+            </div>
+          </>
+        )}
+
+        <button className="entry-form__submit" type="submit" disabled={pending}>
+          {pending
+            ? mode === "setup"
+              ? "Setting up…"
+              : "Signing in…"
+            : mode === "setup"
+              ? "Create owner and continue"
+              : "Sign in"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/components/public/entry-experience.tsx
+++ b/apps/web/components/public/entry-experience.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
 export type Phase =

--- a/apps/web/components/public/entry-meta-list.tsx
+++ b/apps/web/components/public/entry-meta-list.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from "react";
+import React, { Fragment } from "react";
 
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";

--- a/apps/web/components/public/entry-root.tsx
+++ b/apps/web/components/public/entry-root.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import React, { useState } from "react";
 
 import { STAAASH_BRONZE_HEX } from "@/lib/brand";
 

--- a/apps/web/components/public/entry-root.tsx
+++ b/apps/web/components/public/entry-root.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+
+import { STAAASH_BRONZE_HEX } from "@/lib/brand";
+
+import { EntryExperience, type Phase } from "./entry-experience";
+import { EntryShell } from "./entry-shell";
+import { SilkBackground } from "./silk-background";
+
+type EntryRootProps = {
+  mode: "setup" | "signin";
+  instanceName?: string;
+};
+
+export function EntryRoot({ mode, instanceName }: EntryRootProps) {
+  const [phase, setPhase] = useState<Phase>("intro");
+
+  function handleBrandClick() {
+    setPhase("exiting-to-intro");
+    setTimeout(() => setPhase("intro-return"), 320);
+  }
+
+  return (
+    <EntryShell
+      background={
+        <SilkBackground
+          color={STAAASH_BRONZE_HEX}
+          noiseIntensity={1.1}
+          opacity={0.56}
+          rotation={0.1}
+          scale={1.08}
+          speed={4.2}
+        />
+      }
+      contentClassName="justify-center"
+      scrimVariant="setup"
+      onBrandClick={phase === "form" ? handleBrandClick : undefined}
+    >
+      <EntryExperience
+        mode={mode}
+        phase={phase}
+        setPhase={setPhase}
+        instanceName={instanceName}
+      />
+    </EntryShell>
+  );
+}

--- a/apps/web/components/public/entry-shell.tsx
+++ b/apps/web/components/public/entry-shell.tsx
@@ -11,6 +11,7 @@ type EntryShellProps = {
   className?: string;
   contentClassName?: string;
   scrimVariant?: "gateway" | "setup";
+  onBrandClick?: () => void;
 };
 
 export function EntryShell({
@@ -20,6 +21,7 @@ export function EntryShell({
   className,
   contentClassName,
   scrimVariant = "gateway",
+  onBrandClick,
 }: EntryShellProps) {
   return (
     <main
@@ -47,9 +49,19 @@ export function EntryShell({
 
       <div className="relative mx-auto flex min-h-dvh w-full max-w-6xl flex-col px-6 py-6 sm:px-8 lg:px-10">
         <header className="flex items-center justify-between gap-4">
-          <Link href="/" className="entry-brand">
-            Staaash
-          </Link>
+          {onBrandClick ? (
+            <button
+              className="entry-brand"
+              onClick={onBrandClick}
+              aria-label="Back to start"
+            >
+              Staaash
+            </button>
+          ) : (
+            <Link href="/" className="entry-brand">
+              Staaash
+            </Link>
+          )}
           {topNote ? <p className="entry-top-note">{topNote}</p> : null}
         </header>
 

--- a/apps/web/components/public/setup-experience.tsx
+++ b/apps/web/components/public/setup-experience.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/button";

--- a/apps/web/components/public/silk-background.tsx
+++ b/apps/web/components/public/silk-background.tsx
@@ -55,7 +55,7 @@ const canUseAnimatedSilk = () => {
     connection?.effectiveType === "3g";
   const constrainedCpu =
     typeof navigator.hardwareConcurrency === "number" &&
-    navigator.hardwareConcurrency <= 4;
+    navigator.hardwareConcurrency <= 2;
 
   return !lowPowerConnection && !constrainedCpu;
 };
@@ -73,12 +73,10 @@ export function SilkBackground({
 
   useEffect(() => {
     const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const desktopQuery = window.matchMedia("(min-width: 960px)");
 
     const update = () => {
       setCanAnimate(
         document.visibilityState === "visible" &&
-          desktopQuery.matches &&
           canUseAnimatedSilk() &&
           !motionQuery.matches,
       );
@@ -86,12 +84,10 @@ export function SilkBackground({
 
     update();
     motionQuery.addEventListener("change", update);
-    desktopQuery.addEventListener("change", update);
     document.addEventListener("visibilitychange", update);
 
     return () => {
       motionQuery.removeEventListener("change", update);
-      desktopQuery.removeEventListener("change", update);
       document.removeEventListener("visibilitychange", update);
     };
   }, []);

--- a/apps/web/server/homepage-route.test.ts
+++ b/apps/web/server/homepage-route.test.ts
@@ -1,13 +1,12 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { STAAASH_BRONZE_HEX } from "@/lib/brand";
-
 const getCurrentSession = vi.fn();
 const getSetupState = vi.fn();
 const redirect = vi.fn((path: string) => {
   throw new Error(`redirect:${path}`);
 });
+const pushMock = vi.fn();
 
 vi.mock("@/server/auth/session", () => ({
   getCurrentSession,
@@ -21,6 +20,7 @@ vi.mock("@/server/auth/service", () => ({
 
 vi.mock("next/navigation", () => ({
   redirect,
+  useRouter: () => ({ push: pushMock }),
 }));
 
 describe("HomePage route", () => {
@@ -30,18 +30,19 @@ describe("HomePage route", () => {
 
   it("renders the setup entry state for an unbootstrapped instance", async () => {
     getCurrentSession.mockResolvedValue(null);
-    getSetupState.mockResolvedValue({ isBootstrapped: false });
+    getSetupState.mockResolvedValue({
+      isBootstrapped: false,
+      instanceName: null,
+    });
 
     const { default: HomePage } = await import("@/app/page");
     const page = await HomePage();
     const markup = renderToStaticMarkup(page);
 
-    expect(markup).toContain("Bring this Staaash instance online.");
-    expect(markup).toContain("Set up Staaash");
+    expect(markup).toContain("Bring your Staaash online.");
     expect(markup).toContain(
-      "Create the first owner account once. After that, this Staaash stays private and invite-only.",
+      "Create the first owner account. After this, your instance is private and invite-only.",
     );
-    expect(page.props.background.props.color).toBe(STAAASH_BRONZE_HEX);
   });
 
   it("redirects signed-in visitors to the library", async () => {


### PR DESCRIPTION
## Summary

- Consolidates setup and sign-in into a single cinematic experience at `/` — `/setup` now redirects there
- New `EntryRoot` + `EntryExperience` components replace the old card-based UI with a click-anywhere intro flow and floating form
- Phase state machine: `intro` → `transitioning` → `form` ↔ `exiting-to-intro` → `intro-return`, with a `success` terminal state
- Sign-out redirects to `/` instead of `/sign-in`

## What changed

- **`/`**: Renders `EntryRoot` — detects bootstrapped vs. unbootstrapped and shows sign-in or setup accordingly; uses instance name as title in sign-in mode
- **`/setup`**: Redirects to `/`
- **Entry animations**: Staggered fade-up on intro text; reversed animation when brand is clicked in form state; fill-mode snap bug fixed for cycling transitions
- **Silk background**: Removed viewport-size gate so it renders on all screen sizes; strengthened static fallback gradient
- **Success state**: Large Cabinet Grotesk message matching the intro title size, with a 1.6s pause before redirecting to `/library`
- **Misc fixes**: Removed `scrollbar-gutter: stable` (caused 15px black bar); hint text no longer pulses

## Test plan

- [ ] Fresh instance (not bootstrapped): `/` shows "Bring your Staaash online." setup form
- [ ] Bootstrapped instance: `/` shows instance name as title, sign-in form
- [ ] Click anywhere advances from intro to form; clicking brand in form returns to intro
- [ ] Cycling intro → form → intro → form plays cleanly with no animation glitch
- [ ] Clicking Staaash brand in intro state does NOT advance to form
- [ ] Silk background renders on mobile/small viewports
- [ ] Sign-out lands on `/`, not `/sign-in`
- [ ] Success message is large and readable before redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)