### PR TITLE
feat(uploads): show estimated time remaining on upload rows

### DIFF
--- a/apps/web/app/(workspace)/files/files-view.tsx
+++ b/apps/web/app/(workspace)/files/files-view.tsx
@@ -102,6 +102,28 @@ function formatBytes(bytes: number): string {
   return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
 }
 
+function formatEta(
+  totalBytes: number,
+  progress: number,
+  speed: number,
+): string {
+  if (speed <= 0 || progress >= 100) return "";
+  const remainingBytes = totalBytes * (1 - progress / 100);
+  const seconds = Math.round(remainingBytes / speed);
+  if (seconds < 60)
+    return `(${seconds} ${seconds === 1 ? "second" : "seconds"} left)`;
+  if (seconds < 3600) {
+    const m = Math.round(seconds / 60);
+    return `(${m} ${m === 1 ? "minute" : "minutes"} left)`;
+  }
+  if (seconds < 86400) {
+    const h = Math.round(seconds / 3600);
+    return `(${h} ${h === 1 ? "hour" : "hours"} left)`;
+  }
+  const d = Math.round(seconds / 86400);
+  return `(${d} ${d === 1 ? "day" : "days"} left)`;
+}
+
 // ---------------------------------------------------------------------------
 // Rubber-band state
 // ---------------------------------------------------------------------------
@@ -1634,6 +1656,7 @@ function UploadingRow({
 }) {
   const { File: FileIcon } = { File: require("lucide-react").File };
 
+  const eta = formatEta(file.size, file.progress, file.speed);
   const statusText =
     file.status === "error"
       ? (file.error ?? "Upload failed")
@@ -1641,7 +1664,7 @@ function UploadingRow({
         ? "Done"
         : file.resumeHint && file.progress === 0
           ? file.resumeHint
-          : `${file.progress}% · ${formatSpeed(file.speed)}`;
+          : `${file.progress}% · ${formatSpeed(file.speed)}${eta ? ` · ${eta}` : ""}`;
 
   return (
     <div className="uploading-row">


### PR DESCRIPTION
## Summary

- Adds `formatEta(totalBytes, progress, speed)` helper alongside `formatSpeed`/`formatBytes`
- Upload rows now show `42% · 2.3 MB/s · (3 minutes left)` while uploading
- ETA hidden when speed is 0 (start/resume) or progress reaches 100%

## Test plan

- [x] Upload a large file and verify ETA appears once speed stabilizes
- [x] Verify unit boundaries: ~59s shows seconds, ~61s shows minutes, etc.
- [x] Verify ETA disappears on completion/error
- [x] Verify resume hint still shows correctly when resuming from 0%

🤖 Generated with [Claude Code](https://claude.com/claude-code)