### PR TITLE
Harden file transfers and downloads

### DIFF
--- a/apps/web/app/(workspace)/files/files-row.tsx
+++ b/apps/web/app/(workspace)/files/files-row.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Folder,
   Image,
@@ -133,7 +133,7 @@ type BaseFileRowProps = {
   onProperties: () => void;
   onCut: () => void;
   onMoveTo: (destinationId: string) => void;
-  onDownload?: () => void;
+  onDownload: () => void;
   rowRef: (el: HTMLDivElement | null) => void;
 };
 
@@ -200,7 +200,14 @@ export function FilesRow(props: FilesRowProps) {
   const name = props.data.name;
 
   // ---- Meta ----
-  const date = formatDateTime(props.data.updatedAt);
+  // Format on the client only — server's timezone diverges from the browser's
+  // so a render-time `Intl.DateTimeFormat` call mismatches at hydration
+  // (React #418). Empty on first paint, populated on mount.
+  const updatedAt = props.data.updatedAt;
+  const [date, setDate] = useState("");
+  useEffect(() => {
+    setDate(formatDateTime(updatedAt));
+  }, [updatedAt]);
   const size = props.kind === "file" ? formatBytes(props.data.sizeBytes) : "";
 
   // ---- Href ----
@@ -282,7 +289,9 @@ export function FilesRow(props: FilesRowProps) {
           <span className="explorer-row-meta">{size}</span>
 
           {/* Date */}
-          <span className="explorer-row-meta">{date}</span>
+          <span className="explorer-row-meta" suppressHydrationWarning>
+            {date}
+          </span>
         </div>
       </ContextMenuTrigger>
 
@@ -298,25 +307,16 @@ export function FilesRow(props: FilesRowProps) {
           <ContextMenuShortcut>↵</ContextMenuShortcut>
         </ContextMenuItem>
 
-        {onDownload ? (
+        {isMultiSelected ? (
           <ContextMenuItem onClick={onDownload}>
-            {isMultiSelected
-              ? `Download ${selectedCount} items as zip`
-              : "Download as zip"}
+            {`Download ${selectedCount} items as zip`}
           </ContextMenuItem>
-        ) : props.kind === "file" && props.data.viewerKind ? (
-          <ContextMenuItem
-            onClick={() => {
-              const a = document.createElement("a");
-              a.href = `/api/files/files/${props.data.id}/download`;
-              a.rel = "noopener noreferrer";
-              document.body.appendChild(a);
-              a.click();
-              document.body.removeChild(a);
-            }}
-          >
-            Download
+        ) : props.kind === "folder" ? (
+          <ContextMenuItem onClick={onDownload}>
+            Download as zip
           </ContextMenuItem>
+        ) : props.data.viewerKind ? (
+          <ContextMenuItem onClick={onDownload}>Download</ContextMenuItem>
         ) : null}
 
         <ContextMenuSeparator />

--- a/apps/web/app/(workspace)/files/files-view.tsx
+++ b/apps/web/app/(workspace)/files/files-view.tsx
@@ -21,6 +21,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { FlashMessage } from "@/app/auth-ui";
+import { startValidatedDownload } from "@/lib/transfers/download";
 import type { FilesListing } from "@/server/files/types";
 import type { ShareFilesLookup } from "@/server/sharing";
 
@@ -171,8 +172,7 @@ export function FilesView({
   useEffect(() => {
     registerFileInput(fileInputRef.current, listing.currentFolder.id);
     return () => registerFileInput(null);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [listing.currentFolder.id, registerFileInput]);
 
   // Auto-open file picker when navigated here via Upload button from another route.
   useEffect(() => {
@@ -479,6 +479,19 @@ export function FilesView({
   // Item actions
   // ---------------------------------------------------------------------------
 
+  const downloadFile = async (id: string) => {
+    try {
+      await startValidatedDownload(
+        `/api/files/files/${id}/download`,
+        "File download failed",
+      );
+    } catch (err) {
+      setTrashError(
+        err instanceof Error ? err.message : "File download failed",
+      );
+    }
+  };
+
   const openItem = (id: string) => {
     const folder = listing.childFolders.find((f) => f.id === id);
     if (folder) {
@@ -488,14 +501,7 @@ export function FilesView({
     const file = listing.files.find((f) => f.id === id);
     if (file) {
       if (file.viewerKind) router.push(`/files/view/${file.id}`);
-      else {
-        const a = document.createElement("a");
-        a.href = `/api/files/files/${file.id}/download`;
-        a.rel = "noopener noreferrer";
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
-      }
+      else void downloadFile(file.id);
     }
   };
 
@@ -552,9 +558,13 @@ export function FilesView({
         : `/api/files/files/${id}/trash`;
     const res = await fetch(endpoint, {
       method: "POST",
+      headers: { Accept: "application/json" },
       body: new URLSearchParams({ redirectTo: currentPath }),
     });
-    if (!res.ok) throw new Error(`Trash failed (${res.status})`);
+    if (res.ok || res.status === 404) return;
+
+    const data = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(data.error ?? `Trash failed (${res.status})`);
   };
 
   const trashItem = async (id: string, kind: "folder" | "file") => {
@@ -1301,12 +1311,7 @@ export function FilesView({
                       handleDownload(Array.from(current));
                       return;
                     }
-                    const a = document.createElement("a");
-                    a.href = `/api/files/files/${file.id}/download`;
-                    a.rel = "noopener noreferrer";
-                    document.body.appendChild(a);
-                    a.click();
-                    document.body.removeChild(a);
+                    void downloadFile(file.id);
                   }}
                   rowRef={(el) => {
                     if (el) rowRefs.current.set(file.id, el);

--- a/apps/web/app/(workspace)/files/files-view.tsx
+++ b/apps/web/app/(workspace)/files/files-view.tsx
@@ -130,6 +130,21 @@ export function FilesView({
   const selectedIdsRef = useRef(selectedIds);
   selectedIdsRef.current = selectedIds;
 
+  // ---- Optimistic trash ----
+  // Items moved to trash are filtered out client-side before the server-side
+  // refresh comes back so the list visually updates instantly. Cleared once
+  // the new listing arrives (the server response no longer contains them).
+  const [trashedIds, setTrashedIds] = useState<Set<string>>(new Set());
+  const [trashError, setTrashError] = useState<string | null>(null);
+  useEffect(() => {
+    setTrashedIds(new Set());
+  }, [listing]);
+  useEffect(() => {
+    if (!trashError) return;
+    const t = setTimeout(() => setTrashError(null), 4000);
+    return () => clearTimeout(t);
+  }, [trashError]);
+
   // ---- Rename ----
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
@@ -222,13 +237,17 @@ export function FilesView({
   // ---- Sets ----
   const favoriteFileSet = new Set(favoriteFileIds);
   const favoriteFolderSet = new Set(favoriteFolderIds);
+  const visibleFolders = listing.childFolders.filter(
+    (f) => !trashedIds.has(f.id),
+  );
+  const visibleFiles = listing.files.filter((f) => !trashedIds.has(f.id));
 
   // Flat ordered list of all items (folders first, then files)
   type AnyItem = { kind: "folder"; id: string } | { kind: "file"; id: string };
 
   const allItems: AnyItem[] = [
-    ...listing.childFolders.map((f) => ({ kind: "folder" as const, id: f.id })),
-    ...listing.files.map((f) => ({ kind: "file" as const, id: f.id })),
+    ...visibleFolders.map((f) => ({ kind: "folder" as const, id: f.id })),
+    ...visibleFiles.map((f) => ({ kind: "file" as const, id: f.id })),
   ];
 
   // ---- Load persisted state ----
@@ -526,22 +545,69 @@ export function FilesView({
     startTransition(() => router.refresh());
   };
 
-  const trashItem = async (id: string, kind: "folder" | "file") => {
+  const moveToTrash = async (id: string, kind: "folder" | "file") => {
     const endpoint =
       kind === "folder"
         ? `/api/files/folders/${id}/trash`
         : `/api/files/files/${id}/trash`;
-    await fetch(endpoint, {
+    const res = await fetch(endpoint, {
       method: "POST",
       body: new URLSearchParams({ redirectTo: currentPath }),
     });
-    startTransition(() => router.refresh());
+    if (!res.ok) throw new Error(`Trash failed (${res.status})`);
+  };
+
+  const trashItem = async (id: string, kind: "folder" | "file") => {
+    setTrashedIds((prev) => {
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
+    try {
+      await moveToTrash(id, kind);
+      startTransition(() => router.refresh());
+    } catch (err) {
+      setTrashedIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+      setTrashError(
+        err instanceof Error ? err.message : "Failed to move to trash",
+      );
+    }
   };
 
   const handleTrashSelected = async () => {
     const items = allItems.filter((i) => selectedIds.has(i.id));
-    await Promise.all(items.map((i) => trashItem(i.id, i.kind)));
+    if (items.length === 0) return;
     setSelectedIds(new Set());
+    setTrashedIds((prev) => {
+      const next = new Set(prev);
+      for (const item of items) next.add(item.id);
+      return next;
+    });
+    const results = await Promise.allSettled(
+      items.map((i) => moveToTrash(i.id, i.kind)),
+    );
+    let succeeded = false;
+    const failedIds = new Set<string>();
+    results.forEach((result, index) => {
+      if (result.status === "fulfilled") {
+        succeeded = true;
+      } else {
+        failedIds.add(items[index].id);
+      }
+    });
+    if (failedIds.size > 0) {
+      setTrashedIds((prev) => {
+        const next = new Set(prev);
+        for (const id of failedIds) next.delete(id);
+        return next;
+      });
+      setTrashError("Some items could not be moved to trash.");
+    }
+    if (succeeded) startTransition(() => router.refresh());
   };
 
   const moveItem = async (
@@ -800,18 +866,18 @@ export function FilesView({
       f.folderId === listing.currentFolder.id &&
       (f.status !== "done" ||
         !f.fileId ||
-        !listing.files.some((lf) => lf.id === f.fileId)),
+        !visibleFiles.some((lf) => lf.id === f.fileId)),
   );
 
   // Ghost rows for sessions not already being actively uploaded or already in the listing
   const activeUploadNames = new Set(uploadingFiles.map((f) => f.name));
-  const existingFileNames = new Set(listing.files.map((f) => f.name));
+  const existingFileNames = new Set(visibleFiles.map((f) => f.name));
   const ghostEntries = resumableSessions.filter(
     (s) => !activeUploadNames.has(s.name) && !existingFileNames.has(s.name),
   );
 
   const mergedFileEntries: MergedFileEntry[] = [
-    ...listing.files.map((f) => ({ kind: "file" as const, file: f })),
+    ...visibleFiles.map((f) => ({ kind: "file" as const, file: f })),
     ...activeUploads.map((u) => ({ kind: "upload" as const, upload: u })),
     ...ghostEntries.map((s) => ({ kind: "ghost" as const, ...s })),
   ];
@@ -841,6 +907,7 @@ export function FilesView({
         {/* Flash messages */}
         {error ? <FlashMessage>{error}</FlashMessage> : null}
         {success ? <FlashMessage tone="success">{success}</FlashMessage> : null}
+        {trashError ? <FlashMessage>{trashError}</FlashMessage> : null}
 
         <div
           className="explorer-root"
@@ -1003,7 +1070,7 @@ export function FilesView({
             )}
 
             {/* ---- Folders ---- */}
-            {listing.childFolders.map((folder) => {
+            {visibleFolders.map((folder) => {
               const availableMoveTargetIds = new Set(
                 listing.availableMoveTargetIdsByFolderId[folder.id] ?? [],
               );
@@ -1101,13 +1168,11 @@ export function FilesView({
             })}
 
             {/* ---- Empty state ---- */}
-            {mergedFileEntries.length === 0 &&
-              listing.childFolders.length === 0 && (
-                <div className="explorer-empty">
-                  This folder is empty. Drop files here or use the Upload
-                  button.
-                </div>
-              )}
+            {mergedFileEntries.length === 0 && visibleFolders.length === 0 && (
+              <div className="explorer-empty">
+                This folder is empty. Drop files here or use the Upload button.
+              </div>
+            )}
 
             {/* ---- Files + uploading rows merged, sorted alphabetically ---- */}
             {mergedFileEntries.map((entry) => {
@@ -1230,11 +1295,19 @@ export function FilesView({
                       startTransition(() => router.refresh()),
                     );
                   }}
-                  onDownload={
-                    selectedIds.has(file.id) && selectedIds.size > 1
-                      ? () => handleDownload(Array.from(selectedIdsRef.current))
-                      : undefined
-                  }
+                  onDownload={() => {
+                    const current = selectedIdsRef.current;
+                    if (current.has(file.id) && current.size > 1) {
+                      handleDownload(Array.from(current));
+                      return;
+                    }
+                    const a = document.createElement("a");
+                    a.href = `/api/files/files/${file.id}/download`;
+                    a.rel = "noopener noreferrer";
+                    document.body.appendChild(a);
+                    a.click();
+                    document.body.removeChild(a);
+                  }}
                   rowRef={(el) => {
                     if (el) rowRefs.current.set(file.id, el);
                     else rowRefs.current.delete(file.id);

--- a/apps/web/app/(workspace)/transfer-context.tsx
+++ b/apps/web/app/(workspace)/transfer-context.tsx
@@ -3,6 +3,7 @@
 import {
   createContext,
   startTransition,
+  useCallback,
   useContext,
   useEffect,
   useRef,
@@ -136,13 +137,13 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
     string | null
   >(null);
 
-  const registerFileInput = (
-    el: HTMLInputElement | null,
-    folderId?: string,
-  ) => {
-    fileInputRef.current = el;
-    setCurrentFilesViewFolderId(folderId ?? null);
-  };
+  const registerFileInput = useCallback(
+    (el: HTMLInputElement | null, folderId?: string) => {
+      fileInputRef.current = el;
+      setCurrentFilesViewFolderId(folderId ?? null);
+    },
+    [],
+  );
 
   // ---- staaash:upload-click ----
   useEffect(() => {

--- a/apps/web/app/(workspace)/transfer-context.tsx
+++ b/apps/web/app/(workspace)/transfer-context.tsx
@@ -10,6 +10,11 @@ import {
 } from "react";
 import { useRouter } from "next/navigation";
 import { randomClientId } from "@/lib/client-id";
+import {
+  fetchWithRetry,
+  queuedFetch,
+  queuedXhrUpload,
+} from "@/lib/transfers/request-queue";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -120,9 +125,13 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
     state: DownloadProgressState;
   } | null>(null);
   const downloadPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const downloadAbortRef = useRef<AbortController | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const uploadingFilesRef = useRef<UploadingFile[]>([]);
   uploadingFilesRef.current = uploadingFiles;
+  const uploadAbortControllers = useRef<Map<string, AbortController>>(
+    new Map(),
+  );
   const [currentFilesViewFolderId, setCurrentFilesViewFolderId] = useState<
     string | null
   >(null);
@@ -160,7 +169,16 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
   const startDownloadPoll = (archiveId: string) => {
     stopDownloadPoll();
     downloadPollRef.current = setInterval(() => {
-      void fetch(`/api/files/archives/${archiveId}`)
+      void queuedFetch(
+        "poll",
+        `/api/files/archives/${archiveId}`,
+        { headers: { Accept: "application/json" } },
+        {
+          retries: 5,
+          backoffMs: 1000,
+          signal: downloadAbortRef.current?.signal,
+        },
+      )
         .then((res) => res.json())
         .then(
           (data: { status: string; fileCount?: number; error?: string }) => {
@@ -196,7 +214,10 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
             }
           },
         )
-        .catch(() => {});
+        .catch(() => {
+          // Transient errors are absorbed by fetchWithRetry; anything still
+          // surfacing here (e.g. user-aborted) is intentionally swallowed.
+        });
     }, 2000);
   };
 
@@ -212,20 +233,35 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
     } catch {
       // ignore
     }
-    return () => stopDownloadPoll();
+    return () => {
+      stopDownloadPoll();
+      downloadAbortRef.current?.abort();
+      downloadAbortRef.current = null;
+      for (const controller of uploadAbortControllers.current.values()) {
+        controller.abort();
+      }
+      uploadAbortControllers.current.clear();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleDownload = async (ids: string[]) => {
     stopDownloadPoll();
+    downloadAbortRef.current?.abort();
+    const controller = new AbortController();
+    downloadAbortRef.current = controller;
     setActiveDownload({ archiveId: "", state: { status: "queued" } });
 
     try {
-      const res = await fetch("/api/files/archives", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ids }),
-      });
+      const res = await fetchWithRetry(
+        "/api/files/archives",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ids }),
+        },
+        { retries: 2, backoffMs: 500, signal: controller.signal },
+      );
 
       if (!res.ok) {
         const data = (await res.json().catch(() => ({}))) as {
@@ -254,6 +290,7 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
         startDownloadPoll(archiveId);
       }
     } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
       setActiveDownload({
         archiveId: "",
         state: {
@@ -266,17 +303,20 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
 
   const dismissDownload = () => {
     stopDownloadPoll();
+    downloadAbortRef.current?.abort();
+    downloadAbortRef.current = null;
     setActiveDownload(null);
     localStorage.removeItem(ACTIVE_DOWNLOAD_KEY);
   };
 
   // ---- Upload ----
 
-  const uploadSingleFile = (
+  const uploadSingleFile = async (
     clientKey: string,
     file: File,
     folderId: string,
     currentPath: string,
+    signal: AbortSignal,
   ) => {
     const startTime = Date.now();
     const formData = new FormData();
@@ -290,24 +330,27 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
     );
     formData.append("files", file);
 
-    const xhr = new XMLHttpRequest();
-    xhr.upload.onprogress = (ev) => {
-      if (!ev.lengthComputable) return;
-      const progress = Math.round((ev.loaded / ev.total) * 100);
-      const elapsed = (Date.now() - startTime) / 1000;
-      const speed = elapsed > 0 ? ev.loaded / elapsed : 0;
-      setUploadingFiles((prev) =>
-        prev.map((f) =>
-          f.clientKey === clientKey ? { ...f, progress, speed } : f,
-        ),
-      );
-    };
+    try {
+      const result = await queuedXhrUpload({
+        url: "/api/files/files",
+        body: formData,
+        signal,
+        onProgress: (loaded, total) => {
+          const progress = Math.round((loaded / total) * 100);
+          const elapsed = (Date.now() - startTime) / 1000;
+          const speed = elapsed > 0 ? loaded / elapsed : 0;
+          setUploadingFiles((prev) =>
+            prev.map((f) =>
+              f.clientKey === clientKey ? { ...f, progress, speed } : f,
+            ),
+          );
+        },
+      });
 
-    xhr.onload = () => {
-      if (xhr.status >= 200 && xhr.status < 300) {
+      if (result.status >= 200 && result.status < 300) {
         let fileId: string | undefined;
         try {
-          fileId = JSON.parse(xhr.responseText)?.uploadedFiles?.[0]?.id;
+          fileId = JSON.parse(result.responseText)?.uploadedFiles?.[0]?.id;
         } catch {
           /* ignore */
         }
@@ -327,7 +370,7 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
       } else {
         let msg = "Upload failed";
         try {
-          msg = JSON.parse(xhr.responseText)?.error ?? msg;
+          msg = JSON.parse(result.responseText)?.error ?? msg;
         } catch {
           /* ignore */
         }
@@ -339,9 +382,8 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
           ),
         );
       }
-    };
-
-    xhr.onerror = () => {
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
       setUploadingFiles((prev) =>
         prev.map((f) =>
           f.clientKey === clientKey
@@ -349,17 +391,16 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
             : f,
         ),
       );
-    };
-
-    xhr.open("POST", "/api/files/files");
-    xhr.setRequestHeader("Accept", "application/json");
-    xhr.send(formData);
+    } finally {
+      uploadAbortControllers.current.delete(clientKey);
+    }
   };
 
   const uploadLargeFile = async (
     clientKey: string,
     file: File,
     folderId: string,
+    signal: AbortSignal,
   ) => {
     const sessionStorageKey = `${UPLOAD_SESSION_KEY_PREFIX}:${folderId}:${file.name}:${file.size}`;
     let sessionId: string | null = null;
@@ -371,9 +412,12 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
         localStorage.getItem(sessionStorageKey) ?? "null",
       ) as { sessionId: string } | null;
       if (stored?.sessionId) {
-        const res = await fetch(`/api/uploads/sessions/${stored.sessionId}`, {
-          headers: { Accept: "application/json" },
-        });
+        const res = await queuedFetch(
+          "upload",
+          `/api/uploads/sessions/${stored.sessionId}`,
+          { headers: { Accept: "application/json" } },
+          { retries: 3, backoffMs: 500, signal },
+        );
         if (res.ok) {
           const data = (await res.json()) as { receivedBytes: number };
           sessionId = stored.sessionId;
@@ -394,26 +438,32 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
           localStorage.removeItem(sessionStorageKey);
         }
       }
-    } catch {
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") throw err;
       localStorage.removeItem(sessionStorageKey);
     }
 
     if (!sessionId) {
       try {
-        const res = await fetch("/api/uploads/sessions", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Accept: "application/json",
+        const res = await queuedFetch(
+          "upload",
+          "/api/uploads/sessions",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Accept: "application/json",
+            },
+            body: JSON.stringify({
+              folderId,
+              originalName: file.name,
+              mimeType: file.type || "application/octet-stream",
+              totalSizeBytes: file.size,
+              conflictStrategy: "safeRename",
+            }),
           },
-          body: JSON.stringify({
-            folderId,
-            originalName: file.name,
-            mimeType: file.type || "application/octet-stream",
-            totalSizeBytes: file.size,
-            conflictStrategy: "safeRename",
-          }),
-        });
+          { retries: 3, backoffMs: 500, signal },
+        );
         if (!res.ok) {
           const data = (await res.json().catch(() => ({}))) as {
             error?: string;
@@ -448,15 +498,20 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
         const chunk = file.slice(receivedBytes, chunkEnd);
         const buffer = await chunk.arrayBuffer();
 
-        const res = await fetch(`/api/uploads/sessions/${sessionId}`, {
-          method: "PATCH",
-          headers: {
-            "Content-Type": "application/octet-stream",
-            "Content-Range": `bytes ${receivedBytes}-${chunkEnd - 1}/${file.size}`,
-            Accept: "application/json",
+        const res = await queuedFetch(
+          "upload",
+          `/api/uploads/sessions/${sessionId}`,
+          {
+            method: "PATCH",
+            headers: {
+              "Content-Type": "application/octet-stream",
+              "Content-Range": `bytes ${receivedBytes}-${chunkEnd - 1}/${file.size}`,
+              Accept: "application/json",
+            },
+            body: buffer,
           },
-          body: buffer,
-        });
+          { retries: 3, backoffMs: 500, signal },
+        );
 
         if (!res.ok) {
           const data = (await res.json().catch(() => ({}))) as {
@@ -482,12 +537,14 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
         );
       }
 
-      const completeRes = await fetch(
+      const completeRes = await queuedFetch(
+        "upload",
         `/api/uploads/sessions/${sessionId}/complete`,
         {
           method: "POST",
           headers: { Accept: "application/json" },
         },
+        { retries: 3, backoffMs: 500, signal },
       );
 
       if (!completeRes.ok) {
@@ -514,6 +571,7 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
       }, 1800);
       startTransition(() => router.refresh());
     } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") return;
       setUploadingFiles((prev) =>
         prev.map((f) =>
           f.clientKey === clientKey
@@ -524,6 +582,31 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
               }
             : f,
         ),
+      );
+    } finally {
+      uploadAbortControllers.current.delete(clientKey);
+    }
+  };
+
+  const startUpload = (
+    clientKey: string,
+    file: File,
+    folderId: string,
+    currentPath: string,
+  ) => {
+    const existing = uploadAbortControllers.current.get(clientKey);
+    existing?.abort();
+    const controller = new AbortController();
+    uploadAbortControllers.current.set(clientKey, controller);
+    if (file.size >= CHUNKED_UPLOAD_THRESHOLD) {
+      void uploadLargeFile(clientKey, file, folderId, controller.signal);
+    } else {
+      void uploadSingleFile(
+        clientKey,
+        file,
+        folderId,
+        currentPath,
+        controller.signal,
       );
     }
   };
@@ -548,15 +631,16 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
           folderId,
         },
       ]);
-      if (file.size >= CHUNKED_UPLOAD_THRESHOLD) {
-        void uploadLargeFile(clientKey, file, folderId);
-      } else {
-        uploadSingleFile(clientKey, file, folderId, currentPath);
-      }
+      startUpload(clientKey, file, folderId, currentPath);
     }
   };
 
   const dismissUpload = (clientKey: string) => {
+    const controller = uploadAbortControllers.current.get(clientKey);
+    if (controller) {
+      controller.abort();
+      uploadAbortControllers.current.delete(clientKey);
+    }
     setUploadingFiles((prev) => prev.filter((f) => f.clientKey !== clientKey));
   };
 
@@ -578,11 +662,7 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
           : f,
       ),
     );
-    if (file.fileRef.size >= CHUNKED_UPLOAD_THRESHOLD) {
-      void uploadLargeFile(clientKey, file.fileRef, file.folderId);
-    } else {
-      uploadSingleFile(clientKey, file.fileRef, file.folderId, "");
-    }
+    startUpload(clientKey, file.fileRef, file.folderId, "");
   };
 
   return (

--- a/apps/web/app/(workspace)/transfer-panel.tsx
+++ b/apps/web/app/(workspace)/transfer-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { usePathname } from "next/navigation";
 import {
@@ -19,6 +19,7 @@ import {
   type UploadingFile,
   type DownloadProgressState,
 } from "./transfer-context";
+import { startValidatedDownload } from "@/lib/transfers/download";
 
 // ---------------------------------------------------------------------------
 // Transfer panel (portal-rendered, bottom-right)
@@ -37,26 +38,41 @@ export function TransferPanel() {
   const pathname = usePathname();
   const [collapsed, setCollapsed] = useState(false);
   const [mounted, setMounted] = useState(false);
-  const anchorRef = useRef<HTMLAnchorElement>(null);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
 
   useEffect(() => {
     setMounted(true);
   }, []);
 
-  // Auto-trigger download when archive is ready
+  // Auto-trigger download when archive is ready.
   useEffect(() => {
-    if (activeDownload?.state.status === "ready") {
-      anchorRef.current?.click();
-    }
-  }, [activeDownload?.state.status]);
+    if (activeDownload?.state.status !== "ready") return;
+
+    let cancelled = false;
+    setDownloadError(null);
+    startValidatedDownload(
+      `/api/files/archives/${activeDownload.archiveId}/download`,
+      "Archive download failed",
+    ).catch((err) => {
+      if (!cancelled) {
+        setDownloadError(
+          err instanceof Error ? err.message : "Archive download failed",
+        );
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeDownload?.archiveId, activeDownload?.state.status]);
 
   // Auto-dismiss download panel 3s after it's ready
   useEffect(() => {
-    if (activeDownload?.state.status === "ready") {
+    if (activeDownload?.state.status === "ready" && !downloadError) {
       const timer = setTimeout(dismissDownload, 3000);
       return () => clearTimeout(timer);
     }
-  }, [activeDownload?.state.status, dismissDownload]);
+  }, [activeDownload?.state.status, dismissDownload, downloadError]);
 
   const isOnFilesRoute =
     pathname === "/files" || pathname.startsWith("/files/");
@@ -104,19 +120,11 @@ export function TransferPanel() {
           {activeDownload && (
             <PanelDownloadRow
               state={activeDownload.state}
+              error={downloadError}
               onClose={dismissDownload}
             />
           )}
         </div>
-      )}
-
-      {activeDownload?.state.status === "ready" && (
-        <a
-          ref={anchorRef}
-          href={`/api/files/archives/${activeDownload.archiveId}/download`}
-          style={{ display: "none" }}
-          aria-hidden
-        />
       )}
     </div>
   );
@@ -195,13 +203,16 @@ function PanelUploadRow({
 
 function PanelDownloadRow({
   state,
+  error,
   onClose,
 }: {
   state: DownloadProgressState;
+  error: string | null;
   onClose: () => void;
 }) {
-  const bodyText =
-    state.status === "queued"
+  const bodyText = error
+    ? error
+    : state.status === "queued"
       ? "Waiting for worker…"
       : state.status === "processing"
         ? state.fileCount != null
@@ -214,12 +225,12 @@ function PanelDownloadRow({
   return (
     <div className="transfer-panel-row transfer-panel-row--download">
       <div className="transfer-panel-row-top">
-        {state.status === "ready" ? (
+        {state.status === "ready" && !error ? (
           <CheckCircle2
             size={13}
             className="transfer-panel-row-icon--success"
           />
-        ) : state.status === "error" ? null : (
+        ) : state.status === "error" || error ? null : (
           <Loader2 size={13} className="transfer-panel-row-icon--spin" />
         )}
         <span className="transfer-panel-row-name">{bodyText}</span>

--- a/apps/web/lib/transfers/download.ts
+++ b/apps/web/lib/transfers/download.ts
@@ -1,0 +1,62 @@
+const DOWNLOAD_FRAME_ID = "staaash-download-frame";
+
+type ErrorPayload = {
+  error?: string;
+  message?: string;
+};
+
+export async function startValidatedDownload(
+  url: string,
+  fallbackMessage = "Download failed",
+): Promise<void> {
+  const res = await fetch(url, {
+    headers: {
+      Accept: "application/octet-stream, application/json",
+      Range: "bytes=0-0",
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(await downloadErrorMessage(res, fallbackMessage));
+  }
+
+  startBrowserDownload(url);
+}
+
+async function downloadErrorMessage(
+  res: Response,
+  fallbackMessage: string,
+): Promise<string> {
+  const payload = (await res.json().catch(() => null)) as ErrorPayload | null;
+  if (payload?.error) return payload.error;
+  if (payload?.message) return payload.message;
+
+  const text = await res.text().catch(() => "");
+  if (text.trim()) return text.trim();
+
+  return `${fallbackMessage} (${res.status})`;
+}
+
+function startBrowserDownload(url: string) {
+  const frame = ensureDownloadFrame();
+  const a = document.createElement("a");
+  a.href = url;
+  a.target = frame.name;
+  a.rel = "noopener noreferrer";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
+
+function ensureDownloadFrame(): HTMLIFrameElement {
+  const existing = document.getElementById(DOWNLOAD_FRAME_ID);
+  if (existing instanceof HTMLIFrameElement) return existing;
+
+  const frame = document.createElement("iframe");
+  frame.id = DOWNLOAD_FRAME_ID;
+  frame.name = DOWNLOAD_FRAME_ID;
+  frame.style.display = "none";
+  frame.setAttribute("aria-hidden", "true");
+  document.body.appendChild(frame);
+  return frame;
+}

--- a/apps/web/lib/transfers/request-queue.ts
+++ b/apps/web/lib/transfers/request-queue.ts
@@ -1,0 +1,265 @@
+// Client-side transfer concurrency control + retry-with-backoff.
+//
+// Browsers cap HTTP/1.1 connections at 6 per origin. A chunked upload sending
+// 10 MB PATCHes can saturate that pool and starve archive-status polling or
+// short-lived downloads, surfacing as "NetworkError when attempting to fetch
+// resource." This module gates upload requests through a Lane (concurrency:
+// UPLOAD_CONCURRENCY) so a handful of slots stay free for everything else.
+
+const UPLOAD_CONCURRENCY = 3;
+const POLL_CONCURRENCY = 4;
+
+class Lane {
+  private running = 0;
+  private pending: Array<() => void> = [];
+
+  constructor(public concurrency: number) {}
+
+  acquire(signal?: AbortSignal): Promise<() => void> {
+    return new Promise((resolve, reject) => {
+      const tryStart = () => {
+        if (this.running < this.concurrency) {
+          this.running++;
+          let released = false;
+          const release = () => {
+            if (released) return;
+            released = true;
+            this.running--;
+            const next = this.pending.shift();
+            if (next) next();
+          };
+          resolve(release);
+          return true;
+        }
+        return false;
+      };
+
+      if (tryStart()) return;
+
+      const onAbort = () => {
+        const idx = this.pending.indexOf(slot);
+        if (idx >= 0) this.pending.splice(idx, 1);
+        reject(abortError());
+      };
+
+      const slot = () => {
+        if (signal?.aborted) {
+          // Drained but already aborted — promote the next waiter.
+          reject(abortError());
+          const next = this.pending.shift();
+          if (next) next();
+          return;
+        }
+        signal?.removeEventListener("abort", onAbort);
+        tryStart();
+      };
+
+      if (signal) {
+        if (signal.aborted) {
+          reject(abortError());
+          return;
+        }
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+      this.pending.push(slot);
+    });
+  }
+}
+
+const uploadLane = new Lane(UPLOAD_CONCURRENCY);
+const pollLane = new Lane(POLL_CONCURRENCY);
+
+export type TransferLane = "upload" | "poll";
+
+function laneFor(lane: TransferLane): Lane {
+  return lane === "upload" ? uploadLane : pollLane;
+}
+
+export async function withTransferSlot<T>(
+  lane: TransferLane,
+  fn: () => Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  const release = await laneFor(lane).acquire(signal);
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Retry-with-backoff fetch
+// ---------------------------------------------------------------------------
+
+export type FetchRetryOptions = {
+  retries?: number;
+  backoffMs?: number;
+  signal?: AbortSignal;
+  shouldRetry?: (res: Response) => boolean;
+};
+
+const DEFAULT_RETRIES = 3;
+const DEFAULT_BACKOFF_MS = 500;
+const MAX_BACKOFF_MS = 8_000;
+
+export async function fetchWithRetry(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  opts: FetchRetryOptions = {},
+): Promise<Response> {
+  const {
+    retries = DEFAULT_RETRIES,
+    backoffMs = DEFAULT_BACKOFF_MS,
+    signal,
+    shouldRetry,
+  } = opts;
+
+  const mergedSignal = signal ?? init?.signal ?? undefined;
+
+  let attempt = 0;
+  for (;;) {
+    throwIfAborted(mergedSignal);
+
+    let res: Response;
+    try {
+      res = await fetch(input, { ...init, signal: mergedSignal });
+    } catch (err) {
+      if (mergedSignal?.aborted) throw err;
+      if (err instanceof DOMException && err.name === "AbortError") throw err;
+      // `TypeError` is what fetch throws on network failure (DNS, conn reset,
+      // offline, NetworkError when attempting to fetch resource, etc.).
+      const isNetwork = err instanceof TypeError;
+      if (!isNetwork || attempt >= retries) throw err;
+      await delay(backoffFor(backoffMs, attempt), mergedSignal);
+      attempt++;
+      continue;
+    }
+
+    const retryable = shouldRetry
+      ? shouldRetry(res)
+      : res.status >= 500 && res.status < 600;
+    if (retryable && attempt < retries) {
+      await delay(backoffFor(backoffMs, attempt), mergedSignal);
+      attempt++;
+      continue;
+    }
+    return res;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Queued + retried fetch convenience
+// ---------------------------------------------------------------------------
+
+export function queuedFetch(
+  lane: TransferLane,
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  opts: FetchRetryOptions = {},
+): Promise<Response> {
+  return withTransferSlot(
+    lane,
+    () => fetchWithRetry(input, init, opts),
+    opts.signal,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// XHR adapter — keeps progress events for single-file uploads while still
+// participating in the upload concurrency budget.
+// ---------------------------------------------------------------------------
+
+export type XhrUploadOptions = {
+  url: string;
+  body: XMLHttpRequestBodyInit | Document;
+  signal?: AbortSignal;
+  onProgress?: (loaded: number, total: number) => void;
+  headers?: Record<string, string>;
+};
+
+export type XhrUploadResult = {
+  status: number;
+  responseText: string;
+};
+
+export function queuedXhrUpload(
+  opts: XhrUploadOptions,
+): Promise<XhrUploadResult> {
+  return withTransferSlot(
+    "upload",
+    () =>
+      new Promise<XhrUploadResult>((resolve, reject) => {
+        if (opts.signal?.aborted) {
+          reject(abortError());
+          return;
+        }
+        const xhr = new XMLHttpRequest();
+        const onAbort = () => xhr.abort();
+        opts.signal?.addEventListener("abort", onAbort, { once: true });
+
+        xhr.upload.onprogress = (ev) => {
+          if (ev.lengthComputable && opts.onProgress) {
+            opts.onProgress(ev.loaded, ev.total);
+          }
+        };
+        xhr.onload = () => {
+          opts.signal?.removeEventListener("abort", onAbort);
+          resolve({ status: xhr.status, responseText: xhr.responseText });
+        };
+        xhr.onerror = () => {
+          opts.signal?.removeEventListener("abort", onAbort);
+          reject(new TypeError("Network request failed"));
+        };
+        xhr.onabort = () => {
+          opts.signal?.removeEventListener("abort", onAbort);
+          reject(abortError());
+        };
+
+        xhr.open("POST", opts.url);
+        xhr.setRequestHeader("Accept", "application/json");
+        if (opts.headers) {
+          for (const [k, v] of Object.entries(opts.headers)) {
+            xhr.setRequestHeader(k, v);
+          }
+        }
+        xhr.send(opts.body);
+      }),
+    opts.signal,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function abortError(): DOMException {
+  return new DOMException("Aborted", "AbortError");
+}
+
+function throwIfAborted(signal: AbortSignal | undefined) {
+  if (signal?.aborted) throw abortError();
+}
+
+function backoffFor(baseMs: number, attempt: number): number {
+  const exp = Math.min(baseMs * 2 ** attempt, MAX_BACKOFF_MS);
+  return exp + Math.random() * 250;
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(abortError());
+      return;
+    }
+    const t = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(t);
+      reject(abortError());
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}


### PR DESCRIPTION
## 🚀 Summary

Hardens the files workspace transfer paths. Uploads now use queued/retry behavior, file delete/trash is optimistic and tolerant of stale duplicate requests, and file/archive downloads validate the API response before starting the browser download so users do not get navigated to an API error page.

## 📊 Impacts and Changes

Users should see more reliable uploads, downloads, and trash actions in `/files`. Single-file downloads and zip downloads should keep the user on the files page. Stale or duplicate trash requests no longer show a misleading 404 error. The topbar upload target now tracks the current folder after navigation.

No schema, auth, storage layout, or restore behavior changes.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

Deferred: `FilesRow` memoization/performance cleanup and possible batch trash endpoint. Existing files UI polish items are out of scope.

## 🔗 Linked Issues

None.