### PR TITLE
Add home dashboard design

### DIFF
--- a/apps/web/app/(workspace)/files/files-row.tsx
+++ b/apps/web/app/(workspace)/files/files-row.tsx
@@ -3,12 +3,6 @@
 import { useEffect, useRef, useState } from "react";
 import {
   Folder,
-  Image,
-  Film,
-  Music,
-  FileText,
-  Archive,
-  File,
   Star,
   Heart,
   Lock,
@@ -20,6 +14,8 @@ import {
   type LucideIcon,
 } from "lucide-react";
 
+import { getItemVisual } from "@/app/item-visuals";
+import { ItemTypeIcon } from "@/app/item-type-icon";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -35,30 +31,6 @@ import { formatDateTime } from "@/app/auth-ui";
 import type { FileSummary, FolderSummary } from "@/server/files/types";
 import type { ShareLinkSummary } from "@/server/sharing";
 import { FOLDER_ICON_MAP } from "./files-properties-panel";
-
-// ---------------------------------------------------------------------------
-// File icon mapping
-// ---------------------------------------------------------------------------
-
-function getFileIcon(mimeType: string): LucideIcon {
-  if (mimeType.startsWith("image/")) return Image;
-  if (mimeType.startsWith("video/")) return Film;
-  if (mimeType.startsWith("audio/")) return Music;
-  if (
-    mimeType.includes("pdf") ||
-    mimeType.startsWith("text/") ||
-    mimeType.includes("document")
-  )
-    return FileText;
-  if (
-    mimeType.includes("zip") ||
-    mimeType.includes("archive") ||
-    mimeType.includes("tar") ||
-    mimeType.includes("gzip")
-  )
-    return Archive;
-  return File;
-}
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -182,18 +154,18 @@ export function FilesRow(props: FilesRowProps) {
     .join(" ");
 
   // ---- Icon ----
-  let IconComponent: LucideIcon;
-  let iconColor: string;
+  let IconComponent: LucideIcon | undefined;
+  const visual = getItemVisual(
+    props.kind,
+    props.kind === "file" ? props.data.mimeType : null,
+  );
 
   if (props.kind === "folder") {
     const customIcon =
       FOLDER_ICON_MAP[props.folderIconName ?? "Folder"] ?? Folder;
     IconComponent = isSelected ? FolderOpen : customIcon;
-    iconColor =
-      "color-mix(in oklab, var(--primary) 80%, var(--foreground) 20%)";
   } else {
-    IconComponent = getFileIcon(props.data.mimeType);
-    iconColor = "var(--muted-foreground)";
+    IconComponent = undefined;
   }
 
   // ---- Name ----
@@ -242,7 +214,11 @@ export function FilesRow(props: FilesRowProps) {
         >
           {/* Icon */}
           <div className="explorer-row-icon">
-            <IconComponent size={16} style={{ color: iconColor }} aria-hidden />
+            <ItemTypeIcon
+              icon={props.kind === "folder" ? IconComponent : undefined}
+              size={16}
+              visual={visual}
+            />
           </div>
 
           {/* Name */}

--- a/apps/web/app/(workspace)/home/home-helpers.ts
+++ b/apps/web/app/(workspace)/home/home-helpers.ts
@@ -1,0 +1,167 @@
+export type HomeVisualKind =
+  | "archive"
+  | "audio"
+  | "file"
+  | "folder"
+  | "image"
+  | "pdf"
+  | "text"
+  | "video";
+
+export type HomeItemVisual = {
+  kind: HomeVisualKind;
+  label: string;
+  color: string;
+  background: string;
+};
+
+const defaultFileVisual: HomeItemVisual = {
+  kind: "file",
+  label: "File",
+  color: "oklch(58% 0.02 76)",
+  background: "oklch(58% 0.02 76 / 0.1)",
+};
+
+const fileVisuals: Record<Exclude<HomeVisualKind, "folder">, HomeItemVisual> = {
+  archive: {
+    kind: "archive",
+    label: "Archive",
+    color: "oklch(58% 0.02 76)",
+    background: "oklch(58% 0.02 76 / 0.1)",
+  },
+  audio: {
+    kind: "audio",
+    label: "Audio",
+    color: "oklch(62% 0.14 145)",
+    background: "oklch(62% 0.14 145 / 0.12)",
+  },
+  file: defaultFileVisual,
+  image: {
+    kind: "image",
+    label: "Image",
+    color: "oklch(58% 0.13 255)",
+    background: "oklch(58% 0.13 255 / 0.12)",
+  },
+  pdf: {
+    kind: "pdf",
+    label: "PDF",
+    color: "oklch(62% 0.16 45)",
+    background: "oklch(62% 0.16 45 / 0.12)",
+  },
+  text: {
+    kind: "text",
+    label: "Text",
+    color: "oklch(66% 0.12 78)",
+    background: "oklch(66% 0.12 78 / 0.12)",
+  },
+  video: {
+    kind: "video",
+    label: "Video",
+    color: "oklch(58% 0.14 300)",
+    background: "oklch(58% 0.14 300 / 0.12)",
+  },
+};
+
+export function getHomeGreeting(hour: number): string {
+  if (hour < 5) return "Good night";
+  if (hour < 12) return "Good morning";
+  if (hour < 17) return "Good afternoon";
+  if (hour < 21) return "Good evening";
+  return "Good night";
+}
+
+export function formatHomeRelativeTime(
+  value: Date | string,
+  now = new Date(),
+): string {
+  const date = value instanceof Date ? value : new Date(value);
+  const diffMs = Math.max(0, now.getTime() - date.getTime());
+  const diffMinutes = Math.floor(diffMs / 60000);
+
+  if (diffMinutes < 1) return "Just now";
+  if (diffMinutes < 60)
+    return `${diffMinutes} min${diffMinutes === 1 ? "" : "s"} ago`;
+
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24)
+    return `${diffHours} hour${diffHours === 1 ? "" : "s"} ago`;
+
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays < 7) return `${diffDays} days ago`;
+
+  return date.toLocaleDateString("en", {
+    day: "numeric",
+    month: "short",
+  });
+}
+
+export function formatHomeExpiryTime(
+  value: Date | string,
+  now = new Date(),
+): string {
+  const date = value instanceof Date ? value : new Date(value);
+  const diffMs = date.getTime() - now.getTime();
+
+  if (diffMs <= 0) return "expired";
+
+  const diffMinutes = Math.ceil(diffMs / 60000);
+  if (diffMinutes < 60)
+    return `${diffMinutes} min${diffMinutes === 1 ? "" : "s"}`;
+
+  const diffHours = Math.ceil(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours} hour${diffHours === 1 ? "" : "s"}`;
+
+  const diffDays = Math.ceil(diffHours / 24);
+  if (diffDays < 7) return `${diffDays} days`;
+
+  const diffWeeks = Math.ceil(diffDays / 7);
+  if (diffWeeks < 9) return `${diffWeeks} week${diffWeeks === 1 ? "" : "s"}`;
+
+  const diffMonths = Math.ceil(diffDays / 30);
+  return `${diffMonths} month${diffMonths === 1 ? "" : "s"}`;
+}
+
+export function formatHomeFileSize(bytes: number): string {
+  if (bytes < 1024 * 1024) {
+    return `${Math.max(1, Math.round(bytes / 1024))} KB`;
+  }
+
+  if (bytes < 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+export function formatHomeChildCount(count: number): string {
+  if (count === 0) return "Empty";
+  if (count === 1) return "1 item";
+  return `${count} items`;
+}
+
+export function getHomeItemVisual(
+  kind: "file" | "folder",
+  mimeType?: string | null,
+): HomeItemVisual {
+  if (kind === "folder") {
+    return {
+      kind: "folder",
+      label: "Folder",
+      color: "color-mix(in oklab, var(--primary) 78%, var(--foreground) 22%)",
+      background: "color-mix(in oklab, var(--primary) 10%, transparent)",
+    };
+  }
+
+  const mime = mimeType ?? "";
+
+  if (mime.startsWith("image/")) return fileVisuals.image;
+  if (mime.startsWith("video/")) return fileVisuals.video;
+  if (mime.startsWith("audio/")) return fileVisuals.audio;
+  if (mime.includes("pdf")) return fileVisuals.pdf;
+  if (mime.startsWith("text/") || mime.includes("typescript"))
+    return fileVisuals.text;
+  if (mime.includes("zip") || mime.includes("tar")) return fileVisuals.archive;
+
+  return defaultFileVisual;
+}

--- a/apps/web/app/(workspace)/home/home-helpers.ts
+++ b/apps/web/app/(workspace)/home/home-helpers.ts
@@ -1,66 +1,10 @@
-export type HomeVisualKind =
-  | "archive"
-  | "audio"
-  | "file"
-  | "folder"
-  | "image"
-  | "pdf"
-  | "text"
-  | "video";
+import {
+  getItemVisual,
+  type ItemVisual as HomeItemVisual,
+  type ItemVisualKind as HomeVisualKind,
+} from "@/app/item-visuals";
 
-export type HomeItemVisual = {
-  kind: HomeVisualKind;
-  label: string;
-  color: string;
-  background: string;
-};
-
-const defaultFileVisual: HomeItemVisual = {
-  kind: "file",
-  label: "File",
-  color: "oklch(58% 0.02 76)",
-  background: "oklch(58% 0.02 76 / 0.1)",
-};
-
-const fileVisuals: Record<Exclude<HomeVisualKind, "folder">, HomeItemVisual> = {
-  archive: {
-    kind: "archive",
-    label: "Archive",
-    color: "oklch(58% 0.02 76)",
-    background: "oklch(58% 0.02 76 / 0.1)",
-  },
-  audio: {
-    kind: "audio",
-    label: "Audio",
-    color: "oklch(62% 0.14 145)",
-    background: "oklch(62% 0.14 145 / 0.12)",
-  },
-  file: defaultFileVisual,
-  image: {
-    kind: "image",
-    label: "Image",
-    color: "oklch(58% 0.13 255)",
-    background: "oklch(58% 0.13 255 / 0.12)",
-  },
-  pdf: {
-    kind: "pdf",
-    label: "PDF",
-    color: "oklch(62% 0.16 45)",
-    background: "oklch(62% 0.16 45 / 0.12)",
-  },
-  text: {
-    kind: "text",
-    label: "Text",
-    color: "oklch(66% 0.12 78)",
-    background: "oklch(66% 0.12 78 / 0.12)",
-  },
-  video: {
-    kind: "video",
-    label: "Video",
-    color: "oklch(58% 0.14 300)",
-    background: "oklch(58% 0.14 300 / 0.12)",
-  },
-};
+export type { HomeItemVisual, HomeVisualKind };
 
 export function getHomeGreeting(hour: number): string {
   if (hour < 5) return "Good night";
@@ -144,24 +88,5 @@ export function getHomeItemVisual(
   kind: "file" | "folder",
   mimeType?: string | null,
 ): HomeItemVisual {
-  if (kind === "folder") {
-    return {
-      kind: "folder",
-      label: "Folder",
-      color: "color-mix(in oklab, var(--primary) 78%, var(--foreground) 22%)",
-      background: "color-mix(in oklab, var(--primary) 10%, transparent)",
-    };
-  }
-
-  const mime = mimeType ?? "";
-
-  if (mime.startsWith("image/")) return fileVisuals.image;
-  if (mime.startsWith("video/")) return fileVisuals.video;
-  if (mime.startsWith("audio/")) return fileVisuals.audio;
-  if (mime.includes("pdf")) return fileVisuals.pdf;
-  if (mime.startsWith("text/") || mime.includes("typescript"))
-    return fileVisuals.text;
-  if (mime.includes("zip") || mime.includes("tar")) return fileVisuals.archive;
-
-  return defaultFileVisual;
+  return getItemVisual(kind, mimeType);
 }

--- a/apps/web/app/(workspace)/home/page.tsx
+++ b/apps/web/app/(workspace)/home/page.tsx
@@ -1,21 +1,11 @@
 import Link from "next/link";
 import { headers } from "next/headers";
-import {
-  Archive,
-  ArrowRight,
-  File,
-  FileText,
-  Folder,
-  Image,
-  Music,
-  Share2,
-  Video,
-  type LucideIcon,
-} from "lucide-react";
+import { ArrowRight, Share2, Video } from "lucide-react";
 
 import { requireSignedInPageSession } from "@/server/auth/guards";
 import { filesService } from "@/server/files/service";
 import type { FolderSummary } from "@/server/files/types";
+import { ItemTypeIcon, itemVisualIconMap } from "@/app/item-type-icon";
 import { retrievalService } from "@/server/retrieval/service";
 import type { RetrievalItem } from "@/server/retrieval/types";
 import { getBaseUrl } from "@/server/request";
@@ -30,7 +20,6 @@ import {
   getHomeGreeting,
   getHomeItemVisual,
   type HomeItemVisual,
-  type HomeVisualKind,
 } from "./home-helpers";
 
 export const dynamic = "force-dynamic";
@@ -38,17 +27,6 @@ export const dynamic = "force-dynamic";
 type HomeFolder = {
   folder: FolderSummary;
   childCount: number;
-};
-
-const visualIconMap: Record<HomeVisualKind, LucideIcon> = {
-  archive: Archive,
-  audio: Music,
-  file: File,
-  folder: Folder,
-  image: Image,
-  pdf: FileText,
-  text: FileText,
-  video: Video,
 };
 
 function SectionHeader({
@@ -78,13 +56,7 @@ function SectionHeader({
 }
 
 function HomeIcon({ visual }: { visual: HomeItemVisual }) {
-  const Icon = visualIconMap[visual.kind];
-
-  return (
-    <span className="home-item-icon" style={{ background: visual.background }}>
-      <Icon size={14} strokeWidth={1.8} color={visual.color} aria-hidden />
-    </span>
-  );
+  return <ItemTypeIcon className="home-item-icon" visual={visual} />;
 }
 
 function EmptyLine({ children }: { children: React.ReactNode }) {
@@ -170,7 +142,7 @@ function RecentPreview({ item }: { item: RetrievalItem }) {
     item.kind,
     item.kind === "file" ? item.mimeType : null,
   );
-  const Icon = visualIconMap[visual.kind];
+  const Icon = itemVisualIconMap[visual.kind];
 
   if (visual.kind === "video") {
     return (

--- a/apps/web/app/(workspace)/home/page.tsx
+++ b/apps/web/app/(workspace)/home/page.tsx
@@ -5,6 +5,7 @@ import { ArrowRight, Share2, Video } from "lucide-react";
 import { requireSignedInPageSession } from "@/server/auth/guards";
 import { filesService } from "@/server/files/service";
 import type { FolderSummary } from "@/server/files/types";
+import { ItemContextMenu } from "@/app/item-context-menu";
 import { ItemTypeIcon, itemVisualIconMap } from "@/app/item-type-icon";
 import { retrievalService } from "@/server/retrieval/service";
 import type { RetrievalItem } from "@/server/retrieval/types";
@@ -63,7 +64,13 @@ function EmptyLine({ children }: { children: React.ReactNode }) {
   return <p className="home-empty-line">{children}</p>;
 }
 
-function PinnedList({ items }: { items: RetrievalItem[] }) {
+function PinnedList({
+  items,
+  redirectTo,
+}: {
+  items: RetrievalItem[];
+  redirectTo: string;
+}) {
   if (items.length === 0) {
     return <EmptyLine>No pinned files yet</EmptyLine>;
   }
@@ -82,22 +89,26 @@ function PinnedList({ items }: { items: RetrievalItem[] }) {
           </>
         );
 
-        return item.kind === "folder" ? (
-          <Link
-            className="home-pinned-row"
+        return (
+          <ItemContextMenu
             href={item.href}
+            id={item.id}
+            isFavorite={item.isFavorite}
             key={`${item.kind}-${item.id}`}
+            kind={item.kind}
+            name={item.name}
+            redirectTo={redirectTo}
           >
-            {content}
-          </Link>
-        ) : (
-          <a
-            className="home-pinned-row"
-            href={item.href}
-            key={`${item.kind}-${item.id}`}
-          >
-            {content}
-          </a>
+            {item.kind === "folder" ? (
+              <Link className="home-pinned-row" href={item.href}>
+                {content}
+              </Link>
+            ) : (
+              <a className="home-pinned-row" href={item.href}>
+                {content}
+              </a>
+            )}
+          </ItemContextMenu>
         );
       })}
     </div>
@@ -190,7 +201,13 @@ function RecentPreview({ item }: { item: RetrievalItem }) {
   );
 }
 
-function RecentGrid({ items }: { items: RetrievalItem[] }) {
+function RecentGrid({
+  items,
+  redirectTo,
+}: {
+  items: RetrievalItem[];
+  redirectTo: string;
+}) {
   if (items.length === 0) {
     return <EmptyLine>Nothing recent yet</EmptyLine>;
   }
@@ -212,48 +229,67 @@ function RecentGrid({ items }: { items: RetrievalItem[] }) {
           </>
         );
 
-        return item.kind === "folder" ? (
-          <Link
-            className="home-recent-card"
+        return (
+          <ItemContextMenu
             href={item.href}
+            id={item.id}
+            isFavorite={item.isFavorite}
             key={`${item.kind}-${item.id}`}
+            kind={item.kind}
+            name={item.name}
+            redirectTo={redirectTo}
           >
-            {content}
-          </Link>
-        ) : (
-          <a
-            className="home-recent-card"
-            href={item.href}
-            key={`${item.kind}-${item.id}`}
-          >
-            {content}
-          </a>
+            {item.kind === "folder" ? (
+              <Link className="home-recent-card" href={item.href}>
+                {content}
+              </Link>
+            ) : (
+              <a className="home-recent-card" href={item.href}>
+                {content}
+              </a>
+            )}
+          </ItemContextMenu>
         );
       })}
     </div>
   );
 }
 
-function FolderList({ folders }: { folders: HomeFolder[] }) {
+function FolderList({
+  folders,
+  redirectTo,
+}: {
+  folders: HomeFolder[];
+  redirectTo: string;
+}) {
   if (folders.length === 0) {
     return <EmptyLine>No folders yet</EmptyLine>;
   }
 
   return (
     <div className="home-folder-list">
-      {folders.map(({ folder, childCount }) => (
-        <Link
-          className="home-folder-row"
-          href={folder.isFilesRoot ? "/files" : `/files/f/${folder.id}`}
-          key={folder.id}
-        >
-          <HomeIcon visual={getHomeItemVisual("folder")} />
-          <span className="home-folder-name">{folder.name}</span>
-          <span className="home-folder-meta">
-            {formatHomeChildCount(childCount)}
-          </span>
-        </Link>
-      ))}
+      {folders.map(({ folder, childCount }) => {
+        const href = folder.isFilesRoot ? "/files" : `/files/f/${folder.id}`;
+
+        return (
+          <ItemContextMenu
+            href={href}
+            id={folder.id}
+            key={folder.id}
+            kind="folder"
+            name={folder.name}
+            redirectTo={redirectTo}
+          >
+            <Link className="home-folder-row" href={href}>
+              <HomeIcon visual={getHomeItemVisual("folder")} />
+              <span className="home-folder-name">{folder.name}</span>
+              <span className="home-folder-meta">
+                {formatHomeChildCount(childCount)}
+              </span>
+            </Link>
+          </ItemContextMenu>
+        );
+      })}
     </div>
   );
 }
@@ -272,22 +308,26 @@ function SharedList({ shares }: { shares: ShareLinkSummary[] }) {
         );
 
         return (
-          <Link
-            className="home-shared-row"
+          <ItemContextMenu
             href={`/shared#${share.id}`}
+            id={share.id}
             key={share.id}
+            kind="share"
+            name={share.target.name}
           >
-            <HomeIcon visual={visual} />
-            <span className="home-shared-main">
-              <span className="home-shared-name">{share.target.name}</span>
-              <span className="home-shared-meta">
-                {share.downloadDisabled ? "Downloads off" : "Downloads on"}
-                {" · expires "}
-                {formatHomeExpiryTime(share.expiresAt)}
+            <Link className="home-shared-row" href={`/shared#${share.id}`}>
+              <HomeIcon visual={visual} />
+              <span className="home-shared-main">
+                <span className="home-shared-name">{share.target.name}</span>
+                <span className="home-shared-meta">
+                  {share.downloadDisabled ? "Downloads off" : "Downloads on"}
+                  {" · expires "}
+                  {formatHomeExpiryTime(share.expiresAt)}
+                </span>
               </span>
-            </span>
-            <Share2 size={13} strokeWidth={1.8} aria-hidden />
-          </Link>
+              <Share2 size={13} strokeWidth={1.8} aria-hidden />
+            </Link>
+          </ItemContextMenu>
         );
       })}
     </div>
@@ -345,6 +385,7 @@ export default async function HomePage() {
   ]);
   const displayName = session.user.displayName ?? session.user.username;
   const greeting = getHomeGreeting(new Date().getHours());
+  const currentPath = "/home";
 
   return (
     <div className="workspace-page home-page">
@@ -355,7 +396,10 @@ export default async function HomePage() {
       <div className="home-top-grid">
         <section className="home-section" aria-labelledby="home-pinned-title">
           <SectionHeader title="Pinned" titleId="home-pinned-title" />
-          <PinnedList items={favoriteItems.slice(0, 6)} />
+          <PinnedList
+            items={favoriteItems.slice(0, 6)}
+            redirectTo={currentPath}
+          />
         </section>
 
         <section className="home-section" aria-labelledby="home-recent-title">
@@ -365,7 +409,10 @@ export default async function HomePage() {
             title="Recent"
             titleId="home-recent-title"
           />
-          <RecentGrid items={recentItems.slice(0, 6)} />
+          <RecentGrid
+            items={recentItems.slice(0, 6)}
+            redirectTo={currentPath}
+          />
         </section>
       </div>
 
@@ -377,7 +424,7 @@ export default async function HomePage() {
             title="Folders"
             titleId="home-folders-title"
           />
-          <FolderList folders={folders} />
+          <FolderList folders={folders} redirectTo={currentPath} />
         </section>
 
         <section className="home-section" aria-labelledby="home-shared-title">

--- a/apps/web/app/(workspace)/home/page.tsx
+++ b/apps/web/app/(workspace)/home/page.tsx
@@ -1,10 +1,422 @@
-export default function HomePage() {
+import Link from "next/link";
+import { headers } from "next/headers";
+import {
+  Archive,
+  ArrowRight,
+  File,
+  FileText,
+  Folder,
+  Image,
+  Music,
+  Share2,
+  Video,
+  type LucideIcon,
+} from "lucide-react";
+
+import { requireSignedInPageSession } from "@/server/auth/guards";
+import { filesService } from "@/server/files/service";
+import type { FolderSummary } from "@/server/files/types";
+import { retrievalService } from "@/server/retrieval/service";
+import type { RetrievalItem } from "@/server/retrieval/types";
+import { getBaseUrl } from "@/server/request";
+import { sharingService } from "@/server/sharing/service";
+import type { ShareLinkSummary } from "@/server/sharing/types";
+import type { UserRole } from "@/server/types";
+
+import {
+  formatHomeChildCount,
+  formatHomeExpiryTime,
+  formatHomeRelativeTime,
+  getHomeGreeting,
+  getHomeItemVisual,
+  type HomeItemVisual,
+  type HomeVisualKind,
+} from "./home-helpers";
+
+export const dynamic = "force-dynamic";
+
+type HomeFolder = {
+  folder: FolderSummary;
+  childCount: number;
+};
+
+const visualIconMap: Record<HomeVisualKind, LucideIcon> = {
+  archive: Archive,
+  audio: Music,
+  file: File,
+  folder: Folder,
+  image: Image,
+  pdf: FileText,
+  text: FileText,
+  video: Video,
+};
+
+function SectionHeader({
+  actionHref,
+  actionLabel,
+  title,
+  titleId,
+}: {
+  actionHref?: string;
+  actionLabel?: string;
+  title: string;
+  titleId: string;
+}) {
   return (
-    <div className="workspace-page">
-      <div className="workspace-empty-state">
-        <p style={{ color: "var(--muted-foreground)", fontSize: "14px" }}>
-          Home — coming soon.
-        </p>
+    <div className="home-section-head">
+      <h2 className="home-section-title" id={titleId}>
+        {title}
+      </h2>
+      {actionHref && actionLabel ? (
+        <Link className="home-section-link" href={actionHref}>
+          <span>{actionLabel}</span>
+          <ArrowRight size={12} strokeWidth={1.8} aria-hidden />
+        </Link>
+      ) : null}
+    </div>
+  );
+}
+
+function HomeIcon({ visual }: { visual: HomeItemVisual }) {
+  const Icon = visualIconMap[visual.kind];
+
+  return (
+    <span className="home-item-icon" style={{ background: visual.background }}>
+      <Icon size={14} strokeWidth={1.8} color={visual.color} aria-hidden />
+    </span>
+  );
+}
+
+function EmptyLine({ children }: { children: React.ReactNode }) {
+  return <p className="home-empty-line">{children}</p>;
+}
+
+function PinnedList({ items }: { items: RetrievalItem[] }) {
+  if (items.length === 0) {
+    return <EmptyLine>No pinned files yet</EmptyLine>;
+  }
+
+  return (
+    <div className="home-pinned-list">
+      {items.map((item) => {
+        const visual = getHomeItemVisual(
+          item.kind,
+          item.kind === "file" ? item.mimeType : null,
+        );
+        const content = (
+          <>
+            <HomeIcon visual={visual} />
+            <span className="home-pinned-name">{item.name}</span>
+          </>
+        );
+
+        return item.kind === "folder" ? (
+          <Link
+            className="home-pinned-row"
+            href={item.href}
+            key={`${item.kind}-${item.id}`}
+          >
+            {content}
+          </Link>
+        ) : (
+          <a
+            className="home-pinned-row"
+            href={item.href}
+            key={`${item.kind}-${item.id}`}
+          >
+            {content}
+          </a>
+        );
+      })}
+    </div>
+  );
+}
+
+function PreviewLines() {
+  return (
+    <span className="home-doc-preview-lines" aria-hidden>
+      {[82, 65, 90, 50, 76, 60].map((width, index) => (
+        <span
+          key={`${width}-${index}`}
+          style={{
+            width: `${width}%`,
+          }}
+        />
+      ))}
+    </span>
+  );
+}
+
+function AudioBars({ color }: { color: string }) {
+  const bars = [5, 9, 14, 10, 18, 22, 16, 12, 20, 24, 18, 14, 10, 16, 20, 14];
+
+  return (
+    <span className="home-audio-bars" aria-hidden>
+      {bars.map((height, index) => (
+        <span
+          key={`${height}-${index}`}
+          style={{
+            background: color,
+            height: `${height}px`,
+          }}
+        />
+      ))}
+    </span>
+  );
+}
+
+function RecentPreview({ item }: { item: RetrievalItem }) {
+  const visual = getHomeItemVisual(
+    item.kind,
+    item.kind === "file" ? item.mimeType : null,
+  );
+  const Icon = visualIconMap[visual.kind];
+
+  if (visual.kind === "video") {
+    return (
+      <span className="home-recent-preview home-recent-preview-video">
+        <span className="home-video-strips" aria-hidden />
+        <span className="home-video-play" aria-hidden>
+          <Video size={14} strokeWidth={1.8} />
+        </span>
+      </span>
+    );
+  }
+
+  if (visual.kind === "audio") {
+    return (
+      <span
+        className="home-recent-preview"
+        style={{ background: visual.background }}
+      >
+        <AudioBars color={visual.color} />
+      </span>
+    );
+  }
+
+  if (visual.kind === "pdf" || visual.kind === "text") {
+    return (
+      <span
+        className="home-recent-preview home-recent-preview-document"
+        style={{ background: visual.background }}
+      >
+        <PreviewLines />
+        <span className="home-preview-type" style={{ color: visual.color }}>
+          {visual.kind === "pdf" ? "PDF" : "TXT"}
+        </span>
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className="home-recent-preview"
+      style={{ background: visual.background }}
+    >
+      <Icon size={24} strokeWidth={1.7} color={visual.color} aria-hidden />
+    </span>
+  );
+}
+
+function RecentGrid({ items }: { items: RetrievalItem[] }) {
+  if (items.length === 0) {
+    return <EmptyLine>Nothing recent yet</EmptyLine>;
+  }
+
+  return (
+    <div className="home-recent-grid">
+      {items.map((item) => {
+        const content = (
+          <>
+            <RecentPreview item={item} />
+            <span className="home-recent-body">
+              <span className="home-recent-name" title={item.name}>
+                {item.name}
+              </span>
+              <span className="home-recent-meta">
+                {formatHomeRelativeTime(item.updatedAt)}
+              </span>
+            </span>
+          </>
+        );
+
+        return item.kind === "folder" ? (
+          <Link
+            className="home-recent-card"
+            href={item.href}
+            key={`${item.kind}-${item.id}`}
+          >
+            {content}
+          </Link>
+        ) : (
+          <a
+            className="home-recent-card"
+            href={item.href}
+            key={`${item.kind}-${item.id}`}
+          >
+            {content}
+          </a>
+        );
+      })}
+    </div>
+  );
+}
+
+function FolderList({ folders }: { folders: HomeFolder[] }) {
+  if (folders.length === 0) {
+    return <EmptyLine>No folders yet</EmptyLine>;
+  }
+
+  return (
+    <div className="home-folder-list">
+      {folders.map(({ folder, childCount }) => (
+        <Link
+          className="home-folder-row"
+          href={folder.isFilesRoot ? "/files" : `/files/f/${folder.id}`}
+          key={folder.id}
+        >
+          <HomeIcon visual={getHomeItemVisual("folder")} />
+          <span className="home-folder-name">{folder.name}</span>
+          <span className="home-folder-meta">
+            {formatHomeChildCount(childCount)}
+          </span>
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+function SharedList({ shares }: { shares: ShareLinkSummary[] }) {
+  if (shares.length === 0) {
+    return <EmptyLine>No active links</EmptyLine>;
+  }
+
+  return (
+    <div className="home-shared-list">
+      {shares.map((share) => {
+        const visual = getHomeItemVisual(
+          share.target.targetType,
+          share.target.targetType === "file" ? share.target.mimeType : null,
+        );
+
+        return (
+          <Link
+            className="home-shared-row"
+            href={`/shared#${share.id}`}
+            key={share.id}
+          >
+            <HomeIcon visual={visual} />
+            <span className="home-shared-main">
+              <span className="home-shared-name">{share.target.name}</span>
+              <span className="home-shared-meta">
+                {share.downloadDisabled ? "Downloads off" : "Downloads on"}
+                {" · expires "}
+                {formatHomeExpiryTime(share.expiresAt)}
+              </span>
+            </span>
+            <Share2 size={13} strokeWidth={1.8} aria-hidden />
+          </Link>
+        );
+      })}
+    </div>
+  );
+}
+
+async function getHomeFolders({
+  actorRole,
+  actorUserId,
+}: {
+  actorRole: UserRole;
+  actorUserId: string;
+}): Promise<HomeFolder[]> {
+  const listing = await filesService.getFilesListing({
+    actorRole,
+    actorUserId,
+  });
+
+  return Promise.all(
+    listing.childFolders.slice(0, 4).map(async (folder) => {
+      const childListing = await filesService.getFilesListing({
+        actorRole,
+        actorUserId,
+        folderId: folder.id,
+      });
+
+      return {
+        folder,
+        childCount:
+          childListing.childFolders.length + childListing.files.length,
+      };
+    }),
+  );
+}
+
+export default async function HomePage() {
+  const [session, h] = await Promise.all([
+    requireSignedInPageSession("/?next=/home"),
+    headers(),
+  ]);
+
+  const actor = {
+    actorUserId: session.user.id,
+    actorRole: session.user.role,
+  };
+  const baseUrl = getBaseUrl(h);
+  const [favoriteItems, recentItems, folders, shares] = await Promise.all([
+    retrievalService.listFavorites(actor),
+    retrievalService.listRecent(actor),
+    getHomeFolders(actor),
+    sharingService.listOwnedShares({
+      ...actor,
+      baseUrl,
+    }),
+  ]);
+  const displayName = session.user.displayName ?? session.user.username;
+  const greeting = getHomeGreeting(new Date().getHours());
+
+  return (
+    <div className="workspace-page home-page">
+      <header className="home-greeting">
+        <h1>{`${greeting}, ${displayName}.`}</h1>
+      </header>
+
+      <div className="home-top-grid">
+        <section className="home-section" aria-labelledby="home-pinned-title">
+          <SectionHeader title="Pinned" titleId="home-pinned-title" />
+          <PinnedList items={favoriteItems.slice(0, 6)} />
+        </section>
+
+        <section className="home-section" aria-labelledby="home-recent-title">
+          <SectionHeader
+            actionHref="/files"
+            actionLabel="All files"
+            title="Recent"
+            titleId="home-recent-title"
+          />
+          <RecentGrid items={recentItems.slice(0, 6)} />
+        </section>
+      </div>
+
+      <div className="home-bottom-grid">
+        <section className="home-section" aria-labelledby="home-folders-title">
+          <SectionHeader
+            actionHref="/files"
+            actionLabel="View all"
+            title="Folders"
+            titleId="home-folders-title"
+          />
+          <FolderList folders={folders} />
+        </section>
+
+        <section className="home-section" aria-labelledby="home-shared-title">
+          <SectionHeader
+            actionHref="/shared"
+            actionLabel="Manage"
+            title="Shared links"
+            titleId="home-shared-title"
+          />
+          <SharedList shares={shares.active.slice(0, 3)} />
+        </section>
       </div>
     </div>
   );

--- a/apps/web/app/(workspace)/retrieval-item-list.tsx
+++ b/apps/web/app/(workspace)/retrieval-item-list.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { formatDateTime } from "@/app/auth-ui";
+import { ItemContextMenu } from "@/app/item-context-menu";
 import { getItemVisual } from "@/app/item-visuals";
 import { ItemTypeIcon } from "@/app/item-type-icon";
 import type { RetrievalItem } from "@/server/retrieval/types";
@@ -44,89 +45,99 @@ export function RetrievalItemList({
   return (
     <div className="retrieval-list">
       {items.map((item) => (
-        <article className="retrieval-row" key={`${item.kind}-${item.id}`}>
-          <div className="retrieval-row-main">
-            <ItemTypeIcon
-              visual={getItemVisual(
-                item.kind,
-                item.kind === "file" ? item.mimeType : null,
-              )}
-            />
-            <div className="retrieval-row-name-wrap">
-              {item.kind === "folder" ? (
-                <Link className="retrieval-row-name" href={item.href}>
-                  {item.name}
-                </Link>
-              ) : (
-                <a className="retrieval-row-name" href={item.href}>
-                  {item.name}
-                </a>
-              )}
+        <ItemContextMenu
+          href={item.href}
+          id={item.id}
+          isFavorite={item.isFavorite}
+          key={`${item.kind}-${item.id}`}
+          kind={item.kind}
+          name={item.name}
+          redirectTo={currentPath}
+        >
+          <article className="retrieval-row">
+            <div className="retrieval-row-main">
+              <ItemTypeIcon
+                visual={getItemVisual(
+                  item.kind,
+                  item.kind === "file" ? item.mimeType : null,
+                )}
+              />
+              <div className="retrieval-row-name-wrap">
+                {item.kind === "folder" ? (
+                  <Link className="retrieval-row-name" href={item.href}>
+                    {item.name}
+                  </Link>
+                ) : (
+                  <a className="retrieval-row-name" href={item.href}>
+                    {item.name}
+                  </a>
+                )}
+              </div>
+
+              <div className="retrieval-row-badges">
+                {showMatchKind && item.matchKind ? (
+                  <span className="pill pill-sm">{item.matchKind}</span>
+                ) : null}
+                <span className="pill pill-sm">
+                  {item.kind === "folder" ? "Folder" : "File"}
+                </span>
+                {item.isFavorite ? (
+                  <span
+                    className="retrieval-row-favorite-dot"
+                    role="img"
+                    aria-label="Favorited"
+                  />
+                ) : null}
+              </div>
             </div>
 
-            <div className="retrieval-row-badges">
-              {showMatchKind && item.matchKind ? (
-                <span className="pill pill-sm">{item.matchKind}</span>
-              ) : null}
-              <span className="pill pill-sm">
-                {item.kind === "folder" ? "Folder" : "File"}
+            <div className="retrieval-row-sub">
+              <span className="retrieval-row-meta">
+                {formatDateTime(item.updatedAt)}
+                {item.kind === "file"
+                  ? ` · ${formatFileSize(item.sizeBytes)}`
+                  : ` · ${item.pathLabel}`}
               </span>
-              {item.isFavorite ? (
-                <span
-                  className="retrieval-row-favorite-dot"
-                  role="img"
-                  aria-label="Favorited"
-                />
-              ) : null}
+
+              <div className="retrieval-row-actions">
+                {item.kind === "folder" ? (
+                  <Link
+                    className="button button-secondary button-sm"
+                    href={item.href}
+                  >
+                    Open
+                  </Link>
+                ) : (
+                  <a
+                    className="button button-secondary button-sm"
+                    href={item.href}
+                  >
+                    Download
+                  </a>
+                )}
+
+                <form
+                  action={`/api/files/${item.kind === "folder" ? "folders" : "files"}/${item.id}/favorite`}
+                  method="post"
+                  className="inline-form"
+                >
+                  <input name="redirectTo" type="hidden" value={currentPath} />
+                  <input
+                    name="isFavorite"
+                    type="hidden"
+                    value={item.isFavorite ? "false" : "true"}
+                  />
+                  <button
+                    className="button button-secondary button-sm"
+                    type="submit"
+                  >
+                    {getFavoriteActionLabel(item)}
+                  </button>
+                </form>
+              </div>
             </div>
-          </div>
-
-          <div className="retrieval-row-sub">
-            <span className="retrieval-row-meta">
-              {formatDateTime(item.updatedAt)}
-              {item.kind === "file"
-                ? ` · ${formatFileSize(item.sizeBytes)}`
-                : ` · ${item.pathLabel}`}
-            </span>
-
-            <div className="retrieval-row-actions">
-              {item.kind === "folder" ? (
-                <Link
-                  className="button button-secondary button-sm"
-                  href={item.href}
-                >
-                  Open
-                </Link>
-              ) : (
-                <a
-                  className="button button-secondary button-sm"
-                  href={item.href}
-                >
-                  Download
-                </a>
-              )}
-
-              <form
-                action={`/api/files/${item.kind === "folder" ? "folders" : "files"}/${item.id}/favorite`}
-                method="post"
-                className="inline-form"
-              >
-                <input name="redirectTo" type="hidden" value={currentPath} />
-                <input
-                  name="isFavorite"
-                  type="hidden"
-                  value={item.isFavorite ? "false" : "true"}
-                />
-                <button
-                  className="button button-secondary button-sm"
-                  type="submit"
-                >
-                  {getFavoriteActionLabel(item)}
-                </button>
-              </form>
-            </div>
-          </div>
-        </article>
+          </article>
+        </ItemContextMenu>
       ))}
     </div>
   );

--- a/apps/web/app/(workspace)/retrieval-item-list.tsx
+++ b/apps/web/app/(workspace)/retrieval-item-list.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 
 import { formatDateTime } from "@/app/auth-ui";
+import { getItemVisual } from "@/app/item-visuals";
+import { ItemTypeIcon } from "@/app/item-type-icon";
 import type { RetrievalItem } from "@/server/retrieval/types";
 
 type RetrievalItemListProps = {
@@ -44,6 +46,12 @@ export function RetrievalItemList({
       {items.map((item) => (
         <article className="retrieval-row" key={`${item.kind}-${item.id}`}>
           <div className="retrieval-row-main">
+            <ItemTypeIcon
+              visual={getItemVisual(
+                item.kind,
+                item.kind === "file" ? item.mimeType : null,
+              )}
+            />
             <div className="retrieval-row-name-wrap">
               {item.kind === "folder" ? (
                 <Link className="retrieval-row-name" href={item.href}>

--- a/apps/web/app/(workspace)/shared/page.tsx
+++ b/apps/web/app/(workspace)/shared/page.tsx
@@ -6,6 +6,7 @@ import {
   formatDateTime,
   getSingleSearchParam,
 } from "@/app/auth-ui";
+import { ItemContextMenu } from "@/app/item-context-menu";
 import { getItemVisual } from "@/app/item-visuals";
 import { ItemTypeIcon } from "@/app/item-type-icon";
 import {
@@ -139,141 +140,179 @@ export default async function SharedPage({ searchParams }: SharedPageProps) {
 
                 <div className="sl-list">
                   {activeItems.map((share) => (
-                    <article className="sl-row" id={share.id} key={share.id}>
-                      {/* ── Row head ── */}
-                      <div className="sl-head">
-                        <div className="sl-identity-row">
-                          <ItemTypeIcon
-                            visual={getItemVisual(
-                              share.target.targetType,
-                              share.target.targetType === "file"
-                                ? share.target.mimeType
-                                : null,
-                            )}
-                          />
-                          <div className="sl-identity">
-                            <span className="sl-name">{share.target.name}</span>
-                            <span className="sl-meta">
-                              {share.target.pathLabel}
-                              {" · "}
-                              {share.target.targetType}
-                              {" · expires in "}
-                              <strong>
-                                {getRelativeExpiry(share.expiresAt)}
-                              </strong>
-                            </span>
-                          </div>
-                        </div>
-                        <span className="sl-badge sl-badge--active">
-                          Active
-                        </span>
-                      </div>
-
-                      {/* ── Management panel ── */}
-                      <details className="sl-panel">
-                        <summary className="sl-summary">Manage</summary>
-
-                        <div className="sl-body">
-                          {/* URL row */}
-                          <div className="sl-url-row">
-                            <input
-                              className="sl-url-input"
-                              readOnly
-                              value={share.shareUrl}
-                              aria-label="Share URL"
+                    <ItemContextMenu
+                      href={`/shared#${share.id}`}
+                      id={share.id}
+                      key={share.id}
+                      kind="share"
+                      name={share.target.name}
+                    >
+                      <article className="sl-row" id={share.id}>
+                        {/* ── Row head ── */}
+                        <div className="sl-head">
+                          <div className="sl-identity-row">
+                            <ItemTypeIcon
+                              visual={getItemVisual(
+                                share.target.targetType,
+                                share.target.targetType === "file"
+                                  ? share.target.mimeType
+                                  : null,
+                              )}
                             />
-                            <a
-                              className="sl-open-link"
-                              href={share.shareUrl}
-                              target="_blank"
-                              rel="noreferrer"
-                            >
-                              Open ↗
-                            </a>
-                          </div>
-
-                          {/* Policy — expiry + downloads */}
-                          <form
-                            action={`/api/shares/${share.id}/update`}
-                            method="post"
-                            className="sl-policy-form"
-                          >
-                            <input
-                              name="redirectTo"
-                              type="hidden"
-                              value={`/shared#${share.id}`}
-                            />
-                            <div className="sl-policy-row">
-                              <input
-                                className="sl-datetime-input"
-                                defaultValue={formatDateTimeLocalValue(
-                                  share.expiresAt,
-                                )}
-                                name="expiresAt"
-                                type="datetime-local"
-                                required
-                              />
-                              <label className="sl-toggle-label">
-                                <input
-                                  type="checkbox"
-                                  name="downloadDisabled"
-                                  value="true"
-                                  defaultChecked={share.downloadDisabled}
-                                  className="share-toggle-check"
-                                />
-                                <span
-                                  className="share-toggle-slider"
-                                  aria-hidden
-                                />
-                                <span className="sl-toggle-text">
-                                  {share.downloadDisabled
-                                    ? "Downloads blocked"
-                                    : "Downloads allowed"}
-                                </span>
-                              </label>
-                              <button className="sl-save-btn" type="submit">
-                                Save
-                              </button>
+                            <div className="sl-identity">
+                              <span className="sl-name">
+                                {share.target.name}
+                              </span>
+                              <span className="sl-meta">
+                                {share.target.pathLabel}
+                                {" · "}
+                                {share.target.targetType}
+                                {" · expires in "}
+                                <strong>
+                                  {getRelativeExpiry(share.expiresAt)}
+                                </strong>
+                              </span>
                             </div>
-                          </form>
+                          </div>
+                          <span className="sl-badge sl-badge--active">
+                            Active
+                          </span>
+                        </div>
 
-                          {/* Password */}
-                          <div className="sl-pw-section">
+                        {/* ── Management panel ── */}
+                        <details className="sl-panel">
+                          <summary className="sl-summary">Manage</summary>
+
+                          <div className="sl-body">
+                            {/* URL row */}
+                            <div className="sl-url-row">
+                              <input
+                                className="sl-url-input"
+                                readOnly
+                                value={share.shareUrl}
+                                aria-label="Share URL"
+                              />
+                              <a
+                                className="sl-open-link"
+                                href={share.shareUrl}
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                Open ↗
+                              </a>
+                            </div>
+
+                            {/* Policy — expiry + downloads */}
                             <form
-                              action={`/api/shares/${share.id}/password`}
+                              action={`/api/shares/${share.id}/update`}
                               method="post"
-                              className="sl-pw-form"
+                              className="sl-policy-form"
                             >
                               <input
                                 name="redirectTo"
                                 type="hidden"
                                 value={`/shared#${share.id}`}
                               />
-                              <div className="sl-pw-row">
+                              <div className="sl-policy-row">
                                 <input
-                                  className="sl-pw-input"
-                                  minLength={4}
-                                  name="password"
-                                  type="password"
-                                  placeholder={
-                                    share.hasPassword
-                                      ? "New password…"
-                                      : "Set a password…"
-                                  }
+                                  className="sl-datetime-input"
+                                  defaultValue={formatDateTimeLocalValue(
+                                    share.expiresAt,
+                                  )}
+                                  name="expiresAt"
+                                  type="datetime-local"
+                                  required
                                 />
-                                <button className="sl-action-btn" type="submit">
-                                  {share.hasPassword ? "Rotate" : "Set"}
-                                </button>
-                                {share.hasPassword && (
-                                  <span className="sl-pw-status">
-                                    Password set
+                                <label className="sl-toggle-label">
+                                  <input
+                                    type="checkbox"
+                                    name="downloadDisabled"
+                                    value="true"
+                                    defaultChecked={share.downloadDisabled}
+                                    className="share-toggle-check"
+                                  />
+                                  <span
+                                    className="share-toggle-slider"
+                                    aria-hidden
+                                  />
+                                  <span className="sl-toggle-text">
+                                    {share.downloadDisabled
+                                      ? "Downloads blocked"
+                                      : "Downloads allowed"}
                                   </span>
-                                )}
+                                </label>
+                                <button className="sl-save-btn" type="submit">
+                                  Save
+                                </button>
                               </div>
                             </form>
-                            {share.hasPassword && (
+
+                            {/* Password */}
+                            <div className="sl-pw-section">
                               <form
                                 action={`/api/shares/${share.id}/password`}
+                                method="post"
+                                className="sl-pw-form"
+                              >
+                                <input
+                                  name="redirectTo"
+                                  type="hidden"
+                                  value={`/shared#${share.id}`}
+                                />
+                                <div className="sl-pw-row">
+                                  <input
+                                    className="sl-pw-input"
+                                    minLength={4}
+                                    name="password"
+                                    type="password"
+                                    placeholder={
+                                      share.hasPassword
+                                        ? "New password…"
+                                        : "Set a password…"
+                                    }
+                                  />
+                                  <button
+                                    className="sl-action-btn"
+                                    type="submit"
+                                  >
+                                    {share.hasPassword ? "Rotate" : "Set"}
+                                  </button>
+                                  {share.hasPassword && (
+                                    <span className="sl-pw-status">
+                                      Password set
+                                    </span>
+                                  )}
+                                </div>
+                              </form>
+                              {share.hasPassword && (
+                                <form
+                                  action={`/api/shares/${share.id}/password`}
+                                  method="post"
+                                >
+                                  <input
+                                    name="redirectTo"
+                                    type="hidden"
+                                    value={`/shared#${share.id}`}
+                                  />
+                                  <input
+                                    name="clear"
+                                    type="hidden"
+                                    value="true"
+                                  />
+                                  <button
+                                    className="sl-action-btn sl-action-btn--danger"
+                                    type="submit"
+                                  >
+                                    Remove password
+                                  </button>
+                                </form>
+                              )}
+                            </div>
+
+                            {/* Danger zone */}
+                            <div className="sl-danger-row">
+                              <form
+                                action={`/api/shares/${share.id}/revoke`}
                                 method="post"
                               >
                                 <input
@@ -281,53 +320,28 @@ export default async function SharedPage({ searchParams }: SharedPageProps) {
                                   type="hidden"
                                   value={`/shared#${share.id}`}
                                 />
-                                <input
-                                  name="clear"
-                                  type="hidden"
-                                  value="true"
-                                />
-                                <button
-                                  className="sl-action-btn sl-action-btn--danger"
-                                  type="submit"
-                                >
-                                  Remove password
+                                <button className="sl-danger-btn" type="submit">
+                                  Revoke link
                                 </button>
                               </form>
-                            )}
+                              <form
+                                action={`/api/shares/${share.id}/delete`}
+                                method="post"
+                              >
+                                <input
+                                  name="redirectTo"
+                                  type="hidden"
+                                  value="/shared"
+                                />
+                                <button className="sl-danger-btn" type="submit">
+                                  Delete record
+                                </button>
+                              </form>
+                            </div>
                           </div>
-
-                          {/* Danger zone */}
-                          <div className="sl-danger-row">
-                            <form
-                              action={`/api/shares/${share.id}/revoke`}
-                              method="post"
-                            >
-                              <input
-                                name="redirectTo"
-                                type="hidden"
-                                value={`/shared#${share.id}`}
-                              />
-                              <button className="sl-danger-btn" type="submit">
-                                Revoke link
-                              </button>
-                            </form>
-                            <form
-                              action={`/api/shares/${share.id}/delete`}
-                              method="post"
-                            >
-                              <input
-                                name="redirectTo"
-                                type="hidden"
-                                value="/shared"
-                              />
-                              <button className="sl-danger-btn" type="submit">
-                                Delete record
-                              </button>
-                            </form>
-                          </div>
-                        </div>
-                      </details>
-                    </article>
+                        </details>
+                      </article>
+                    </ItemContextMenu>
                   ))}
                 </div>
 
@@ -351,96 +365,104 @@ export default async function SharedPage({ searchParams }: SharedPageProps) {
 
                 <div className="sl-list">
                   {inactiveItems.map((share) => (
-                    <article className="sl-row" id={share.id} key={share.id}>
-                      <div className="sl-head">
-                        <div className="sl-identity-row">
-                          <ItemTypeIcon
-                            visual={getItemVisual(
-                              share.target.targetType,
-                              share.target.targetType === "file"
-                                ? share.target.mimeType
-                                : null,
+                    <ItemContextMenu
+                      href={`/shared#${share.id}`}
+                      id={share.id}
+                      key={share.id}
+                      kind="share"
+                      name={share.target.name}
+                    >
+                      <article className="sl-row" id={share.id}>
+                        <div className="sl-head">
+                          <div className="sl-identity-row">
+                            <ItemTypeIcon
+                              visual={getItemVisual(
+                                share.target.targetType,
+                                share.target.targetType === "file"
+                                  ? share.target.mimeType
+                                  : null,
+                              )}
+                            />
+                            <div className="sl-identity">
+                              <span className="sl-name sl-name--inactive">
+                                {share.target.name}
+                              </span>
+                              <span className="sl-meta">
+                                {share.target.pathLabel}
+                                {" · "}
+                                {share.target.targetType}
+                                {" · "}
+                                {formatDateTime(share.expiresAt)}
+                              </span>
+                            </div>
+                          </div>
+                          <span
+                            className={`sl-badge sl-badge--${share.status === "expired" ? "expired" : "revoked"}`}
+                          >
+                            {shareStatusLabel[share.status]}
+                          </span>
+                        </div>
+
+                        <details className="sl-panel">
+                          <summary className="sl-summary">Manage</summary>
+
+                          <div className="sl-body">
+                            {share.status !== "target-unavailable" ? (
+                              <form action="/api/shares" method="post">
+                                <input
+                                  name="mode"
+                                  type="hidden"
+                                  value="reissue"
+                                />
+                                <input
+                                  name="shareId"
+                                  type="hidden"
+                                  value={share.id}
+                                />
+                                <input
+                                  name="redirectTo"
+                                  type="hidden"
+                                  value={`/shared#${share.id}`}
+                                />
+                                <div className="sl-reissue-row">
+                                  <span className="sl-reissue-hint">
+                                    Generate a new link for this{" "}
+                                    {share.target.targetType}.
+                                  </span>
+                                  <button
+                                    className="sl-reissue-btn"
+                                    type="submit"
+                                  >
+                                    Reissue link
+                                  </button>
+                                </div>
+                              </form>
+                            ) : (
+                              <p className="sl-unavailable-hint">
+                                Restore the item in the library before reissuing
+                                this link.
+                              </p>
                             )}
-                          />
-                          <div className="sl-identity">
-                            <span className="sl-name sl-name--inactive">
-                              {share.target.name}
-                            </span>
-                            <span className="sl-meta">
-                              {share.target.pathLabel}
-                              {" · "}
-                              {share.target.targetType}
-                              {" · "}
-                              {formatDateTime(share.expiresAt)}
-                            </span>
-                          </div>
-                        </div>
-                        <span
-                          className={`sl-badge sl-badge--${share.status === "expired" ? "expired" : "revoked"}`}
-                        >
-                          {shareStatusLabel[share.status]}
-                        </span>
-                      </div>
 
-                      <details className="sl-panel">
-                        <summary className="sl-summary">Manage</summary>
-
-                        <div className="sl-body">
-                          {share.status !== "target-unavailable" ? (
-                            <form action="/api/shares" method="post">
-                              <input
-                                name="mode"
-                                type="hidden"
-                                value="reissue"
-                              />
-                              <input
-                                name="shareId"
-                                type="hidden"
-                                value={share.id}
-                              />
-                              <input
-                                name="redirectTo"
-                                type="hidden"
-                                value={`/shared#${share.id}`}
-                              />
-                              <div className="sl-reissue-row">
-                                <span className="sl-reissue-hint">
-                                  Generate a new link for this{" "}
-                                  {share.target.targetType}.
-                                </span>
-                                <button
-                                  className="sl-reissue-btn"
-                                  type="submit"
-                                >
-                                  Reissue link
+                            <div className="sl-danger-row">
+                              <form
+                                action={`/api/shares/${share.id}/delete`}
+                                method="post"
+                              >
+                                <input
+                                  name="redirectTo"
+                                  type="hidden"
+                                  value="/shared"
+                                />
+                                <button className="sl-danger-btn" type="submit">
+                                  Delete record
                                 </button>
-                              </div>
-                            </form>
-                          ) : (
-                            <p className="sl-unavailable-hint">
-                              Restore the item in the library before reissuing
-                              this link.
-                            </p>
-                          )}
-
-                          <div className="sl-danger-row">
-                            <form
-                              action={`/api/shares/${share.id}/delete`}
-                              method="post"
-                            >
-                              <input
-                                name="redirectTo"
-                                type="hidden"
-                                value="/shared"
-                              />
-                              <button className="sl-danger-btn" type="submit">
-                                Delete record
-                              </button>
-                            </form>
+                              </form>
+                            </div>
                           </div>
-                        </div>
-                      </details>
-                    </article>
+                        </details>
+                      </article>
+                    </ItemContextMenu>
                   ))}
                 </div>
 

--- a/apps/web/app/(workspace)/shared/page.tsx
+++ b/apps/web/app/(workspace)/shared/page.tsx
@@ -6,6 +6,8 @@ import {
   formatDateTime,
   getSingleSearchParam,
 } from "@/app/auth-ui";
+import { getItemVisual } from "@/app/item-visuals";
+import { ItemTypeIcon } from "@/app/item-type-icon";
 import {
   PAGE_SIZE,
   PaginationControls,
@@ -140,17 +142,27 @@ export default async function SharedPage({ searchParams }: SharedPageProps) {
                     <article className="sl-row" id={share.id} key={share.id}>
                       {/* ── Row head ── */}
                       <div className="sl-head">
-                        <div className="sl-identity">
-                          <span className="sl-name">{share.target.name}</span>
-                          <span className="sl-meta">
-                            {share.target.pathLabel}
-                            {" · "}
-                            {share.target.targetType}
-                            {" · expires in "}
-                            <strong>
-                              {getRelativeExpiry(share.expiresAt)}
-                            </strong>
-                          </span>
+                        <div className="sl-identity-row">
+                          <ItemTypeIcon
+                            visual={getItemVisual(
+                              share.target.targetType,
+                              share.target.targetType === "file"
+                                ? share.target.mimeType
+                                : null,
+                            )}
+                          />
+                          <div className="sl-identity">
+                            <span className="sl-name">{share.target.name}</span>
+                            <span className="sl-meta">
+                              {share.target.pathLabel}
+                              {" · "}
+                              {share.target.targetType}
+                              {" · expires in "}
+                              <strong>
+                                {getRelativeExpiry(share.expiresAt)}
+                              </strong>
+                            </span>
+                          </div>
                         </div>
                         <span className="sl-badge sl-badge--active">
                           Active
@@ -341,17 +353,27 @@ export default async function SharedPage({ searchParams }: SharedPageProps) {
                   {inactiveItems.map((share) => (
                     <article className="sl-row" id={share.id} key={share.id}>
                       <div className="sl-head">
-                        <div className="sl-identity">
-                          <span className="sl-name sl-name--inactive">
-                            {share.target.name}
-                          </span>
-                          <span className="sl-meta">
-                            {share.target.pathLabel}
-                            {" · "}
-                            {share.target.targetType}
-                            {" · "}
-                            {formatDateTime(share.expiresAt)}
-                          </span>
+                        <div className="sl-identity-row">
+                          <ItemTypeIcon
+                            visual={getItemVisual(
+                              share.target.targetType,
+                              share.target.targetType === "file"
+                                ? share.target.mimeType
+                                : null,
+                            )}
+                          />
+                          <div className="sl-identity">
+                            <span className="sl-name sl-name--inactive">
+                              {share.target.name}
+                            </span>
+                            <span className="sl-meta">
+                              {share.target.pathLabel}
+                              {" · "}
+                              {share.target.targetType}
+                              {" · "}
+                              {formatDateTime(share.expiresAt)}
+                            </span>
+                          </div>
                         </div>
                         <span
                           className={`sl-badge sl-badge--${share.status === "expired" ? "expired" : "revoked"}`}

--- a/apps/web/app/(workspace)/trash/page.tsx
+++ b/apps/web/app/(workspace)/trash/page.tsx
@@ -3,6 +3,8 @@ import {
   formatDateTime,
   getSingleSearchParam,
 } from "@/app/auth-ui";
+import { getItemVisual } from "@/app/item-visuals";
+import { ItemTypeIcon } from "@/app/item-type-icon";
 import { requireSignedInPageSession } from "@/server/auth/guards";
 import { filesService } from "@/server/files/service";
 import type {
@@ -119,14 +121,17 @@ export default async function TrashPage({ searchParams }: TrashPageProps) {
                   {folders.map((item) => (
                     <article className="folder-row" key={item.folder.id}>
                       <div className="folder-row-head">
-                        <div className="stack">
-                          <h2>{item.folder.name}</h2>
-                          <p className="folder-meta">
-                            Deleted{" "}
-                            {formatDateTime(
-                              item.folder.deletedAt ?? item.folder.updatedAt,
-                            )}
-                          </p>
+                        <div className="item-row-title">
+                          <ItemTypeIcon visual={getItemVisual("folder")} />
+                          <div className="stack">
+                            <h2>{item.folder.name}</h2>
+                            <p className="folder-meta">
+                              Deleted{" "}
+                              {formatDateTime(
+                                item.folder.deletedAt ?? item.folder.updatedAt,
+                              )}
+                            </p>
+                          </div>
                         </div>
                         <span className="pill">Restore ready</span>
                       </div>
@@ -171,14 +176,19 @@ export default async function TrashPage({ searchParams }: TrashPageProps) {
                   {files.map((item) => (
                     <article className="folder-row" key={item.file.id}>
                       <div className="folder-row-head">
-                        <div className="stack">
-                          <h2>{item.file.name}</h2>
-                          <p className="folder-meta">
-                            Deleted{" "}
-                            {formatDateTime(
-                              item.file.deletedAt ?? item.file.updatedAt,
-                            )}
-                          </p>
+                        <div className="item-row-title">
+                          <ItemTypeIcon
+                            visual={getItemVisual("file", item.file.mimeType)}
+                          />
+                          <div className="stack">
+                            <h2>{item.file.name}</h2>
+                            <p className="folder-meta">
+                              Deleted{" "}
+                              {formatDateTime(
+                                item.file.deletedAt ?? item.file.updatedAt,
+                              )}
+                            </p>
+                          </div>
                         </div>
                         <span className="pill">File</span>
                       </div>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1644,6 +1644,7 @@ h3 {
   padding: 7px 6px;
 }
 
+.item-type-icon,
 .home-item-icon {
   width: 26px;
   height: 26px;
@@ -1652,6 +1653,17 @@ h3 {
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+}
+
+.item-row-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.item-row-title > .stack {
+  min-width: 0;
 }
 
 .home-pinned-name,
@@ -3343,6 +3355,11 @@ h3 {
   flex-shrink: 0;
 }
 
+.explorer-row-icon .item-type-icon {
+  width: 28px;
+  height: 28px;
+}
+
 .explorer-row-icon svg {
   width: 16px;
   height: 16px;
@@ -4964,6 +4981,13 @@ main.share-locked-page {
 .sl-identity {
   display: grid;
   gap: 3px;
+  min-width: 0;
+}
+
+.sl-identity-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   min-width: 0;
 }
 

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1621,6 +1621,15 @@ h3 {
   gap: 0;
 }
 
+.home-pinned-list > [data-slot="context-menu"],
+.home-folder-list > [data-slot="context-menu"],
+.home-shared-list > [data-slot="context-menu"],
+.home-recent-grid > [data-slot="context-menu"],
+.retrieval-list > [data-slot="context-menu"],
+.sl-list > [data-slot="context-menu"] {
+  display: contents;
+}
+
 .home-pinned-row,
 .home-folder-row,
 .home-shared-row {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1539,6 +1539,327 @@ h3 {
   background: color-mix(in oklab, var(--foreground) 2%, var(--card));
 }
 
+/* ---- Home dashboard ---- */
+
+.home-page {
+  gap: 28px;
+}
+
+.home-greeting {
+  display: grid;
+  gap: 4px;
+}
+
+.home-greeting h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.1;
+}
+
+.home-top-grid,
+.home-bottom-grid {
+  display: grid;
+  gap: 20px;
+  align-items: start;
+}
+
+.home-top-grid {
+  grid-template-columns: minmax(180px, 1fr) minmax(0, 1.8fr);
+}
+
+.home-bottom-grid {
+  grid-template-columns: minmax(0, 1.2fr) minmax(220px, 1fr);
+}
+
+.home-section {
+  min-width: 0;
+}
+
+.home-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.home-section-title {
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  line-height: 1.2;
+  text-transform: uppercase;
+  color: color-mix(in oklab, var(--muted-foreground) 80%, transparent);
+}
+
+.home-section-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  font-weight: 600;
+  transition: color 120ms ease;
+  white-space: nowrap;
+}
+
+.home-section-link:hover {
+  color: var(--foreground);
+}
+
+.home-empty-line {
+  color: var(--muted-foreground);
+  font-size: 13px;
+  padding: 8px 6px;
+}
+
+.home-pinned-list,
+.home-folder-list,
+.home-shared-list {
+  display: grid;
+  gap: 0;
+}
+
+.home-pinned-row,
+.home-folder-row,
+.home-shared-row {
+  display: flex;
+  align-items: center;
+  border-radius: 7px;
+  color: var(--foreground);
+  transition:
+    background 120ms ease,
+    color 120ms ease;
+}
+
+.home-pinned-row:hover,
+.home-folder-row:hover,
+.home-shared-row:hover {
+  background: color-mix(in oklab, var(--foreground) 5%, transparent);
+}
+
+.home-pinned-row {
+  gap: 9px;
+  padding: 7px 6px;
+}
+
+.home-item-icon {
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.home-pinned-name,
+.home-folder-name,
+.home-shared-name,
+.home-recent-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.home-pinned-name {
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.home-recent-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.home-recent-card {
+  border: 1px solid color-mix(in oklab, var(--foreground) 7%, transparent);
+  border-radius: 12px;
+  background: var(--card);
+  color: var(--foreground);
+  overflow: hidden;
+  min-width: 0;
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.home-recent-card:hover {
+  border-color: color-mix(in oklab, var(--foreground) 13%, transparent);
+  box-shadow: 0 4px 14px color-mix(in oklab, var(--foreground) 8%, transparent);
+}
+
+.home-recent-preview {
+  height: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  position: relative;
+}
+
+.home-recent-preview-video {
+  background: oklch(13% 0.008 72);
+  color: oklch(92% 0.008 78);
+}
+
+.home-video-strips {
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    90deg,
+    transparent 0,
+    transparent 10%,
+    oklch(100% 0 0 / 0.04) 10%,
+    oklch(100% 0 0 / 0.04) 18%
+  );
+}
+
+.home-video-play {
+  position: relative;
+  z-index: 1;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: oklch(100% 0 0 / 0.14);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.home-recent-preview-document {
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: 10px 12px;
+}
+
+.home-doc-preview-lines {
+  width: 100%;
+  display: grid;
+  gap: 3px;
+  padding: 7px;
+  border-radius: 4px;
+  background: var(--card);
+  box-shadow: 0 1px 4px color-mix(in oklab, var(--foreground) 10%, transparent);
+}
+
+.home-doc-preview-lines span {
+  display: block;
+  height: 3px;
+  border-radius: 2px;
+  background: color-mix(in oklab, var(--foreground) 10%, transparent);
+}
+
+.home-doc-preview-lines span:first-child {
+  background: color-mix(in oklab, var(--foreground) 16%, transparent);
+}
+
+.home-preview-type {
+  position: absolute;
+  right: 8px;
+  bottom: 6px;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+}
+
+.home-audio-bars {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.home-audio-bars span {
+  width: 3px;
+  border-radius: 2px;
+  opacity: 0.72;
+}
+
+.home-recent-body {
+  display: grid;
+  gap: 3px;
+  padding: 10px 12px 12px;
+  border-top: 1px solid color-mix(in oklab, var(--foreground) 5%, transparent);
+}
+
+.home-recent-name {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.home-recent-meta {
+  color: var(--muted-foreground);
+  font-size: 11px;
+}
+
+.home-folder-row,
+.home-shared-row {
+  gap: 10px;
+  padding: 9px 6px;
+}
+
+.home-folder-name {
+  flex: 1;
+  font-size: 13.5px;
+  font-weight: 500;
+}
+
+.home-folder-meta {
+  flex-shrink: 0;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.home-shared-main {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.home-shared-name {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.home-shared-meta {
+  color: var(--muted-foreground);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 980px) {
+  .home-top-grid,
+  .home-bottom-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .home-recent-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 520px) {
+  .home-greeting h1 {
+    font-size: 1.6rem;
+  }
+
+  .home-recent-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 .folder-list {
   display: grid;
   gap: 3px;

--- a/apps/web/app/item-context-menu.tsx
+++ b/apps/web/app/item-context-menu.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import type { ReactElement } from "react";
+
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+
+type ItemContextMenuProps = {
+  children: ReactElement;
+  downloadHref?: string | null;
+  href: string;
+  id: string;
+  isFavorite?: boolean;
+  kind: "file" | "folder" | "share";
+  name: string;
+  redirectTo?: string;
+  shareHref?: string | null;
+};
+
+function submitFavorite({
+  id,
+  isFavorite,
+  kind,
+  redirectTo,
+}: {
+  id: string;
+  isFavorite: boolean;
+  kind: "file" | "folder";
+  redirectTo: string;
+}) {
+  const form = document.createElement("form");
+  form.method = "post";
+  form.action = `/api/files/${kind === "folder" ? "folders" : "files"}/${id}/favorite`;
+
+  const redirectInput = document.createElement("input");
+  redirectInput.type = "hidden";
+  redirectInput.name = "redirectTo";
+  redirectInput.value = redirectTo;
+  form.appendChild(redirectInput);
+
+  const favoriteInput = document.createElement("input");
+  favoriteInput.type = "hidden";
+  favoriteInput.name = "isFavorite";
+  favoriteInput.value = isFavorite ? "false" : "true";
+  form.appendChild(favoriteInput);
+
+  document.body.appendChild(form);
+  form.submit();
+}
+
+export function ItemContextMenu({
+  children,
+  downloadHref,
+  href,
+  id,
+  isFavorite,
+  kind,
+  name,
+  redirectTo = "/files",
+  shareHref,
+}: ItemContextMenuProps) {
+  const canFavorite =
+    (kind === "file" || kind === "folder") && typeof isFavorite === "boolean";
+  const openLabel =
+    kind === "share"
+      ? "Manage link"
+      : kind === "file" && href.includes("/download")
+        ? "Download"
+        : "Open";
+  const effectiveDownloadHref = downloadHref;
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger render={children} />
+      <ContextMenuContent>
+        <ContextMenuItem
+          onClick={() => {
+            window.location.href = href;
+          }}
+        >
+          {openLabel}
+          <ContextMenuShortcut>↵</ContextMenuShortcut>
+        </ContextMenuItem>
+
+        {effectiveDownloadHref ? (
+          <ContextMenuItem
+            onClick={() => {
+              window.location.href = effectiveDownloadHref;
+            }}
+          >
+            {kind === "folder" ? "Download as zip" : "Download"}
+          </ContextMenuItem>
+        ) : null}
+
+        {canFavorite || shareHref ? <ContextMenuSeparator /> : null}
+
+        {canFavorite ? (
+          <ContextMenuItem
+            onClick={() =>
+              submitFavorite({
+                id,
+                isFavorite: Boolean(isFavorite),
+                kind,
+                redirectTo,
+              })
+            }
+          >
+            {isFavorite ? "Remove from favorites" : "Add to favorites"}
+          </ContextMenuItem>
+        ) : null}
+
+        {shareHref ? (
+          <ContextMenuItem
+            onClick={() => {
+              window.location.href = shareHref;
+            }}
+          >
+            Manage shared link
+          </ContextMenuItem>
+        ) : null}
+
+        <ContextMenuSeparator />
+        <ContextMenuItem
+          onClick={() => {
+            void navigator.clipboard?.writeText(name);
+          }}
+        >
+          Copy name
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}

--- a/apps/web/app/item-type-icon.tsx
+++ b/apps/web/app/item-type-icon.tsx
@@ -1,0 +1,48 @@
+import {
+  Archive,
+  File,
+  FileText,
+  Folder,
+  Image,
+  Music,
+  Video,
+  type LucideIcon,
+} from "lucide-react";
+
+import type { ItemVisual, ItemVisualKind } from "@/app/item-visuals";
+
+export const itemVisualIconMap: Record<ItemVisualKind, LucideIcon> = {
+  archive: Archive,
+  audio: Music,
+  file: File,
+  folder: Folder,
+  image: Image,
+  pdf: FileText,
+  text: FileText,
+  video: Video,
+};
+
+export function ItemTypeIcon({
+  className = "item-type-icon",
+  icon,
+  size = 14,
+  visual,
+}: {
+  className?: string;
+  icon?: LucideIcon;
+  size?: number;
+  visual: ItemVisual;
+}) {
+  const Icon = icon ?? itemVisualIconMap[visual.kind];
+
+  return (
+    <span
+      aria-label={visual.label}
+      className={className}
+      style={{ background: visual.background }}
+      title={visual.label}
+    >
+      <Icon size={size} strokeWidth={1.8} color={visual.color} aria-hidden />
+    </span>
+  );
+}

--- a/apps/web/app/item-visuals.ts
+++ b/apps/web/app/item-visuals.ts
@@ -1,0 +1,100 @@
+export type ItemVisualKind =
+  | "archive"
+  | "audio"
+  | "file"
+  | "folder"
+  | "image"
+  | "pdf"
+  | "text"
+  | "video";
+
+export type ItemVisual = {
+  kind: ItemVisualKind;
+  label: string;
+  color: string;
+  background: string;
+};
+
+const defaultFileVisual: ItemVisual = {
+  kind: "file",
+  label: "File",
+  color: "oklch(58% 0.02 76)",
+  background: "oklch(58% 0.02 76 / 0.1)",
+};
+
+const fileVisuals: Record<Exclude<ItemVisualKind, "folder">, ItemVisual> = {
+  archive: {
+    kind: "archive",
+    label: "Archive",
+    color: "oklch(58% 0.02 76)",
+    background: "oklch(58% 0.02 76 / 0.1)",
+  },
+  audio: {
+    kind: "audio",
+    label: "Audio",
+    color: "oklch(62% 0.14 145)",
+    background: "oklch(62% 0.14 145 / 0.12)",
+  },
+  file: defaultFileVisual,
+  image: {
+    kind: "image",
+    label: "Image",
+    color: "oklch(58% 0.13 255)",
+    background: "oklch(58% 0.13 255 / 0.12)",
+  },
+  pdf: {
+    kind: "pdf",
+    label: "PDF",
+    color: "oklch(62% 0.16 45)",
+    background: "oklch(62% 0.16 45 / 0.12)",
+  },
+  text: {
+    kind: "text",
+    label: "Text",
+    color: "oklch(66% 0.12 78)",
+    background: "oklch(66% 0.12 78 / 0.12)",
+  },
+  video: {
+    kind: "video",
+    label: "Video",
+    color: "oklch(58% 0.14 300)",
+    background: "oklch(58% 0.14 300 / 0.12)",
+  },
+};
+
+export function getItemVisual(
+  kind: "file" | "folder",
+  mimeType?: string | null,
+): ItemVisual {
+  if (kind === "folder") {
+    return {
+      kind: "folder",
+      label: "Folder",
+      color: "color-mix(in oklab, var(--primary) 78%, var(--foreground) 22%)",
+      background: "color-mix(in oklab, var(--primary) 10%, transparent)",
+    };
+  }
+
+  const mime = mimeType ?? "";
+
+  if (mime.startsWith("image/")) return fileVisuals.image;
+  if (mime.startsWith("video/")) return fileVisuals.video;
+  if (mime.startsWith("audio/")) return fileVisuals.audio;
+  if (mime.includes("pdf")) return fileVisuals.pdf;
+  if (
+    mime.startsWith("text/") ||
+    mime.includes("typescript") ||
+    mime.includes("json") ||
+    mime.includes("document")
+  )
+    return fileVisuals.text;
+  if (
+    mime.includes("zip") ||
+    mime.includes("archive") ||
+    mime.includes("tar") ||
+    mime.includes("gzip")
+  )
+    return fileVisuals.archive;
+
+  return defaultFileVisual;
+}

--- a/apps/web/app/s/share-view.tsx
+++ b/apps/web/app/s/share-view.tsx
@@ -8,6 +8,8 @@ import {
   formatDateTime,
   getSingleSearchParam,
 } from "@/app/auth-ui";
+import { getItemVisual } from "@/app/item-visuals";
+import { ItemTypeIcon } from "@/app/item-type-icon";
 import { authService } from "@/server/auth/service";
 import { ShareAudioPlayer } from "./share-audio-player";
 import type { FileSummary } from "@/server/files/types";
@@ -375,16 +377,19 @@ export function ShareView({ resolution, token, searchParams }: ShareViewProps) {
             {resolution.listing.childFolders.map((folder) => (
               <article className="folder-row" key={folder.id}>
                 <div className="folder-row-head">
-                  <div className="stack">
-                    <Link
-                      className="folder-link"
-                      href={`/s/${encodeURIComponent(token)}/f/${folder.id}`}
-                    >
-                      {folder.name}
-                    </Link>
-                    <p className="share-file-meta">
-                      Updated {formatDateTime(folder.updatedAt)}
-                    </p>
+                  <div className="item-row-title">
+                    <ItemTypeIcon visual={getItemVisual("folder")} />
+                    <div className="stack">
+                      <Link
+                        className="folder-link"
+                        href={`/s/${encodeURIComponent(token)}/f/${folder.id}`}
+                      >
+                        {folder.name}
+                      </Link>
+                      <p className="share-file-meta">
+                        Updated {formatDateTime(folder.updatedAt)}
+                      </p>
+                    </div>
                   </div>
                   <span className="pill">Folder</span>
                 </div>
@@ -409,12 +414,17 @@ export function ShareView({ resolution, token, searchParams }: ShareViewProps) {
             {resolution.listing.files.map((file) => (
               <article className="folder-row" key={file.id}>
                 <div className="folder-row-head">
-                  <div className="stack">
-                    <h3 className="folder-link">{file.name}</h3>
-                    <p className="share-file-meta">
-                      {file.mimeType} · {formatBytes(file.sizeBytes)} · updated{" "}
-                      {formatDateTime(file.updatedAt)}
-                    </p>
+                  <div className="item-row-title">
+                    <ItemTypeIcon
+                      visual={getItemVisual("file", file.mimeType)}
+                    />
+                    <div className="stack">
+                      <h3 className="folder-link">{file.name}</h3>
+                      <p className="share-file-meta">
+                        {file.mimeType} · {formatBytes(file.sizeBytes)} ·
+                        updated {formatDateTime(file.updatedAt)}
+                      </p>
+                    </div>
                   </div>
                   <div className="workspace-inline-fields retrieval-inline-actions">
                     {file.viewerKind ? (

--- a/apps/web/server/home-dashboard-helpers.test.ts
+++ b/apps/web/server/home-dashboard-helpers.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatHomeChildCount,
+  formatHomeExpiryTime,
+  formatHomeFileSize,
+  formatHomeRelativeTime,
+  getHomeGreeting,
+  getHomeItemVisual,
+} from "@/app/(workspace)/home/home-helpers";
+
+describe("home dashboard helpers", () => {
+  it("returns the expected greeting for the current hour", () => {
+    expect(getHomeGreeting(4)).toBe("Good night");
+    expect(getHomeGreeting(8)).toBe("Good morning");
+    expect(getHomeGreeting(14)).toBe("Good afternoon");
+    expect(getHomeGreeting(18)).toBe("Good evening");
+    expect(getHomeGreeting(22)).toBe("Good night");
+  });
+
+  it("formats relative time labels", () => {
+    const now = new Date("2026-05-16T12:00:00.000Z");
+
+    expect(formatHomeRelativeTime("2026-05-16T12:00:00.000Z", now)).toBe(
+      "Just now",
+    );
+    expect(formatHomeRelativeTime("2026-05-16T11:55:00.000Z", now)).toBe(
+      "5 mins ago",
+    );
+    expect(formatHomeRelativeTime("2026-05-16T10:00:00.000Z", now)).toBe(
+      "2 hours ago",
+    );
+    expect(formatHomeRelativeTime("2026-05-15T11:00:00.000Z", now)).toBe(
+      "Yesterday",
+    );
+    expect(formatHomeRelativeTime("2026-05-12T12:00:00.000Z", now)).toBe(
+      "4 days ago",
+    );
+  });
+
+  it("formats future expiry labels", () => {
+    const now = new Date("2026-05-16T12:00:00.000Z");
+
+    expect(formatHomeExpiryTime("2026-05-16T12:05:00.000Z", now)).toBe(
+      "5 mins",
+    );
+    expect(formatHomeExpiryTime("2026-05-16T14:00:00.000Z", now)).toBe(
+      "2 hours",
+    );
+    expect(formatHomeExpiryTime("2026-05-20T12:00:00.000Z", now)).toBe(
+      "4 days",
+    );
+    expect(formatHomeExpiryTime("2026-05-15T12:00:00.000Z", now)).toBe(
+      "expired",
+    );
+  });
+
+  it("formats file sizes and folder child counts", () => {
+    expect(formatHomeFileSize(4200)).toBe("4 KB");
+    expect(formatHomeFileSize(2_400_000)).toBe("2.3 MB");
+    expect(formatHomeFileSize(4_500_000_000)).toBe("4.2 GB");
+
+    expect(formatHomeChildCount(0)).toBe("Empty");
+    expect(formatHomeChildCount(1)).toBe("1 item");
+    expect(formatHomeChildCount(3)).toBe("3 items");
+  });
+
+  it("maps item type visuals from kind and mime type", () => {
+    expect(getHomeItemVisual("folder").kind).toBe("folder");
+    expect(getHomeItemVisual("file", "image/png").kind).toBe("image");
+    expect(getHomeItemVisual("file", "video/mp4").kind).toBe("video");
+    expect(getHomeItemVisual("file", "audio/wav").kind).toBe("audio");
+    expect(getHomeItemVisual("file", "application/pdf").kind).toBe("pdf");
+    expect(getHomeItemVisual("file", "text/typescript").kind).toBe("text");
+    expect(getHomeItemVisual("file", "application/zip").kind).toBe("archive");
+    expect(getHomeItemVisual("file", "application/octet-stream").kind).toBe(
+      "file",
+    );
+  });
+});


### PR DESCRIPTION
## 🚀 Summary

Adds the new `/home` dashboard content and reuses its file-type visual language across related item lists. The home page now shows real pinned, recent, folder, and shared-link data, and common non-destructive context-menu actions work outside the Files explorer.

## 📊 Impacts and Changes

Users get a richer dashboard home view with real Staaash data, consistent file/folder icons, and right-click actions on home, retrieval, and shared-link rows. The Files explorer keeps its full existing context menu for rename, move, trash, properties, and share dialog actions.

No schema, auth, storage, restore, or share behavior changes.

## 🧪 Testing Checklist

- [ ] `pnpm lint` passed
- [x] `pnpm web:lint` passed
- [ ] `pnpm test` passed
- [x] `pnpm web:test` passed
- [ ] `pnpm build` successful
- [x] `pnpm web:build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [ ] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

Manual browser smoke was limited by browser tooling availability in the coding session. A local screenshot review caught and fixed a context-menu wrapper layout regression on Home.

## 🔗 Linked Issues

None.
