### PR TITLE
feat(dev-env): add dev.example.env and wire root .env.local as single dev config source

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > [!IMPORTANT]
 > **Staaash has just shipped its first pre-release and is in early alpha.** Expect bugs, missing features, and breaking changes between releases. Do not use as your only copy of important files — set up a [3-2-1 backup strategy](https://www.backblaze.com/blog/the-3-2-1-backup-strategy/) before you start.
 
-Staaash is a self-hosted personal cloud drive I am building in public. 
+Staaash is a self-hosted personal cloud drive I am building in public.
 
 This was just gonna be something that only I was going to use and share with some friends but I thought "why not I just do it open-source, maybe some people would like to see aswell" so I made it.
 
@@ -61,17 +61,17 @@ Next.js · TypeScript · Prisma · PostgreSQL
 
 ## Local Development
 
-1. Copy `example.env` to `.env`.
+1. Copy `dev.example.env` to `.env.local` at the repo root.
 2. Start PostgreSQL.
-   The default `example.env` expects `postgresql://staaash:staaash@localhost:5432/staaash`.
+   The default `.env.local` expects `postgresql://staaash:staaash@localhost:5432/staaash`.
    If you want a local Docker container that matches those values, run:
 
    ```console
-   docker run --name staaash-postgres -e POSTGRES_USER=staaash -e POSTGRES_PASSWORD=staaash -e POSTGRES_DB=staaash -p 5432:5432 -v staaash-postgres-data:/var/lib/postgresql -d postgres:18
+   docker run --name staaash-postgres -e POSTGRES_USER=staaash -e POSTGRES_PASSWORD=staaash -e POSTGRES_DB=staaash -p 5432:5432 -v staaash-postgres-data:/var/lib/postgresql -d postgres:16
    ```
 
    After that first run, you can restart it later with `docker start staaash-postgres`.
-   If you already have PostgreSQL running another way, just make sure `DATABASE_URL` in `.env` matches it.
+   If you already have PostgreSQL running another way, just update `DATABASE_URL` in `.env.local`.
 
 3. Run `pnpm i`.
 4. Run `pnpm db:generate`.

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,6 +1,23 @@
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import type { NextConfig } from "next";
 import { PHASE_DEVELOPMENT_SERVER } from "next/constants";
+
+const rootEnvLocal = path.resolve(__dirname, "../../.env.local");
+if (existsSync(rootEnvLocal)) {
+  for (const line of readFileSync(rootEnvLocal, "utf-8").split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const val = trimmed
+      .slice(eq + 1)
+      .trim()
+      .replace(/^["']|["']$/g, "");
+    if (!(key in process.env)) process.env[key] = val;
+  }
+}
 
 export default function config(phase: string): NextConfig {
   return {

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -10,7 +10,7 @@
     "prelint": "pnpm run build:deps",
     "pretest": "pnpm run build:deps",
     "pretypecheck": "pnpm run build:deps",
-    "dev": "node --env-file=../../.env --import tsx src/index.ts",
+    "dev": "node --env-file=../../.env.local --import tsx src/index.ts",
     "build": "tsc -p tsconfig.json",
     "lint": "tsc --noEmit -p tsconfig.json",
     "typecheck": "tsc --noEmit -p tsconfig.json",

--- a/dev.example.env
+++ b/dev.example.env
@@ -1,0 +1,21 @@
+# ── App ───────────────────────────────────────────────────────────────────────
+NODE_ENV=development
+
+# ── Database ──────────────────────────────────────────────────────────────────
+# Matches the default docker-compose.dev.yml postgres service (if you have one),
+# or point at any local Postgres instance.
+DATABASE_URL=postgresql://staaash:staaash@localhost:5432/staaash
+
+# ── Storage ───────────────────────────────────────────────────────────────────
+UPLOAD_LOCATION=./.data/files
+
+# ── Security ──────────────────────────────────────────────────────────────────
+# Change this — used to sign auth tokens
+AUTH_SECRET=change-me
+
+# ── Worker ────────────────────────────────────────────────────────────────────
+# Optional — defaults to 2 hours
+# UPLOAD_STAGING_RETENTION_HOURS=2
+
+################################################################################
+# Use this only when you are doing local development please

--- a/packages/db/prisma.config.ts
+++ b/packages/db/prisma.config.ts
@@ -1,4 +1,25 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { defineConfig } from "prisma/config";
+
+if (!process.env.DATABASE_URL) {
+  const envFile = resolve(__dirname, "../../.env.local");
+  if (existsSync(envFile)) {
+    for (const line of readFileSync(envFile, "utf-8").split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq === -1) continue;
+      const key = trimmed.slice(0, eq).trim();
+      const val = trimmed
+        .slice(eq + 1)
+        .trim()
+        .replace(/^["']|["']$/g, "");
+      if (!(key in process.env)) process.env[key] = val;
+    }
+  }
+}
 
 export default defineConfig({
   datasource: {


### PR DESCRIPTION
## Summary

- Adds `dev.example.env` as the canonical local development env template (replaces the incorrect `example.env` reference in the README)
- Wires root `.env.local` as the single source of truth for local dev — loaded by Next.js (`next.config.ts`), Prisma CLI (`prisma.config.ts`), and the worker (`--env-file`)
- Fixes README local development steps: correct file names, correct Postgres image tag (`postgres:16`)

## Test plan

- [ ] Copy `dev.example.env` to `.env.local` at repo root and fill in values
- [ ] `pnpm db:push` succeeds without setting `DATABASE_URL` manually
- [ ] `pnpm web:dev` starts and connects to DB
- [ ] `pnpm worker:dev` starts without `UPLOAD_LOCATION` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)