### PR TITLE
feat(onboarding): add media preview step for owner setup

### DIFF
--- a/apps/web/app/admin/settings/actions.ts
+++ b/apps/web/app/admin/settings/actions.ts
@@ -60,3 +60,17 @@ export async function updateSystemSettings(
   revalidatePath("/admin/settings");
   return { success: true };
 }
+
+export async function setMediaPreviewEnabled(
+  enabled: boolean,
+): Promise<{ error?: string; success?: boolean }> {
+  await requireOwnerPageSession();
+  const db = getPrisma();
+  await db.systemSettings.upsert({
+    where: { id: "singleton" },
+    create: { id: "singleton", mediaPreviewEnabled: enabled },
+    update: { mediaPreviewEnabled: enabled },
+  });
+  revalidatePath("/admin/settings");
+  return { success: true };
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -5,6 +5,7 @@ import { getSafeLocalPath, getSingleSearchParam } from "@/app/auth-ui";
 import { EntryRoot } from "@/components/public/entry-root";
 import { authService } from "@/server/auth/service";
 import { getCurrentSession } from "@/server/auth/session";
+import { getSystemSettings } from "@/server/settings";
 
 export const dynamic = "force-dynamic";
 
@@ -13,11 +14,13 @@ type HomePageProps = {
 };
 
 export default async function HomePage({ searchParams }: HomePageProps) {
-  const [resolvedSearchParams, setupState, session] = await Promise.all([
-    searchParams,
-    authService.getSetupState(),
-    getCurrentSession(),
-  ]);
+  const [resolvedSearchParams, setupState, session, systemSettings] =
+    await Promise.all([
+      searchParams,
+      authService.getSetupState(),
+      getCurrentSession(),
+      getSystemSettings(),
+    ]);
 
   const next = getSafeLocalPath(
     getSingleSearchParam(resolvedSearchParams, "next"),
@@ -33,6 +36,7 @@ export default async function HomePage({ searchParams }: HomePageProps) {
         mode="onboarding"
         instanceName={setupState.instanceName ?? undefined}
         isOwner={session.user.role === "owner"}
+        initialMediaPreviewEnabled={systemSettings.mediaPreviewEnabled}
       />
     );
   }

--- a/apps/web/components/public/entry-root.tsx
+++ b/apps/web/components/public/entry-root.tsx
@@ -14,6 +14,7 @@ type EntryRootProps = {
   instanceName?: string;
   next?: string;
   isOwner?: boolean;
+  initialMediaPreviewEnabled?: boolean;
 };
 
 export function EntryRoot({
@@ -21,6 +22,7 @@ export function EntryRoot({
   instanceName,
   next,
   isOwner = false,
+  initialMediaPreviewEnabled = true,
 }: EntryRootProps) {
   const [phase, setPhase] = useState<Phase>("intro");
   const [onboardingKey, setOnboardingKey] = useState(0);
@@ -51,6 +53,7 @@ export function EntryRoot({
           key={onboardingKey}
           instanceName={instanceName}
           isOwner={isOwner}
+          initialMediaPreviewEnabled={initialMediaPreviewEnabled}
         />
       </EntryShell>
     );

--- a/apps/web/components/public/onboarding-experience.tsx
+++ b/apps/web/components/public/onboarding-experience.tsx
@@ -2,10 +2,18 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+
+import { setMediaPreviewEnabled as saveMediaPreviewSetting } from "@/app/admin/settings/actions";
 import confetti from "canvas-confetti";
 
 type Theme = "light" | "dark" | "system";
-type OnboardingStep = "welcome" | "theme" | "profile" | "privacy" | "done";
+type OnboardingStep =
+  | "welcome"
+  | "theme"
+  | "profile"
+  | "privacy"
+  | "media"
+  | "done";
 
 type Prefs = {
   theme: Theme;
@@ -20,6 +28,7 @@ const STEP_ORDER: OnboardingStep[] = [
   "theme",
   "profile",
   "privacy",
+  "media",
   "done",
 ];
 
@@ -33,9 +42,11 @@ function applyThemePreview(theme: Theme) {
 export function OnboardingExperience({
   instanceName,
   isOwner,
+  initialMediaPreviewEnabled = true,
 }: {
   instanceName?: string;
   isOwner: boolean;
+  initialMediaPreviewEnabled?: boolean;
 }) {
   const [step, setStep] = useState<OnboardingStep>("welcome");
   const [animating, setAnimating] = useState(false);
@@ -46,6 +57,9 @@ export function OnboardingExperience({
     displayName: "",
     avatarUrl: null,
   });
+  const [mediaPreviewEnabled, setMediaPreviewEnabled] = useState(
+    initialMediaPreviewEnabled,
+  );
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [donePhase, setDonePhase] = useState<0 | 1 | 2>(0);
@@ -85,29 +99,32 @@ export function OnboardingExperience({
     setPending(true);
     setError(null);
     try {
-      const res = await fetch("/api/user/preferences", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Accept: "application/json",
-        },
-        body: JSON.stringify({
-          theme: prefs.theme,
-          showUpdateNotifications: prefs.showUpdateNotifications,
-          enableVersionChecks: prefs.enableVersionChecks,
-          displayName: prefs.displayName || null,
-          avatarUrl: prefs.avatarUrl,
+      const tasks: Promise<unknown>[] = [
+        fetch("/api/user/preferences", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          },
+          body: JSON.stringify({
+            theme: prefs.theme,
+            showUpdateNotifications: prefs.showUpdateNotifications,
+            enableVersionChecks: prefs.enableVersionChecks,
+            displayName: prefs.displayName || null,
+            avatarUrl: prefs.avatarUrl,
+          }),
+        }).then(async (res) => {
+          if (!res.ok) {
+            const json = await res.json().catch(() => ({}));
+            throw new Error(json.error ?? "Something went wrong.");
+          }
         }),
-      });
-      if (res.ok) {
-        setStep("done");
-      } else {
-        const json = await res.json().catch(() => ({}));
-        setError(json.error ?? "Something went wrong.");
-        setPending(false);
-      }
-    } catch {
-      setError("Network error. Please try again.");
+      ];
+      if (isOwner) tasks.push(saveMediaPreviewSetting(mediaPreviewEnabled));
+      await Promise.all(tasks);
+      setStep("done");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong.");
       setPending(false);
     }
   }
@@ -189,7 +206,7 @@ export function OnboardingExperience({
     );
   }
 
-  const totalSteps = isOwner ? 3 : 2;
+  const totalSteps = isOwner ? 4 : 2;
 
   return (
     <div
@@ -237,7 +254,20 @@ export function OnboardingExperience({
               showUpdateNotifications: val,
             }))
           }
-          onComplete={handleComplete}
+          onComplete={advance}
+          onBack={goBack}
+          pending={false}
+          error={null}
+          isLastStep={false}
+        />
+      )}
+      {step === "media" && isOwner && (
+        <MediaStep
+          enabled={mediaPreviewEnabled}
+          onToggle={setMediaPreviewEnabled}
+          onComplete={() => {
+            void handleComplete();
+          }}
           onBack={goBack}
           pending={pending}
           error={error}
@@ -577,6 +607,7 @@ function PrivacyStep({
   onBack,
   pending,
   error,
+  isLastStep = true,
 }: {
   prefs: Prefs;
   onVersionChecksChange: (val: boolean) => void;
@@ -584,6 +615,7 @@ function PrivacyStep({
   onBack: () => void;
   pending: boolean;
   error: string | null;
+  isLastStep?: boolean;
 }) {
   return (
     <div className="onboarding-step">
@@ -596,7 +628,7 @@ function PrivacyStep({
         >
           ← Back
         </button>
-        <StepProgress current={3} total={3} />
+        <StepProgress current={3} total={4} />
       </div>
 
       <div className="onboarding-step__header">
@@ -625,6 +657,88 @@ function PrivacyStep({
             onClick={() => onVersionChecksChange(!prefs.enableVersionChecks)}
             type="button"
             aria-label="Version checks"
+          >
+            <span className="onboarding-switch__thumb" />
+          </button>
+        </label>
+      </div>
+
+      {error && (
+        <p className="onboarding-error" role="alert">
+          {error}
+        </p>
+      )}
+
+      <button
+        className="onboarding-continue"
+        onClick={onComplete}
+        disabled={pending}
+        type="button"
+      >
+        {pending ? "Saving…" : isLastStep ? "Enter Staaash" : "Continue"}
+      </button>
+    </div>
+  );
+}
+
+function MediaStep({
+  enabled,
+  onToggle,
+  onComplete,
+  onBack,
+  pending,
+  error,
+}: {
+  enabled: boolean;
+  onToggle: (val: boolean) => void;
+  onComplete: () => void;
+  onBack: () => void;
+  pending: boolean;
+  error: string | null;
+}) {
+  return (
+    <div className="onboarding-step">
+      <div className="onboarding-step__nav">
+        <button
+          className="onboarding-back"
+          onClick={onBack}
+          type="button"
+          aria-label="Go back"
+        >
+          ← Back
+        </button>
+        <StepProgress current={4} total={4} />
+      </div>
+
+      <div className="onboarding-step__header">
+        <span className="onboarding-step__index">04</span>
+        <h2 className="onboarding-step__title">Media previews</h2>
+      </div>
+
+      <p className="onboarding-step__body">
+        Staaash can transcode uploaded videos into streamable previews using
+        FFmpeg. This runs in a background worker and can use significant CPU.
+        You can change this anytime in Admin → Settings.
+      </p>
+
+      <div className="onboarding-toggles">
+        <label className="onboarding-toggle">
+          <div className="onboarding-toggle__text">
+            <span className="onboarding-toggle__label">
+              Enable media previews
+            </span>
+            <span className="onboarding-toggle__desc">
+              Generates compressed video previews on demand. Requires a worker
+              process and a reasonably capable CPU.
+            </span>
+          </div>
+          <button
+            role="switch"
+            aria-checked={enabled}
+            className={`onboarding-switch${enabled ? " onboarding-switch--on" : ""}`}
+            onClick={() => onToggle(!enabled)}
+            type="button"
+            aria-label="Enable media previews"
           >
             <span className="onboarding-switch__thumb" />
           </button>


### PR DESCRIPTION
## Summary

- Adds a 4th owner-only onboarding step ("Media previews") between the Privacy step and the Done screen
- Owner can toggle `mediaPreviewEnabled` on/off with clear CPU-cost framing before entering the workspace
- The toggle reflects the current system setting at onboarding time (default: enabled); the choice is saved in parallel with user preferences on completion

## How it works

- `page.tsx` fetches `SystemSettings` and passes `initialMediaPreviewEnabled` down to `EntryRoot` → `OnboardingExperience`
- A new `setMediaPreviewEnabled` server action in `actions.ts` handles the `SystemSettings` upsert (guarded by `requireOwnerPageSession`)
- `PrivacyStep.onComplete` now calls `advance` instead of `handleComplete`, making it a pass-through step; `MediaStep` is the new terminal step for owners
- `handleComplete` fires both the user preferences POST and the system settings server action in parallel via `Promise.all`
- Non-owner flow is completely unchanged (2 steps)

## Test plan

- [x] Sign in as owner with incomplete onboarding → confirm 4-segment progress bar appears across all owner steps
- [x] Reach the media step → verify toggle defaults to the current `SystemSettings.mediaPreviewEnabled` value
- [x] Toggle off → complete → confirm `SystemSettings.mediaPreviewEnabled = false` in DB
- [x] Repeat with toggle on → confirm `SystemSettings.mediaPreviewEnabled = true`
- [x] Create a member account → confirm onboarding still shows 2 steps with no media step
- [x] Back button from media → returns to privacy; back from privacy → returns to profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)