### PR TITLE
chore: use Node 24 Docker base

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,3 +51,7 @@ updates:
       time: "06:30"
       timezone: "UTC"
     open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "node"
+        update-types:
+          - "version-update:semver-major"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 RUN npm install -g pnpm@10.33.0 --no-fund --no-audit
 
 # ── Install dependencies ──────────────────────────────────────────────────────
@@ -21,7 +21,7 @@ RUN pnpm run db:generate && pnpm build && \
     cp -r apps/worker/dist /deploy/worker/dist
 
 # ── Runner ────────────────────────────────────────────────────────────────────
-FROM node:22-alpine AS runner
+FROM node:24-alpine AS runner
 RUN apk add --no-cache openssl ffmpeg
 WORKDIR /app
 ENV NODE_ENV=production


### PR DESCRIPTION
## 🚀 Summary

Updates the Docker base image from Node 22 Alpine to Node 24 Alpine and keeps Dependabot from proposing Node major-version jumps for the Docker image.

## 📊 Impacts and Changes

The published Docker image will build and run on the current Node 24 LTS line instead of jumping to Node 26 Current. Dependabot can still update other Docker dependencies, but it will not open major-version Node image bumps automatically.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

Docker build was not run locally because Docker Desktop's Linux engine is not available in this environment. GitHub release builds should still validate the actual image build path before release.

## 🔗 Linked Issues

Related to Dependabot PR #37.