### PR TITLE
fix: patch brace-expansion vulnerability

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   "@hono/node-server": 1.19.13
+  brace-expansion: 5.0.6
   fast-uri: 3.1.2
   hono: 4.12.18
   ip-address: 10.1.1
@@ -2680,10 +2681,10 @@ packages:
       }
     engines: { node: ">=18" }
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     resolution:
       {
-        integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==,
+        integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==,
       }
     engines: { node: 18 || 20 || >=22 }
 
@@ -7239,7 +7240,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -8113,7 +8114,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - "packages/*"
 overrides:
   "@hono/node-server": 1.19.13
+  brace-expansion: 5.0.6
   fast-uri: 3.1.2
   hono: 4.12.18
   ip-address: 10.1.1


### PR DESCRIPTION
## 🚀 Summary

Patches the Dependabot security alert for `brace-expansion` by pinning the transitive dependency to `5.0.6` through the workspace overrides.

## 📊 Impacts and Changes

Maintainers get a clean production audit for the reported `brace-expansion` denial-of-service advisory. There is no app behavior, schema, auth, storage, or restore change.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

Additional validation:

- [x] `pnpm install --frozen-lockfile` passed
- [x] `pnpm audit --prod --json` reports 0 vulnerabilities
- [x] `pnpm format:check` passed
- [x] `pnpm typecheck` passed

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

Dependabot alert #1 should close after this merges into `main`.

## 🔗 Linked Issues

Dependabot alert #1