### PR TITLE
feat(media): cancel running derivatives, show file names in job history

### DIFF
--- a/apps/web/app/(workspace)/files/files-properties-panel.tsx
+++ b/apps/web/app/(workspace)/files/files-properties-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   X,
   Folder,
@@ -62,6 +62,118 @@ function formatBytes(bytes: number): string {
   if (bytes < 1024 * 1024 * 1024)
     return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+// ---------------------------------------------------------------------------
+// Media preview section
+// ---------------------------------------------------------------------------
+
+type DerivativeStatus =
+  | "none"
+  | "queued"
+  | "processing"
+  | "ready"
+  | "failed"
+  | "stale";
+
+type DerivativeState = {
+  status: DerivativeStatus;
+  generatedAt: string | null;
+};
+
+function MediaPreviewSection({ fileId }: { fileId: string }) {
+  const [state, setState] = useState<DerivativeState | null>(null);
+  const [queuing, setQueuing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetch(`/api/files/files/${fileId}/derivative`)
+      .then((r) => r.json())
+      .then((data: DerivativeState) => {
+        if (!cancelled) setState(data);
+      })
+      .catch(() => {
+        if (!cancelled) setState({ status: "none", generatedAt: null });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [fileId]);
+
+  const handleGenerate = async () => {
+    setQueuing(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/files/files/${fileId}/derivative`, {
+        method: "POST",
+      });
+      const data = (await res.json()) as { status?: string; error?: string };
+      if (!res.ok) {
+        setError(data.error ?? "Failed to queue preview.");
+      } else {
+        setState({ status: "queued", generatedAt: null });
+      }
+    } catch {
+      setError("Failed to queue preview.");
+    } finally {
+      setQueuing(false);
+    }
+  };
+
+  const STATUS_LABEL: Record<DerivativeStatus, string> = {
+    none: "Not generated",
+    queued: "Queued…",
+    processing: "Generating…",
+    ready: "Ready",
+    failed: "Failed",
+    stale: "Stale",
+  };
+
+  const isActive = state?.status === "queued" || state?.status === "processing";
+  const buttonLabel =
+    state?.status === "ready" || state?.status === "stale"
+      ? "Regenerate"
+      : "Generate preview";
+
+  return (
+    <div className="properties-section">
+      <p className="properties-section-title">Media preview</p>
+      {state ? (
+        <div className="properties-row">
+          <span className="properties-row-label">Status</span>
+          <span className="properties-row-value">
+            {STATUS_LABEL[state.status]}
+          </span>
+        </div>
+      ) : (
+        <div className="properties-row">
+          <span className="properties-row-label">Status</span>
+          <span className="properties-row-value muted">Loading…</span>
+        </div>
+      )}
+      <Button
+        size="sm"
+        variant="outline"
+        disabled={queuing || isActive || state === null}
+        onClick={() => void handleGenerate()}
+      >
+        {queuing ? "Queuing…" : buttonLabel}
+      </Button>
+      {error && (
+        <p
+          className="muted"
+          style={{
+            fontSize: "0.78rem",
+            color: "var(--color-error, red)",
+            marginTop: 4,
+          }}
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -180,6 +292,12 @@ export function FilesPropertiesPanel({
                 </span>
               </div>
             </div>
+
+            {/* Media preview section — video files only */}
+            {item.kind === "file" &&
+              item.data.mimeType.startsWith("video/") && (
+                <MediaPreviewSection fileId={item.data.id} />
+              )}
 
             {/* Sharing section */}
             {onShare && (

--- a/apps/web/app/admin/admin-format.ts
+++ b/apps/web/app/admin/admin-format.ts
@@ -39,9 +39,11 @@ export const getAdminStatusClassName = (status: string) =>
           status === "queued" ||
           status === "running"
         ? "status-warning"
-        : status === "owner"
-          ? "status-owner"
-          : status === "member"
-            ? "status-member"
-            : "status-error"
+        : status === "cancelled"
+          ? ""
+          : status === "owner"
+            ? "status-owner"
+            : status === "member"
+              ? "status-member"
+              : "status-error"
   }`;

--- a/apps/web/app/admin/jobs/job-operations.tsx
+++ b/apps/web/app/admin/jobs/job-operations.tsx
@@ -19,6 +19,7 @@ export type JsonBackgroundJob = {
   maxAttempts: number;
   dedupeKey: string | null;
   payloadJson: Record<string, unknown> | null;
+  fileName?: string | null;
 };
 
 const JOB_META: Record<string, { name: string; desc: string }> = {
@@ -47,6 +48,15 @@ const JOB_META: Record<string, { name: string; desc: string }> = {
     desc: "Remove stale or orphaned derivative files from storage.",
   },
 };
+
+function effectiveStatus(
+  job: Pick<JsonBackgroundJob, "status" | "lastError">,
+): string {
+  if (job.status === "dead" && job.lastError === "Cancelled by admin.") {
+    return "cancelled";
+  }
+  return job.status;
+}
 
 function formatTimeAgo(dateStr: string): string {
   const diff = Date.now() - new Date(dateStr).getTime();
@@ -168,8 +178,10 @@ function JobOperationRow({
           <span className="admin-op-desc">{meta?.desc}</span>
           {lastRun ? (
             <span className="admin-op-last">
-              <span className={getAdminStatusClassName(lastRun.status)}>
-                {lastRun.status}
+              <span
+                className={getAdminStatusClassName(effectiveStatus(lastRun))}
+              >
+                {effectiveStatus(lastRun)}
               </span>{" "}
               · {formatTimeAgo(lastRun.updatedAt)}
               {activeCount !== null && activeCount > 1 && (
@@ -225,20 +237,22 @@ function JobOperationRow({
                 typeof job.payloadJson?.reason === "string"
                   ? job.payloadJson.reason
                   : null;
+              const fileLabel =
+                job.fileName ?? (fileId ? `${fileId.slice(0, 8)}…` : null);
               return (
                 <div className="admin-history-row" key={job.id}>
-                  <span className={getAdminStatusClassName(job.status)}>
-                    {job.status}
+                  <span
+                    className={getAdminStatusClassName(effectiveStatus(job))}
+                  >
+                    {effectiveStatus(job)}
                   </span>
                   <span className="muted">
                     {formatAdminDateTime(job.createdAt)}
                   </span>
-                  {fileId ? (
+                  {fileLabel ? (
                     <span className="muted" style={{ fontSize: "0.78rem" }}>
                       {reason ? `${reason} · ` : ""}
-                      <code style={{ fontSize: "0.75rem" }}>
-                        {fileId.slice(0, 8)}…
-                      </code>
+                      {fileLabel}
                     </span>
                   ) : (
                     <span className="muted" style={{ fontSize: "0.78rem" }}>

--- a/apps/web/app/admin/media/actions.ts
+++ b/apps/web/app/admin/media/actions.ts
@@ -79,8 +79,8 @@ export async function cancelDerivative(
     select: { fileId: true, status: true },
   });
   if (!derivative) return { error: "Derivative not found." };
-  if (derivative.status !== "queued")
-    return { error: "Only queued derivatives can be cancelled." };
+  if (derivative.status !== "queued" && derivative.status !== "processing")
+    return { error: "Only queued or processing derivatives can be cancelled." };
 
   const dedupeKey = buildDerivativeDedupeKey(
     derivative.fileId,
@@ -88,10 +88,25 @@ export async function cancelDerivative(
     DERIVATIVE_PROFILE_1080P,
   );
 
-  await db.backgroundJob.updateMany({
-    where: { dedupeKey, status: "queued" },
-    data: { status: "dead", lastError: "Cancelled by admin." },
-  });
+  if (derivative.status === "queued") {
+    await db.backgroundJob.updateMany({
+      where: { dedupeKey, status: "queued" },
+      data: { status: "dead", lastError: "Cancelled by admin." },
+    });
+  } else {
+    // Mark the running job dead immediately so:
+    // 1. The UI shows "dead" without waiting for the worker
+    // 2. The job can't be re-claimed after its 60s lease expires
+    await db.backgroundJob.updateMany({
+      where: { dedupeKey, status: "running" },
+      data: {
+        status: "dead",
+        lastError: "Cancelled by admin.",
+        lockedAt: null,
+        lockedBy: null,
+      },
+    });
+  }
 
   await markDerivativeStale(id);
   revalidatePath("/admin/media");

--- a/apps/web/app/admin/media/derivative-actions.tsx
+++ b/apps/web/app/admin/media/derivative-actions.tsx
@@ -43,7 +43,7 @@ export function DerivativeActions({
   const isActive = status === "queued" || status === "processing";
   const canRemove =
     status === "ready" || status === "failed" || status === "stale";
-  const canCancel = status === "queued";
+  const canCancel = status === "queued" || status === "processing";
   const anyError = regenState.error ?? removeState.error ?? cancelState.error;
 
   return (

--- a/apps/web/app/api/admin/jobs/route.ts
+++ b/apps/web/app/api/admin/jobs/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { getPrisma } from "@staaash/db/client";
+import { MEDIA_DERIVATIVE_GENERATE_JOB_KIND } from "@staaash/db/jobs";
+
 import { enforceSameOrigin, requireOwnerApiSession } from "@/server/admin/http";
 import {
   getAdminJobList,
@@ -23,12 +26,40 @@ export async function GET(request: NextRequest) {
     cursor: request.nextUrl.searchParams.get("cursor"),
   });
 
-  return NextResponse.json(
-    toJsonAdminJobListResponse(
-      await getAdminJobList({
-        ...filters,
-        limit: 25,
-      }),
-    ),
+  const jobList = await getAdminJobList({ ...filters, limit: 25 });
+  const response = toJsonAdminJobListResponse(jobList);
+
+  const derivativeItems = response.items.filter(
+    (j) => j.kind === MEDIA_DERIVATIVE_GENERATE_JOB_KIND,
   );
+
+  if (derivativeItems.length > 0) {
+    const fileIds = derivativeItems
+      .map((j) => (j.payloadJson as { fileId?: string } | null)?.fileId)
+      .filter((id): id is string => Boolean(id));
+
+    if (fileIds.length > 0) {
+      const db = getPrisma();
+      const files = await db.file.findMany({
+        where: { id: { in: fileIds } },
+        select: { id: true, originalName: true },
+      });
+      const fileNameMap = new Map(files.map((f) => [f.id, f.originalName]));
+
+      return NextResponse.json({
+        ...response,
+        items: response.items.map((job) => {
+          if (job.kind !== MEDIA_DERIVATIVE_GENERATE_JOB_KIND) return job;
+          const fileId = (job.payloadJson as { fileId?: string } | null)
+            ?.fileId;
+          return {
+            ...job,
+            fileName: fileId ? (fileNameMap.get(fileId) ?? null) : null,
+          };
+        }),
+      });
+    }
+  }
+
+  return NextResponse.json(response);
 }

--- a/apps/web/app/api/files/files/[fileId]/derivative/route.ts
+++ b/apps/web/app/api/files/files/[fileId]/derivative/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getPrisma } from "@staaash/db/client";
+import { scheduleDerivativeGenerate } from "@staaash/db/media-derivatives";
+
+import { getRequestSession } from "@/server/auth/guards";
+import { isSameOrigin } from "@/server/auth/http";
+
+type RouteContext = {
+  params: Promise<{ fileId: string }>;
+};
+
+const getAuthorizedFile = async (
+  fileId: string,
+  actorId: string,
+  actorRole: string,
+) => {
+  const db = getPrisma();
+  const file = await db.file.findFirst({
+    where: { id: fileId, deletedAt: null },
+    select: { ownerUserId: true, mimeType: true },
+  });
+  if (!file) return null;
+  if (file.ownerUserId !== actorId && actorRole !== "owner") return null;
+  return file;
+};
+
+export async function GET(request: NextRequest, { params }: RouteContext) {
+  const { fileId } = await params;
+  const session = await getRequestSession(request);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+
+  const file = await getAuthorizedFile(
+    fileId,
+    session.user.id,
+    session.user.role,
+  );
+  if (!file) {
+    return NextResponse.json({ error: "File not found." }, { status: 404 });
+  }
+
+  const db = getPrisma();
+  const derivative = await db.mediaDerivative.findFirst({
+    where: { fileId },
+    select: { status: true, generatedAt: true },
+  });
+
+  if (!derivative) {
+    return NextResponse.json({ status: "none" });
+  }
+
+  return NextResponse.json({
+    status: derivative.status,
+    generatedAt: derivative.generatedAt?.toISOString() ?? null,
+  });
+}
+
+export async function POST(request: NextRequest, { params }: RouteContext) {
+  if (!isSameOrigin(request)) {
+    return NextResponse.json(
+      { error: "Cross-origin requests are not allowed." },
+      { status: 403 },
+    );
+  }
+
+  const { fileId } = await params;
+  const session = await getRequestSession(request);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+
+  const file = await getAuthorizedFile(
+    fileId,
+    session.user.id,
+    session.user.role,
+  );
+  if (!file) {
+    return NextResponse.json({ error: "File not found." }, { status: 404 });
+  }
+
+  if (!file.mimeType.startsWith("video/")) {
+    return NextResponse.json(
+      { error: "Preview generation is only supported for video files." },
+      { status: 400 },
+    );
+  }
+
+  await scheduleDerivativeGenerate({ fileId, reason: "manual-regenerate" });
+
+  return NextResponse.json({ status: "queued" });
+}

--- a/apps/web/server/admin/types.ts
+++ b/apps/web/server/admin/types.ts
@@ -84,6 +84,7 @@ export type JsonAdminJobListResponse = Omit<AdminJobListResponse, "items"> & {
       lockedAt: string | null;
       createdAt: string;
       updatedAt: string;
+      fileName?: string | null;
     }
   >;
 };

--- a/apps/worker/src/ffmpeg.ts
+++ b/apps/worker/src/ffmpeg.ts
@@ -1,7 +1,44 @@
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
+
+const runFfmpegProcess = (
+  args: string[],
+  signal?: AbortSignal,
+): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const proc = spawn("ffmpeg", args, { stdio: "ignore" });
+
+    let killedBySignal = false;
+
+    const onAbort = () => {
+      killedBySignal = true;
+      proc.kill();
+    };
+
+    if (signal?.aborted) {
+      proc.kill();
+      killedBySignal = true;
+    } else if (signal) {
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+
+    proc.on("close", (code) => {
+      if (signal) signal.removeEventListener("abort", onAbort);
+      if (killedBySignal) {
+        reject(
+          Object.assign(new Error("ffmpeg aborted."), { code: "ABORT_ERR" }),
+        );
+      } else if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`ffmpeg exited with code ${String(code)}.`));
+      }
+    });
+
+    proc.on("error", reject);
+  });
 
 export type FfmpegHealth = {
   available: boolean;
@@ -92,53 +129,61 @@ export const isStreamCopyCompatible = (probe: FfprobeResult): boolean => {
 export const runFfmpegStreamCopy = (
   inputPath: string,
   outputPath: string,
-): Promise<{ stdout: string; stderr: string }> =>
-  execFileAsync("ffmpeg", [
-    "-y",
-    "-i",
-    inputPath,
-    "-map",
-    "0:v:0",
-    "-map",
-    "0:a:0?",
-    "-c",
-    "copy",
-    "-movflags",
-    "+faststart",
-    "-f",
-    "mp4",
-    outputPath,
-  ]);
+  signal?: AbortSignal,
+): Promise<void> =>
+  runFfmpegProcess(
+    [
+      "-y",
+      "-i",
+      inputPath,
+      "-map",
+      "0:v:0",
+      "-map",
+      "0:a:0?",
+      "-c",
+      "copy",
+      "-movflags",
+      "+faststart",
+      "-f",
+      "mp4",
+      outputPath,
+    ],
+    signal,
+  );
 
 export const runFfmpegTranscode = (
   inputPath: string,
   outputPath: string,
   maxHeight: number,
   crf: number,
-): Promise<{ stdout: string; stderr: string }> =>
-  execFileAsync("ffmpeg", [
-    "-y",
-    "-i",
-    inputPath,
-    "-map",
-    "0:v:0",
-    "-map",
-    "0:a:0?",
-    "-vf",
-    `scale=-2:min(ih\\,${maxHeight}):force_original_aspect_ratio=decrease`,
-    "-c:v",
-    "libx264",
-    "-preset",
-    "medium",
-    "-crf",
-    String(crf),
-    "-c:a",
-    "aac",
-    "-b:a",
-    "160k",
-    "-movflags",
-    "+faststart",
-    "-f",
-    "mp4",
-    outputPath,
-  ]);
+  signal?: AbortSignal,
+): Promise<void> =>
+  runFfmpegProcess(
+    [
+      "-y",
+      "-i",
+      inputPath,
+      "-map",
+      "0:v:0",
+      "-map",
+      "0:a:0?",
+      "-vf",
+      `scale=-2:min(ih\\,${maxHeight}):force_original_aspect_ratio=decrease`,
+      "-c:v",
+      "libx264",
+      "-preset",
+      "medium",
+      "-crf",
+      String(crf),
+      "-c:a",
+      "aac",
+      "-b:a",
+      "160k",
+      "-movflags",
+      "+faststart",
+      "-f",
+      "mp4",
+      outputPath,
+    ],
+    signal,
+  );

--- a/apps/worker/src/handlers/media-derivative.ts
+++ b/apps/worker/src/handlers/media-derivative.ts
@@ -7,6 +7,7 @@ import {
   DERIVATIVE_KIND_PREVIEW,
   DERIVATIVE_PROFILE_1080P,
   DERIVATIVE_STATUS_PROCESSING,
+  DERIVATIVE_STATUS_STALE,
   buildDerivativeStorageKey,
   markDerivativeFailed,
   markDerivativeReady,
@@ -46,6 +47,7 @@ type PrismaClient = {
     findUnique(args: object): Promise<SystemSettingsRecord | null>;
   };
   mediaDerivative: {
+    findUnique(args: object): Promise<{ id: string; status: string } | null>;
     upsert(args: object): Promise<{ id: string; status: string }>;
     update(args: object): Promise<{ id: string; status: string }>;
   };
@@ -86,7 +88,7 @@ const DEFAULT_SETTINGS: SystemSettingsRecord = {
 export const handleMediaDerivativeGenerate = async (
   job: BackgroundJobRecord,
   storagePaths: WorkerStoragePaths,
-): Promise<void> => {
+): Promise<boolean> => {
   const health = getFfmpegHealth();
   if (!health.available) {
     throw new Error(
@@ -109,7 +111,7 @@ export const handleMediaDerivativeGenerate = async (
   const settings: SystemSettingsRecord = rawSettings ?? DEFAULT_SETTINGS;
 
   if (!settings.mediaPreviewEnabled) {
-    return;
+    return false;
   }
 
   const file = await prisma.file.findUnique({
@@ -129,14 +131,14 @@ export const handleMediaDerivativeGenerate = async (
   }
 
   if (!file.mimeType.startsWith("video/")) {
-    return;
+    return false;
   }
 
   if (
     payload.reason !== "manual-regenerate" &&
     file.sizeBytes < settings.mediaPreviewThresholdBytes
   ) {
-    return;
+    return false;
   }
 
   const kind =
@@ -175,18 +177,50 @@ export const handleMediaDerivativeGenerate = async (
     throw err;
   }
 
+  const controller = new AbortController();
+  let cancelledByAdmin = false;
+
+  const cancelPollId = setInterval(() => {
+    void (getPrisma() as unknown as PrismaClient).mediaDerivative
+      .findUnique({
+        where: { id: derivative.id },
+        select: { status: true } as object,
+      })
+      .then((current) => {
+        if (current?.status === DERIVATIVE_STATUS_STALE) {
+          cancelledByAdmin = true;
+          controller.abort();
+        }
+      })
+      .catch(() => {
+        // ignore transient DB errors during poll
+      });
+  }, 3000);
+
   try {
     if (isStreamCopyCompatible(probe)) {
-      await runFfmpegStreamCopy(inputPath, tmpPath);
+      await runFfmpegStreamCopy(inputPath, tmpPath, controller.signal);
     } else {
       await runFfmpegTranscode(
         inputPath,
         tmpPath,
         settings.mediaPreviewMaxHeight,
         settings.mediaPreviewCrf,
+        controller.signal,
       );
     }
+  } catch (err) {
+    await rm(tmpPath, { force: true });
+    if (cancelledByAdmin) {
+      return true;
+    }
+    await markDerivativeFailed(derivative.id, String(err));
+    throw err;
+  } finally {
+    clearInterval(cancelPollId);
+  }
 
+  try {
     await mkdir(path.dirname(outputPath), { recursive: true });
     await rename(tmpPath, outputPath);
   } catch (err) {
@@ -202,6 +236,18 @@ export const handleMediaDerivativeGenerate = async (
     ? parseFloat(probe.format.duration)
     : null;
 
+  // Guard: admin may have marked stale while we were processing.
+  const current = await (
+    getPrisma() as unknown as PrismaClient
+  ).mediaDerivative.findUnique({
+    where: { id: derivative.id },
+    select: { status: true } as object,
+  });
+  if (current?.status === DERIVATIVE_STATUS_STALE) {
+    await rm(outputPath, { force: true });
+    return true;
+  }
+
   await markDerivativeReady(derivative.id, {
     storageKey,
     mimeType: "video/mp4",
@@ -213,4 +259,6 @@ export const handleMediaDerivativeGenerate = async (
     audioCodec: audioStream?.codec_name ?? null,
     generatedAt: new Date(),
   });
+
+  return false;
 };

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -172,9 +172,16 @@ const processNextJob = async (): Promise<boolean> => {
         await handleRestoreReconciliation(job, storagePaths);
         break;
 
-      case MEDIA_DERIVATIVE_GENERATE_JOB_KIND:
-        await handleMediaDerivativeGenerate(job, storagePaths);
+      case MEDIA_DERIVATIVE_GENERATE_JOB_KIND: {
+        const cancelled = await handleMediaDerivativeGenerate(
+          job,
+          storagePaths,
+        );
+        if (cancelled) {
+          return true;
+        }
         break;
+      }
 
       case MEDIA_DERIVATIVE_CLEANUP_JOB_KIND:
         await handleMediaDerivativeCleanup(job, storagePaths);


### PR DESCRIPTION
## Summary

- **Cancel running jobs** — Cancel button now works for `processing` derivatives (not just `queued`). Uses `spawn` + explicit `proc.kill()` for reliable ffmpeg termination (replaces unreliable `execFile` + AbortSignal). Web side immediately marks the background job `dead` so the UI updates without waiting for the worker, and prevents re-claim after the 60s lease expiry.
- **Stale guard** — Added a DB check before `markDerivativeReady` as a second line of defence; if the derivative was marked stale while ffmpeg was still running, the output file is deleted and the job exits cleanly.
- **No succeeded overwrite** — Handler returns `boolean`; `index.ts` skips `markBackgroundJobSucceeded` when cancelled so the job stays `dead` instead of flipping to `succeeded`.
- **"Cancelled" display** — Dead jobs with `lastError = "Cancelled by admin."` render as a neutral "Cancelled" chip instead of red "Dead".
- **File names in job history** — Job history panel now shows the original file name instead of a truncated file ID. The jobs API batch-fetches `originalName` for derivative jobs.
- **Generate preview from properties panel** — New `GET/POST /api/files/files/[fileId]/derivative` endpoint lets file owners queue preview generation. Video files in the properties panel show a "Media preview" section with current status and a Generate/Regenerate button.

## Test plan

- [x] Cancel a queued derivative → job shows Cancelled immediately, derivative shows Stale
- [ ] Cancel a processing (running) derivative → ffmpeg terminates within ~3s, job shows Cancelled, derivative stays Stale (not overwritten to Ready)
- [ ] Verify no phantom restart after 60s (job stays dead, not re-claimed)
- [x] Job history panel shows file name (e.g. `2026-04-11 20-12-29.mp4`) not truncated ID
- [x] Open properties on a video file → Media preview section shows current status
- [x] Click Generate preview on a file with no existing derivative → job queues, status updates to Queued

🤖 Generated with [Claude Code](https://claude.com/claude-code)