### PR TITLE
feat(version): show development in admin UI and skip update check outside production

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > [!IMPORTANT]
 > **Staaash has just shipped its first pre-release and is in early alpha.** Expect bugs, missing features, and breaking changes between releases. Do not use as your only copy of important files — set up a [3-2-1 backup strategy](https://www.backblaze.com/blog/the-3-2-1-backup-strategy/) before you start.
 
-Staaash is a self-hosted personal cloud drive I am building in public. 
+Staaash is a self-hosted personal cloud drive I am building in public.
 
 This was just gonna be something that only I was going to use and share with some friends but I thought "why not I just do it open-source, maybe some people would like to see aswell" so I made it.
 

--- a/apps/web/server/admin/updates.ts
+++ b/apps/web/server/admin/updates.ts
@@ -4,6 +4,8 @@ import {
 } from "@staaash/db/jobs";
 import { readInstanceUpdateCheck } from "@staaash/db/instance";
 
+import { version as packageVersion } from "../../package.json";
+
 import { getSystemSettings } from "@/server/settings";
 
 import type { AdminUpdateStatus, JsonAdminUpdateStatus } from "./types";
@@ -16,7 +18,11 @@ export const getAdminUpdateStatus = async (): Promise<AdminUpdateStatus> => {
 
   return {
     currentVersion:
-      process.env.STAAASH_VERSION ?? process.env.APP_VERSION ?? "0.1.0",
+      process.env.NODE_ENV !== "production"
+        ? "development"
+        : (process.env.STAAASH_VERSION ??
+          process.env.APP_VERSION ??
+          packageVersion),
     repository: settings.updateCheckRepository || null,
     lastUpdateCheckAt: state.lastUpdateCheckAt,
     updateCheckStatus: state.updateCheckStatus,

--- a/apps/web/server/health.ts
+++ b/apps/web/server/health.ts
@@ -8,6 +8,8 @@ import {
 import { readInstanceUpdateCheck } from "@staaash/db/instance";
 import { readLatestRestoreReconciliationRun } from "@staaash/db/reconciliation";
 
+import { version as packageVersion } from "../package.json";
+
 import { getSystemSettings } from "@/server/settings";
 import { buildRestoreReconciliationHealthSummary } from "@/server/restore";
 import {
@@ -232,7 +234,11 @@ export const getReadiness = async () => {
     storageWarnings,
     versionInfo: {
       currentVersion:
-        process.env.STAAASH_VERSION ?? process.env.APP_VERSION ?? "0.1.0",
+        process.env.NODE_ENV !== "production"
+          ? "development"
+          : (process.env.STAAASH_VERSION ??
+            process.env.APP_VERSION ??
+            packageVersion),
       lastUpdateCheckAt:
         instanceState?.lastUpdateCheckAt?.toISOString() ?? null,
       updateCheckStatus: instanceState?.updateCheckStatus ?? null,

--- a/apps/worker/src/handlers/update-check.test.ts
+++ b/apps/worker/src/handlers/update-check.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const writeInstanceUpdateCheck = vi.fn();
 const mockFindUnique = vi.fn();
@@ -33,7 +33,15 @@ const createJob = () =>
   }) as const;
 
 describe("update check handler", () => {
+  let originalNodeEnv: string | undefined;
+
+  beforeEach(() => {
+    originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+  });
+
   afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
     vi.restoreAllMocks();
     vi.clearAllMocks();
     mockFindUnique.mockReset();

--- a/apps/worker/src/handlers/update-check.ts
+++ b/apps/worker/src/handlers/update-check.ts
@@ -100,6 +100,9 @@ const readLatestGitHubRelease = async (repository: string) => {
 export const handleUpdateCheck = async (
   _job: BackgroundJobRecord,
 ): Promise<void> => {
+  if (process.env.NODE_ENV !== "production") return;
+
+  const { version } = await import("../../package.json");
   const { getPrisma } = await import("@staaash/db/client");
   const db = getPrisma();
   const settings = await db.systemSettings.findUnique({
@@ -109,7 +112,7 @@ export const handleUpdateCheck = async (
   const currentVersion =
     process.env.STAAASH_VERSION?.trim() ??
     process.env.APP_VERSION?.trim() ??
-    "0.1.0";
+    version;
 
   if (!repository) {
     await writeInstanceUpdateCheck({


### PR DESCRIPTION
## Summary

- Replaces hardcoded `"0.1.0"` fallback with actual `package.json` version in production
- Returns `"development"` as `currentVersion` when `NODE_ENV !== "production"` (admin UI + health endpoint)
- Skips update check handler entirely outside production — no spurious GitHub API calls in dev

## Test plan

- [ ] Run `pnpm web:dev` — admin version panel shows `development`
- [ ] Run `pnpm worker:dev` — update check job exits early, no GitHub request made
- [ ] Build production Docker image — version reads from `STAAASH_VERSION` or `package.json` as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)