### PR TITLE
Redesign Recent page

### DIFF
--- a/apps/web/app/(workspace)/recent/page.tsx
+++ b/apps/web/app/(workspace)/recent/page.tsx
@@ -1,9 +1,9 @@
-import { FlashMessage, getSingleSearchParam } from "@/app/auth-ui";
+import { getSingleSearchParam } from "@/app/auth-ui";
 import { requireSignedInPageSession } from "@/server/auth/guards";
 import { retrievalService } from "@/server/retrieval/service";
-import type { RetrievalItem } from "@/server/retrieval/types";
 
-import { RetrievalItemList } from "../retrieval-item-list";
+import { toRecentClientItem } from "./recent-helpers";
+import { RecentView } from "./recent-view";
 
 export const dynamic = "force-dynamic";
 
@@ -11,87 +11,23 @@ type RecentPageProps = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
-function getDateLabel(date: Date, now: Date): string {
-  const diffMs = now.getTime() - date.getTime();
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-  if (diffDays === 0) return "Today";
-  if (diffDays === 1) return "Yesterday";
-  const dayOfWeek = now.getDay();
-  const daysToMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
-  const startOfWeek = new Date(now);
-  startOfWeek.setHours(0, 0, 0, 0);
-  startOfWeek.setDate(startOfWeek.getDate() - daysToMonday);
-  if (date >= startOfWeek) return "This week";
-  if (diffDays < 30) return "This month";
-  return "Older";
-}
-
-function groupByDate(
-  items: RetrievalItem[],
-  now: Date,
-): { label: string; items: RetrievalItem[] }[] {
-  const order = ["Today", "Yesterday", "This week", "This month", "Older"];
-  const map = new Map<string, RetrievalItem[]>();
-  for (const item of items) {
-    const label = getDateLabel(new Date(item.updatedAt), now);
-    if (!map.has(label)) map.set(label, []);
-    map.get(label)!.push(item);
-  }
-  return order.flatMap((label) => {
-    const group = map.get(label);
-    return group ? [{ label, items: group }] : [];
-  });
-}
-
 export default async function RecentPage({ searchParams }: RecentPageProps) {
   const [resolvedSearchParams, session] = await Promise.all([
     searchParams,
     requireSignedInPageSession("/?next=/recent"),
   ]);
-  const allItems = await retrievalService.listRecent({
+  const allItems = await retrievalService.listRecentlyAdded({
     actorUserId: session.user.id,
     actorRole: session.user.role,
   });
   const error = getSingleSearchParam(resolvedSearchParams, "error");
   const success = getSingleSearchParam(resolvedSearchParams, "success");
-  const groups = groupByDate(allItems, new Date());
 
   return (
-    <div className="workspace-page">
-      <div className="stack">
-        <div className="split">
-          <h1>Recent</h1>
-          {allItems.length > 0 && (
-            <span className="section-count">{allItems.length}</span>
-          )}
-        </div>
-
-        {error ? <FlashMessage>{error}</FlashMessage> : null}
-        {success ? <FlashMessage tone="success">{success}</FlashMessage> : null}
-
-        {groups.length === 0 ? (
-          <RetrievalItemList
-            currentPath="/recent"
-            emptyDescription="Open folders, download files, or make changes to build your recents list."
-            emptyTitle="Nothing recent yet"
-            items={[]}
-          />
-        ) : (
-          <div className="recent-groups">
-            {groups.map((group) => (
-              <div className="recent-group" key={group.label}>
-                <p className="recent-group-label">{group.label}</p>
-                <RetrievalItemList
-                  currentPath="/recent"
-                  emptyDescription=""
-                  emptyTitle=""
-                  items={group.items}
-                />
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
+    <RecentView
+      error={error}
+      items={allItems.map(toRecentClientItem)}
+      success={success}
+    />
   );
 }

--- a/apps/web/app/(workspace)/recent/recent-helpers.ts
+++ b/apps/web/app/(workspace)/recent/recent-helpers.ts
@@ -1,0 +1,232 @@
+import type { ItemVisualKind } from "@/app/item-visuals";
+import type { RetrievalItem } from "@/server/retrieval/types";
+
+export type RecentClientItem = {
+  folderId?: string | null;
+  href: string;
+  id: string;
+  isFavorite: boolean;
+  kind: RetrievalItem["kind"];
+  locationLabel: string;
+  mimeType?: string;
+  name: string;
+  parentId?: string | null;
+  sizeBytes?: number;
+  uploadedAt: string;
+};
+
+export type RecentFilterType =
+  | "all"
+  | "archive"
+  | "audio"
+  | "folder"
+  | "image"
+  | "pdf"
+  | "text"
+  | "video";
+
+export type RecentSortKey = "name" | "path" | "size" | "uploadedAt";
+export type RecentSortDirection = "asc" | "desc";
+
+export const RECENT_GROUP_ORDER = [
+  "Today",
+  "Yesterday",
+  "This week",
+  "This month",
+  "Older",
+] as const;
+
+export type RecentGroupLabel = (typeof RECENT_GROUP_ORDER)[number];
+
+export type RecentGroup<T> = {
+  label: RecentGroupLabel;
+  items: T[];
+};
+
+function splitPathLabel(pathLabel: string): string[] {
+  return pathLabel
+    .split("/")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+export function getRecentLocationLabel(item: RetrievalItem): string {
+  const parts = splitPathLabel(item.pathLabel);
+  const pathWithoutSelf =
+    parts.at(-1) === item.name ? parts.slice(0, -1) : parts;
+  const withoutRoot =
+    pathWithoutSelf.length > 1 ? pathWithoutSelf.slice(1) : [];
+  return withoutRoot.length > 0 ? withoutRoot.join(" / ") : "/";
+}
+
+export function toRecentClientItem(item: RetrievalItem): RecentClientItem {
+  return {
+    folderId: item.kind === "file" ? item.folderId : undefined,
+    href: item.href,
+    id: item.id,
+    isFavorite: item.isFavorite,
+    kind: item.kind,
+    locationLabel: getRecentLocationLabel(item),
+    mimeType: item.kind === "file" ? item.mimeType : undefined,
+    name: item.name,
+    parentId: item.kind === "folder" ? item.parentId : undefined,
+    sizeBytes: item.kind === "file" ? item.sizeBytes : undefined,
+    uploadedAt: item.updatedAt.toISOString(),
+  };
+}
+
+export function getRecentType(
+  item: Pick<RecentClientItem, "kind" | "mimeType">,
+): RecentFilterType {
+  if (item.kind === "folder") return "folder";
+
+  const mime = item.mimeType ?? "";
+  if (mime.startsWith("image/")) return "image";
+  if (mime.startsWith("video/")) return "video";
+  if (mime.startsWith("audio/")) return "audio";
+  if (mime.includes("pdf")) return "pdf";
+  if (
+    mime.startsWith("text/") ||
+    mime.includes("typescript") ||
+    mime.includes("json") ||
+    mime.includes("document")
+  ) {
+    return "text";
+  }
+  if (
+    mime.includes("zip") ||
+    mime.includes("archive") ||
+    mime.includes("tar") ||
+    mime.includes("gzip")
+  ) {
+    return "archive";
+  }
+
+  return "all";
+}
+
+export function getRecentVisualKind(
+  item: Pick<RecentClientItem, "kind" | "mimeType">,
+): ItemVisualKind {
+  const type = getRecentType(item);
+  return type === "all" ? "file" : type;
+}
+
+export function filterRecentItems(
+  items: RecentClientItem[],
+  filterType: RecentFilterType,
+): RecentClientItem[] {
+  if (filterType === "all") return items;
+  return items.filter((item) => getRecentType(item) === filterType);
+}
+
+export function formatRecentFileSize(bytes?: number): string {
+  if (bytes == null) return "-";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.max(1, Math.round(bytes / 1024))} KB`;
+  if (bytes < 1024 * 1024 * 1024)
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+export function formatRecentRelativeTime(
+  value: Date | string,
+  now = new Date(),
+): string {
+  const date = value instanceof Date ? value : new Date(value);
+  const diffMs = Math.max(0, now.getTime() - date.getTime());
+  const diffMinutes = Math.floor(diffMs / 60000);
+
+  if (diffMinutes < 1) return "Just now";
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays < 7) return `${diffDays} days ago`;
+
+  return date.toLocaleDateString("en", {
+    day: "numeric",
+    month: "short",
+  });
+}
+
+export function getRecentDateGroup(
+  value: Date | string,
+  now = new Date(),
+): RecentGroupLabel {
+  const date = value instanceof Date ? value : new Date(value);
+  const diffMs = Math.max(0, now.getTime() - date.getTime());
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Yesterday";
+
+  const dayOfWeek = now.getDay();
+  const daysToMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+  const startOfWeek = new Date(now);
+  startOfWeek.setHours(0, 0, 0, 0);
+  startOfWeek.setDate(startOfWeek.getDate() - daysToMonday);
+
+  if (date >= startOfWeek) return "This week";
+  if (diffDays < 30) return "This month";
+  return "Older";
+}
+
+function compareStrings(left: string, right: string): number {
+  return left.localeCompare(right, undefined, {
+    numeric: true,
+    sensitivity: "base",
+  });
+}
+
+export function sortRecentItems(
+  items: RecentClientItem[],
+  sortKey: RecentSortKey,
+  sortDirection: RecentSortDirection,
+): RecentClientItem[] {
+  const direction = sortDirection === "asc" ? 1 : -1;
+
+  return [...items].sort((left, right) => {
+    let delta = 0;
+
+    if (sortKey === "name") {
+      delta = compareStrings(left.name, right.name);
+    } else if (sortKey === "path") {
+      delta = compareStrings(left.locationLabel, right.locationLabel);
+    } else if (sortKey === "size") {
+      delta = (left.sizeBytes ?? -1) - (right.sizeBytes ?? -1);
+    } else {
+      delta =
+        new Date(left.uploadedAt).getTime() -
+        new Date(right.uploadedAt).getTime();
+    }
+
+    if (delta === 0) {
+      delta =
+        compareStrings(left.name, right.name) ||
+        left.id.localeCompare(right.id);
+    }
+
+    return delta * direction;
+  });
+}
+
+export function groupRecentItems<T extends { uploadedAt: string }>(
+  items: T[],
+  now = new Date(),
+): RecentGroup<T>[] {
+  const map = new Map<RecentGroupLabel, T[]>();
+
+  for (const item of items) {
+    const label = getRecentDateGroup(item.uploadedAt, now);
+    map.set(label, [...(map.get(label) ?? []), item]);
+  }
+
+  return RECENT_GROUP_ORDER.flatMap((label) => {
+    const group = map.get(label);
+    return group ? [{ label, items: group }] : [];
+  });
+}

--- a/apps/web/app/(workspace)/recent/recent-view.tsx
+++ b/apps/web/app/(workspace)/recent/recent-view.tsx
@@ -1,0 +1,608 @@
+"use client";
+
+import {
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+  type KeyboardEvent,
+} from "react";
+import { useRouter } from "next/navigation";
+import {
+  ArrowDown,
+  ArrowUp,
+  Download,
+  ExternalLink,
+  Grid2X2,
+  List,
+  Trash2,
+  X,
+} from "lucide-react";
+
+import { FlashMessage } from "@/app/auth-ui";
+import { getItemVisual } from "@/app/item-visuals";
+import { ItemTypeIcon } from "@/app/item-type-icon";
+import { startValidatedDownload } from "@/lib/transfers/download";
+
+import { useTransferContext } from "../transfer-context";
+import {
+  filterRecentItems,
+  formatRecentFileSize,
+  formatRecentRelativeTime,
+  groupRecentItems,
+  sortRecentItems,
+  type RecentClientItem,
+  type RecentFilterType,
+  type RecentSortDirection,
+  type RecentSortKey,
+} from "./recent-helpers";
+
+type RecentViewMode = "grid" | "list";
+
+type RecentViewProps = {
+  error?: string | null;
+  items: RecentClientItem[];
+  success?: string | null;
+};
+
+const FILTERS: { id: RecentFilterType; label: string }[] = [
+  { id: "all", label: "All" },
+  { id: "folder", label: "Folders" },
+  { id: "image", label: "Images" },
+  { id: "pdf", label: "PDFs" },
+  { id: "video", label: "Videos" },
+  { id: "audio", label: "Audio" },
+  { id: "text", label: "Docs" },
+  { id: "archive", label: "Archives" },
+];
+
+function getOpenHref(item: RecentClientItem): string {
+  if (item.kind === "folder") return item.href;
+  return item.href.startsWith("/files/view/")
+    ? item.href
+    : `/api/files/files/${item.id}/download`;
+}
+
+function getDownloadHref(item: RecentClientItem): string {
+  return `/api/files/files/${item.id}/download`;
+}
+
+function SortIcon({
+  active,
+  direction,
+}: {
+  active: boolean;
+  direction: RecentSortDirection;
+}) {
+  if (!active) return <ArrowDown size={11} aria-hidden />;
+  return direction === "asc" ? (
+    <ArrowUp size={11} aria-hidden />
+  ) : (
+    <ArrowDown size={11} aria-hidden />
+  );
+}
+
+function ItemIcon({
+  item,
+  size = 14,
+}: {
+  item: RecentClientItem;
+  size?: number;
+}) {
+  return (
+    <ItemTypeIcon
+      size={size}
+      visual={getItemVisual(
+        item.kind,
+        item.kind === "file" ? item.mimeType : null,
+      )}
+    />
+  );
+}
+
+export function RecentView({ error, items, success }: RecentViewProps) {
+  const router = useRouter();
+  const [, startTransition] = useTransition();
+  const { handleDownload } = useTransferContext();
+  const [viewMode, setViewMode] = useState<RecentViewMode>("list");
+  const [filterType, setFilterType] = useState<RecentFilterType>("all");
+  const [sortKey, setSortKey] = useState<RecentSortKey>("uploadedAt");
+  const [sortDirection, setSortDirection] =
+    useState<RecentSortDirection>("desc");
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [trashedIds, setTrashedIds] = useState<Set<string>>(new Set());
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const visibleItems = useMemo(() => {
+    const activeItems = items.filter((item) => !trashedIds.has(item.id));
+    return sortRecentItems(
+      filterRecentItems(activeItems, filterType),
+      sortKey,
+      sortDirection,
+    );
+  }, [filterType, items, sortDirection, sortKey, trashedIds]);
+
+  const groups = useMemo(() => groupRecentItems(visibleItems), [visibleItems]);
+  const visibleIdSet = useMemo(
+    () => new Set(visibleItems.map((item) => item.id)),
+    [visibleItems],
+  );
+  const allVisibleSelected =
+    visibleItems.length > 0 &&
+    visibleItems.every((item) => selectedIds.has(item.id));
+  const selectedItems = visibleItems.filter((item) => selectedIds.has(item.id));
+
+  useEffect(() => {
+    setSelectedIds((current) => {
+      const next = new Set([...current].filter((id) => visibleIdSet.has(id)));
+      return next.size === current.size ? current : next;
+    });
+  }, [visibleIdSet]);
+
+  useEffect(() => {
+    setSelectedIds(new Set());
+  }, [filterType, viewMode]);
+
+  useEffect(() => {
+    if (!actionError) return;
+    const timer = window.setTimeout(() => setActionError(null), 4000);
+    return () => window.clearTimeout(timer);
+  }, [actionError]);
+
+  const toggleSort = (key: RecentSortKey) => {
+    if (sortKey === key) {
+      setSortDirection((current) => (current === "asc" ? "desc" : "asc"));
+      return;
+    }
+
+    setSortKey(key);
+    setSortDirection(key === "uploadedAt" || key === "size" ? "desc" : "asc");
+  };
+
+  const toggleItem = (id: string) => {
+    setSelectedIds((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const selectAllVisible = () => {
+    setSelectedIds((current) => {
+      if (allVisibleSelected) return new Set();
+      return new Set([...current, ...visibleItems.map((item) => item.id)]);
+    });
+  };
+
+  const openItem = (item: RecentClientItem) => {
+    const href = getOpenHref(item);
+    if (href.startsWith("/files/")) {
+      router.push(href);
+      return;
+    }
+    window.location.href = href;
+  };
+
+  const downloadItem = async (item: RecentClientItem) => {
+    if (item.kind === "folder") {
+      await handleDownload([item.id]);
+      return;
+    }
+
+    try {
+      await startValidatedDownload(
+        getDownloadHref(item),
+        "File download failed",
+      );
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : "File download failed",
+      );
+    }
+  };
+
+  const moveToTrash = async (item: RecentClientItem) => {
+    const endpoint =
+      item.kind === "folder"
+        ? `/api/files/folders/${item.id}/trash`
+        : `/api/files/files/${item.id}/trash`;
+    const res = await fetch(endpoint, {
+      method: "POST",
+      headers: { Accept: "application/json" },
+      body: new URLSearchParams({ redirectTo: "/recent" }),
+    });
+
+    if (res.ok || res.status === 404) return;
+    const data = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(data.error ?? `Trash failed (${res.status})`);
+  };
+
+  const trashItems = async (targets: RecentClientItem[]) => {
+    if (targets.length === 0) return;
+
+    setSelectedIds(new Set());
+    setTrashedIds((current) => {
+      const next = new Set(current);
+      for (const item of targets) next.add(item.id);
+      return next;
+    });
+
+    const results = await Promise.allSettled(
+      targets.map((item) => moveToTrash(item)),
+    );
+    const failedIds = new Set<string>();
+    let movedAny = false;
+
+    results.forEach((result, index) => {
+      if (result.status === "fulfilled") movedAny = true;
+      else failedIds.add(targets[index].id);
+    });
+
+    if (failedIds.size > 0) {
+      setTrashedIds((current) => {
+        const next = new Set(current);
+        for (const id of failedIds) next.delete(id);
+        return next;
+      });
+      setActionError("Some items could not be moved to trash.");
+    }
+
+    if (movedAny) startTransition(() => router.refresh());
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      setSelectedIds(new Set());
+      return;
+    }
+
+    if (
+      (event.key === "Delete" || event.key === "Backspace") &&
+      selectedItems.length > 0
+    ) {
+      event.preventDefault();
+      void trashItems(selectedItems);
+      return;
+    }
+
+    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "a") {
+      event.preventDefault();
+      selectAllVisible();
+      return;
+    }
+
+    if (event.key === "Enter" && selectedItems.length === 1) {
+      event.preventDefault();
+      openItem(selectedItems[0]);
+    }
+  };
+
+  const renderSortButton = (
+    key: RecentSortKey,
+    label: string,
+    align = "left",
+  ) => (
+    <button
+      className={`recent-col-head-cell${sortKey === key ? " is-sorted" : ""}`}
+      data-column={key}
+      data-align={align}
+      type="button"
+      onClick={() => toggleSort(key)}
+    >
+      {label}
+      <SortIcon active={sortKey === key} direction={sortDirection} />
+    </button>
+  );
+
+  const renderItemActions = (item: RecentClientItem) => (
+    <>
+      <button
+        aria-label={`Open ${item.name}`}
+        className="recent-action-btn"
+        type="button"
+        onClick={(event) => {
+          event.stopPropagation();
+          openItem(item);
+        }}
+      >
+        <ExternalLink size={13} aria-hidden />
+      </button>
+      <button
+        aria-label={`Download ${item.name}`}
+        className="recent-action-btn"
+        type="button"
+        onClick={(event) => {
+          event.stopPropagation();
+          void downloadItem(item);
+        }}
+      >
+        <Download size={13} aria-hidden />
+      </button>
+      <button
+        aria-label={`Move ${item.name} to trash`}
+        className="recent-action-btn recent-action-btn-danger"
+        type="button"
+        onClick={(event) => {
+          event.stopPropagation();
+          void trashItems([item]);
+        }}
+      >
+        <Trash2 size={13} aria-hidden />
+      </button>
+    </>
+  );
+
+  return (
+    <div
+      className="workspace-page recent-page"
+      tabIndex={-1}
+      onKeyDown={handleKeyDown}
+    >
+      <div className="recent-header">
+        <h1>Recent</h1>
+        {items.length > 0 ? (
+          <span className="section-count">{items.length}</span>
+        ) : null}
+      </div>
+
+      {error ? <FlashMessage>{error}</FlashMessage> : null}
+      {success ? <FlashMessage tone="success">{success}</FlashMessage> : null}
+      {actionError ? <FlashMessage>{actionError}</FlashMessage> : null}
+
+      <div className="recent-toolbar" aria-label="Recent display controls">
+        <label className="recent-filter-label">
+          <span>Type</span>
+          <select
+            className="recent-type-select"
+            value={filterType}
+            onChange={(event) =>
+              setFilterType(event.target.value as RecentFilterType)
+            }
+          >
+            {FILTERS.map((filter) => (
+              <option key={filter.id} value={filter.id}>
+                {filter.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="recent-view-toggle" aria-label="View mode">
+          <button
+            aria-label="List view"
+            className={viewMode === "list" ? "is-active" : ""}
+            type="button"
+            onClick={() => setViewMode("list")}
+          >
+            <List size={14} aria-hidden />
+          </button>
+          <button
+            aria-label="Grid view"
+            className={viewMode === "grid" ? "is-active" : ""}
+            type="button"
+            onClick={() => setViewMode("grid")}
+          >
+            <Grid2X2 size={14} aria-hidden />
+          </button>
+        </div>
+      </div>
+
+      {visibleItems.length === 0 ? (
+        <div className="recent-empty-state">
+          <span className="recent-empty-icon">
+            <ItemTypeIcon size={22} visual={getItemVisual("folder", null)} />
+          </span>
+          <p>No recent uploads</p>
+          <span>Files and folders you add will appear here.</span>
+        </div>
+      ) : viewMode === "list" ? (
+        <div
+          className="recent-table-wrap"
+          onClick={() => setSelectedIds(new Set())}
+        >
+          <div
+            className="recent-col-head"
+            role="row"
+            aria-label="Recent columns"
+          >
+            <button
+              aria-label={allVisibleSelected ? "Clear selection" : "Select all"}
+              aria-pressed={allVisibleSelected}
+              className={`recent-select-box${allVisibleSelected ? " is-checked" : ""}`}
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                selectAllVisible();
+              }}
+            />
+            <span aria-hidden />
+            {renderSortButton("name", "Name")}
+            {renderSortButton("path", "Location")}
+            {renderSortButton("size", "Size", "right")}
+            {renderSortButton("uploadedAt", "Uploaded", "right")}
+          </div>
+
+          {groups.map((group) => (
+            <section className="recent-group-section" key={group.label}>
+              <div className="recent-group-header">
+                <span>{group.label}</span>
+                <small>{group.items.length}</small>
+              </div>
+
+              {group.items.map((item) => {
+                const selected = selectedIds.has(item.id);
+                return (
+                  <article
+                    className={`recent-row${selected ? " is-selected" : ""}`}
+                    key={`${item.kind}-${item.id}`}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      toggleItem(item.id);
+                    }}
+                    onDoubleClick={(event) => {
+                      event.stopPropagation();
+                      openItem(item);
+                    }}
+                  >
+                    <button
+                      aria-label={
+                        selected
+                          ? `Deselect ${item.name}`
+                          : `Select ${item.name}`
+                      }
+                      aria-pressed={selected}
+                      className={`recent-select-box${selected ? " is-checked" : ""}`}
+                      type="button"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        toggleItem(item.id);
+                      }}
+                    />
+                    <span className="recent-row-thumb">
+                      <ItemIcon item={item} />
+                    </span>
+                    <span className="recent-row-name" title={item.name}>
+                      {item.name}
+                      {item.isFavorite ? (
+                        <span
+                          aria-label="Favorited"
+                          className="recent-favorite-dot"
+                        />
+                      ) : null}
+                    </span>
+                    <span
+                      className="recent-row-location"
+                      title={item.locationLabel}
+                    >
+                      {item.locationLabel}
+                    </span>
+                    <span className="recent-row-size">
+                      {formatRecentFileSize(item.sizeBytes)}
+                    </span>
+                    <span className="recent-row-time">
+                      {formatRecentRelativeTime(item.uploadedAt)}
+                    </span>
+                    <span className="recent-row-actions">
+                      {renderItemActions(item)}
+                    </span>
+                  </article>
+                );
+              })}
+            </section>
+          ))}
+        </div>
+      ) : (
+        <div
+          className="recent-grid-wrap"
+          onClick={() => setSelectedIds(new Set())}
+        >
+          {groups.map((group) => (
+            <section className="recent-grid-group" key={group.label}>
+              <div className="recent-grid-group-header">
+                <span>{group.label}</span>
+                <small>{group.items.length}</small>
+              </div>
+
+              <div className="recent-grid-cards">
+                {group.items.map((item) => {
+                  const selected = selectedIds.has(item.id);
+                  const visual = getItemVisual(
+                    item.kind,
+                    item.kind === "file" ? item.mimeType : null,
+                  );
+                  return (
+                    <article
+                      className={`recent-grid-card${selected ? " is-selected" : ""}`}
+                      key={`${item.kind}-${item.id}`}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        toggleItem(item.id);
+                      }}
+                      onDoubleClick={(event) => {
+                        event.stopPropagation();
+                        openItem(item);
+                      }}
+                    >
+                      <button
+                        aria-label={
+                          selected
+                            ? `Deselect ${item.name}`
+                            : `Select ${item.name}`
+                        }
+                        aria-pressed={selected}
+                        className={`recent-select-box recent-grid-card-check${
+                          selected ? " is-checked" : ""
+                        }`}
+                        type="button"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          toggleItem(item.id);
+                        }}
+                      />
+                      <div
+                        className="recent-grid-card-preview"
+                        style={{ background: visual.background }}
+                      >
+                        <ItemIcon item={item} size={30} />
+                      </div>
+                      <div className="recent-grid-card-body">
+                        <span
+                          className="recent-grid-card-name"
+                          title={item.name}
+                        >
+                          {item.name}
+                        </span>
+                        <span className="recent-grid-card-meta">
+                          <span>
+                            {formatRecentRelativeTime(item.uploadedAt)}
+                          </span>
+                          <span>{formatRecentFileSize(item.sizeBytes)}</span>
+                        </span>
+                      </div>
+                      <span className="recent-grid-card-actions">
+                        {renderItemActions(item)}
+                      </span>
+                    </article>
+                  );
+                })}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+
+      {selectedItems.length > 0 ? (
+        <div className="recent-float-bar" role="status">
+          <span>{selectedItems.length} selected</span>
+          <span className="recent-float-divider" aria-hidden />
+          <button
+            type="button"
+            onClick={() =>
+              void handleDownload(selectedItems.map((item) => item.id))
+            }
+          >
+            <Download size={13} aria-hidden />
+            Download
+          </button>
+          <button
+            className="recent-float-danger"
+            type="button"
+            onClick={() => void trashItems(selectedItems)}
+          >
+            <Trash2 size={13} aria-hidden />
+            Move to trash
+          </button>
+          <span className="recent-float-divider" aria-hidden />
+          <button
+            aria-label="Clear selection"
+            type="button"
+            onClick={() => setSelectedIds(new Set())}
+          >
+            <X size={13} aria-hidden />
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1996,6 +1996,550 @@ h3 {
     color-mix(in oklab, var(--foreground) 8%, transparent);
 }
 
+/* ---- Recent dashboard redesign ---- */
+
+.recent-page {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  gap: 12px;
+}
+
+.recent-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.recent-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.recent-filter-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 30px;
+  padding: 0 0 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  color: color-mix(in oklab, var(--foreground) 76%, transparent);
+  background: transparent;
+}
+
+.recent-filter-label span {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: color-mix(in oklab, var(--foreground) 45%, transparent);
+}
+
+.recent-type-select {
+  min-height: 28px;
+  padding: 0 28px 0 0;
+  border: 0;
+  color: var(--foreground);
+  background: transparent;
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 600;
+  outline: none;
+}
+
+.recent-view-toggle {
+  display: inline-flex;
+  margin-left: auto;
+  overflow: hidden;
+  border: 1px solid color-mix(in oklab, var(--foreground) 10%, transparent);
+  border-radius: 7px;
+  background: color-mix(in oklab, var(--foreground) 4%, transparent);
+}
+
+.recent-view-toggle button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  min-height: 30px;
+  border: 0;
+  border-radius: 0;
+  color: var(--muted-foreground);
+  background: transparent;
+}
+
+.recent-view-toggle button + button {
+  border-left: 1px solid color-mix(in oklab, var(--foreground) 10%, transparent);
+}
+
+.recent-view-toggle button:hover,
+.recent-view-toggle button.is-active {
+  color: var(--foreground);
+  background: color-mix(in oklab, var(--foreground) 10%, transparent);
+}
+
+.recent-table-wrap {
+  display: grid;
+  min-height: 0;
+}
+
+.recent-col-head,
+.recent-row {
+  display: grid;
+  grid-template-columns:
+    32px 32px minmax(180px, 1fr) minmax(140px, 180px) minmax(70px, 80px)
+    minmax(86px, 110px);
+  align-items: center;
+}
+
+.recent-col-head {
+  position: sticky;
+  top: -24px;
+  z-index: 2;
+  min-height: 34px;
+  padding: 0 8px;
+  border-bottom: 1px solid var(--border);
+  background: var(--background);
+}
+
+.recent-col-head-cell {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  padding: 0 4px;
+  border: 0;
+  color: color-mix(in oklab, var(--muted-foreground) 65%, transparent);
+  background: transparent;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.recent-col-head-cell[data-align="right"] {
+  justify-content: flex-end;
+}
+
+.recent-col-head-cell:hover,
+.recent-col-head-cell.is-sorted {
+  color: var(--foreground);
+}
+
+.recent-group-section,
+.recent-grid-group {
+  display: grid;
+}
+
+.recent-group-header,
+.recent-grid-group-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 18px 12px 5px;
+}
+
+.recent-group-section:first-of-type .recent-group-header,
+.recent-grid-group:first-of-type .recent-grid-group-header {
+  padding-top: 8px;
+}
+
+.recent-group-header span,
+.recent-grid-group-header span {
+  color: color-mix(in oklab, var(--muted-foreground) 56%, transparent);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.recent-group-header small,
+.recent-grid-group-header small {
+  color: color-mix(in oklab, var(--muted-foreground) 44%, transparent);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.recent-row {
+  position: relative;
+  min-height: 42px;
+  padding: 0 8px;
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--foreground) 5%, transparent);
+  cursor: default;
+  transition: background 100ms ease;
+}
+
+.recent-row:hover,
+.recent-row:focus-within {
+  background: color-mix(in oklab, var(--foreground) 4%, transparent);
+}
+
+.recent-row.is-selected {
+  background: color-mix(in oklab, var(--primary) 8%, transparent);
+}
+
+.recent-select-box {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  justify-self: center;
+  width: 15px;
+  height: 15px;
+  border: 1.5px solid color-mix(in oklab, var(--foreground) 28%, transparent);
+  border-radius: 4px;
+  background: transparent;
+}
+
+.recent-select-box.is-checked {
+  border-color: var(--primary);
+  background: var(--primary);
+}
+
+.recent-select-box.is-checked::after {
+  width: 7px;
+  height: 4px;
+  border-bottom: 1.6px solid var(--primary-foreground);
+  border-left: 1.6px solid var(--primary-foreground);
+  content: "";
+  transform: translateY(-1px) rotate(-45deg);
+}
+
+.recent-row-thumb {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.recent-row-name {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+  padding: 0 8px 0 2px;
+  color: var(--foreground);
+  font-size: 13.5px;
+  font-weight: 550;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.recent-row-location,
+.recent-row-size,
+.recent-row-time {
+  min-width: 0;
+  overflow: hidden;
+  color: color-mix(in oklab, var(--muted-foreground) 78%, transparent);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.recent-row-location {
+  padding: 0 8px;
+}
+
+.recent-row-size,
+.recent-row-time {
+  padding: 0 4px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.recent-row-size {
+  font-family: "Cascadia Code", "JetBrains Mono", monospace;
+}
+
+.recent-favorite-dot {
+  flex: 0 0 auto;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--primary);
+  opacity: 0.75;
+}
+
+.recent-row-actions,
+.recent-grid-card-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: color-mix(in oklab, var(--card) 94%, var(--foreground) 6%);
+  box-shadow: 0 1px 4px color-mix(in oklab, var(--foreground) 8%, transparent);
+}
+
+.recent-row-actions {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-50%);
+  transition: opacity 100ms ease;
+}
+
+.recent-row:hover .recent-row-actions,
+.recent-row:focus-within .recent-row-actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.recent-action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: 0;
+  border-radius: 5px;
+  color: var(--muted-foreground);
+  background: transparent;
+}
+
+.recent-action-btn:hover {
+  color: var(--foreground);
+  background: color-mix(in oklab, var(--foreground) 8%, transparent);
+}
+
+.recent-action-btn-danger:hover {
+  color: var(--destructive);
+  background: color-mix(in oklab, var(--destructive) 10%, transparent);
+}
+
+.recent-grid-wrap {
+  display: grid;
+  gap: 4px;
+  padding-bottom: 56px;
+}
+
+.recent-grid-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 9px;
+}
+
+.recent-grid-card {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: color-mix(in oklab, var(--foreground) 3%, transparent);
+  cursor: default;
+  transition:
+    background 100ms ease,
+    border-color 100ms ease;
+}
+
+.recent-grid-card:hover {
+  border-color: color-mix(in oklab, var(--foreground) 14%, transparent);
+  background: color-mix(in oklab, var(--foreground) 5%, transparent);
+}
+
+.recent-grid-card.is-selected {
+  border-color: color-mix(in oklab, var(--primary) 32%, transparent);
+  background: color-mix(in oklab, var(--primary) 8%, transparent);
+}
+
+.recent-grid-card-preview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 92px;
+  border-bottom: 1px solid var(--border);
+}
+
+.recent-grid-card-preview .item-type-icon {
+  width: 48px;
+  height: 48px;
+  background: transparent !important;
+}
+
+.recent-grid-card-body {
+  display: grid;
+  gap: 4px;
+  padding: 8px 10px 9px;
+}
+
+.recent-grid-card-name {
+  overflow: hidden;
+  color: var(--foreground);
+  font-size: 12.5px;
+  font-weight: 550;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.recent-grid-card-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  color: color-mix(in oklab, var(--muted-foreground) 66%, transparent);
+  font-size: 11px;
+}
+
+.recent-grid-card-check {
+  position: absolute;
+  top: 7px;
+  left: 7px;
+  z-index: 1;
+  opacity: 0;
+  transition: opacity 100ms ease;
+}
+
+.recent-grid-card:hover .recent-grid-card-check,
+.recent-grid-card.is-selected .recent-grid-card-check,
+.recent-grid-card:focus-within .recent-grid-card-check {
+  opacity: 1;
+}
+
+.recent-grid-card-actions {
+  position: absolute;
+  top: 7px;
+  right: 7px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 100ms ease;
+}
+
+.recent-grid-card:hover .recent-grid-card-actions,
+.recent-grid-card:focus-within .recent-grid-card-actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.recent-empty-state {
+  display: flex;
+  flex: 1;
+  min-height: 320px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  color: var(--muted-foreground);
+  text-align: center;
+}
+
+.recent-empty-state p {
+  color: var(--foreground);
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.recent-empty-state span {
+  font-size: 12px;
+}
+
+.recent-empty-icon {
+  opacity: 0.45;
+}
+
+.recent-float-bar {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 10px 8px 10px 16px;
+  border-radius: 12px;
+  color: var(--background);
+  background: var(--foreground);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.22);
+  font-size: 13px;
+  font-weight: 650;
+  transform: translateX(-50%);
+}
+
+.recent-float-bar button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 32px;
+  padding: 0 12px;
+  border: 0;
+  border-radius: 8px;
+  color: inherit;
+  background: rgba(255, 255, 255, 0.12);
+  font: inherit;
+  font-size: 12.5px;
+}
+
+.recent-float-bar button:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.recent-float-danger {
+  color: var(--background);
+}
+
+.recent-float-divider {
+  width: 1px;
+  height: 20px;
+  margin: 0 2px;
+  background: rgba(255, 255, 255, 0.18);
+}
+
+@media (max-width: 860px) {
+  .recent-col-head,
+  .recent-row {
+    grid-template-columns: 32px 32px minmax(140px, 1fr) minmax(78px, 96px);
+  }
+
+  .recent-col-head-cell[data-column="path"],
+  .recent-col-head-cell[data-column="size"],
+  .recent-row-location,
+  .recent-row-size {
+    display: none;
+  }
+
+  .recent-row-actions {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .recent-float-bar {
+    right: 14px;
+    bottom: 14px;
+    left: 14px;
+    justify-content: center;
+    transform: none;
+  }
+}
+
+@media (max-width: 560px) {
+  .recent-toolbar,
+  .recent-header {
+    align-items: stretch;
+  }
+
+  .recent-toolbar {
+    flex-wrap: wrap;
+  }
+
+  .recent-filter-label {
+    flex: 1 1 160px;
+  }
+
+  .recent-type-select {
+    flex: 1;
+  }
+
+  .recent-float-bar {
+    flex-wrap: wrap;
+  }
+}
+
 /* ---- Retrieval list (Recent / Favorites / Search) ---- */
 
 .retrieval-list {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -79,7 +79,7 @@ export default async function RootLayout({
       lang="en"
       className={`${switzer.variable} ${cabinetGrotesk.variable} font-sans${themeClass ? ` ${themeClass}` : ""}`}
     >
-      <body>
+      <body suppressHydrationWarning>
         <TransferRoot>{children}</TransferRoot>
       </body>
     </html>

--- a/apps/web/server/files/service.test.ts
+++ b/apps/web/server/files/service.test.ts
@@ -1,4 +1,5 @@
 import { access, readFile, rm } from "node:fs/promises";
+import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 
 import { describe, expect, it } from "vitest";
@@ -6,7 +7,7 @@ import { describe, expect, it } from "vitest";
 import { FilesError } from "@/server/files/errors";
 import type { FilesRepository } from "@/server/files/repository";
 import { createFilesService } from "@/server/files/service";
-import { getStoragePath } from "@/server/storage";
+import { getStoragePath, getStorageRoot } from "@/server/storage";
 import type {
   FileSummary,
   FolderSummary,
@@ -402,10 +403,21 @@ const createService = (repo: FilesRepository) =>
     scheduleStagingCleanupJob: async () => undefined,
   });
 
+const assertTestStorageRoot = () => {
+  const root = path.normalize(getStorageRoot());
+  const marker = `${path.sep}.tmp${path.sep}vitest-files`;
+
+  if (!root.includes(marker)) {
+    throw new Error(`Refusing to clean non-test storage root: ${root}`);
+  }
+};
+
 const cleanDataRoot = async () => {
+  assertTestStorageRoot();
+
   for (let attempt = 0; attempt < 5; attempt += 1) {
     try {
-      await rm(getStoragePath(""), {
+      await rm(getStorageRoot(), {
         recursive: true,
         force: true,
       });

--- a/apps/web/server/recent-page-helpers.test.ts
+++ b/apps/web/server/recent-page-helpers.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  filterRecentItems,
+  formatRecentFileSize,
+  formatRecentRelativeTime,
+  getRecentDateGroup,
+  getRecentLocationLabel,
+  getRecentType,
+  groupRecentItems,
+  sortRecentItems,
+  toRecentClientItem,
+  type RecentClientItem,
+} from "@/app/(workspace)/recent/recent-helpers";
+import type { RetrievalItem } from "@/server/retrieval/types";
+
+const makeFile = (
+  overrides: Partial<Extract<RetrievalItem, { kind: "file" }>> = {},
+): Extract<RetrievalItem, { kind: "file" }> => ({
+  folderId: "folder-1",
+  href: "/files/view/file-1",
+  id: "file-1",
+  isFavorite: false,
+  kind: "file",
+  mimeType: "image/png",
+  name: "hero.png",
+  pathLabel: "Files / Design / hero.png",
+  sizeBytes: 2400000,
+  updatedAt: new Date("2026-05-19T10:00:00.000Z"),
+  ...overrides,
+});
+
+const makeFolder = (
+  overrides: Partial<Extract<RetrievalItem, { kind: "folder" }>> = {},
+): Extract<RetrievalItem, { kind: "folder" }> => ({
+  href: "/files/f/folder-1",
+  id: "folder-1",
+  isFavorite: false,
+  kind: "folder",
+  name: "Design",
+  parentId: "root",
+  pathLabel: "Files / Design",
+  updatedAt: new Date("2026-05-19T09:00:00.000Z"),
+  ...overrides,
+});
+
+const clientItem = (
+  overrides: Partial<RecentClientItem> = {},
+): RecentClientItem => ({
+  href: "/files/view/file-1",
+  id: "file-1",
+  isFavorite: false,
+  kind: "file",
+  locationLabel: "Design",
+  mimeType: "image/png",
+  name: "hero.png",
+  sizeBytes: 2400000,
+  uploadedAt: "2026-05-19T10:00:00.000Z",
+  ...overrides,
+});
+
+describe("recent page helpers", () => {
+  it("serializes retrieval items with compact location labels", () => {
+    expect(getRecentLocationLabel(makeFile())).toBe("Design");
+    expect(getRecentLocationLabel(makeFolder())).toBe("/");
+
+    expect(
+      toRecentClientItem(
+        makeFile({
+          pathLabel: "Files / Client / Reports / Q1.pdf",
+          name: "Q1.pdf",
+          mimeType: "application/pdf",
+        }),
+      ),
+    ).toMatchObject({
+      kind: "file",
+      locationLabel: "Client / Reports",
+      mimeType: "application/pdf",
+      uploadedAt: "2026-05-19T10:00:00.000Z",
+    });
+  });
+
+  it("maps file and folder types for filters", () => {
+    expect(
+      getRecentType(clientItem({ kind: "folder", mimeType: undefined })),
+    ).toBe("folder");
+    expect(getRecentType(clientItem({ mimeType: "image/png" }))).toBe("image");
+    expect(getRecentType(clientItem({ mimeType: "video/mp4" }))).toBe("video");
+    expect(getRecentType(clientItem({ mimeType: "audio/wav" }))).toBe("audio");
+    expect(getRecentType(clientItem({ mimeType: "application/pdf" }))).toBe(
+      "pdf",
+    );
+    expect(getRecentType(clientItem({ mimeType: "text/markdown" }))).toBe(
+      "text",
+    );
+    expect(getRecentType(clientItem({ mimeType: "application/zip" }))).toBe(
+      "archive",
+    );
+    expect(
+      getRecentType(clientItem({ mimeType: "application/octet-stream" })),
+    ).toBe("all");
+  });
+
+  it("filters and sorts recent items", () => {
+    const items = [
+      clientItem({
+        id: "b",
+        name: "Beta.mov",
+        mimeType: "video/mp4",
+        sizeBytes: 20,
+      }),
+      clientItem({
+        id: "a",
+        name: "Alpha.png",
+        mimeType: "image/png",
+        sizeBytes: 10,
+      }),
+      clientItem({
+        id: "c",
+        kind: "folder",
+        locationLabel: "/",
+        mimeType: undefined,
+        name: "Client",
+        sizeBytes: undefined,
+      }),
+    ];
+
+    expect(filterRecentItems(items, "image").map((item) => item.id)).toEqual([
+      "a",
+    ]);
+    expect(
+      sortRecentItems(items, "name", "asc").map((item) => item.id),
+    ).toEqual(["a", "b", "c"]);
+    expect(
+      sortRecentItems(items, "size", "desc").map((item) => item.id),
+    ).toEqual(["b", "a", "c"]);
+  });
+
+  it("groups recent items into date buckets", () => {
+    const now = new Date("2026-05-21T12:00:00.000Z");
+    const grouped = groupRecentItems(
+      [
+        clientItem({ id: "today", uploadedAt: "2026-05-21T11:00:00.000Z" }),
+        clientItem({
+          id: "yesterday",
+          uploadedAt: "2026-05-20T11:00:00.000Z",
+        }),
+        clientItem({ id: "week", uploadedAt: "2026-05-19T11:00:00.000Z" }),
+        clientItem({ id: "month", uploadedAt: "2026-05-01T11:00:00.000Z" }),
+        clientItem({ id: "older", uploadedAt: "2026-03-01T11:00:00.000Z" }),
+      ],
+      now,
+    );
+
+    expect(grouped.map((group) => group.label)).toEqual([
+      "Today",
+      "Yesterday",
+      "This week",
+      "This month",
+      "Older",
+    ]);
+    expect(getRecentDateGroup("2026-05-21T00:10:00.000Z", now)).toBe("Today");
+  });
+
+  it("formats size and relative time labels", () => {
+    const now = new Date("2026-05-19T12:00:00.000Z");
+
+    expect(formatRecentFileSize(undefined)).toBe("-");
+    expect(formatRecentFileSize(400)).toBe("400 B");
+    expect(formatRecentFileSize(4200)).toBe("4 KB");
+    expect(formatRecentFileSize(2_400_000)).toBe("2.3 MB");
+    expect(formatRecentFileSize(4_500_000_000)).toBe("4.2 GB");
+
+    expect(formatRecentRelativeTime("2026-05-19T12:00:00.000Z", now)).toBe(
+      "Just now",
+    );
+    expect(formatRecentRelativeTime("2026-05-19T11:55:00.000Z", now)).toBe(
+      "5m ago",
+    );
+    expect(formatRecentRelativeTime("2026-05-19T10:00:00.000Z", now)).toBe(
+      "2h ago",
+    );
+    expect(formatRecentRelativeTime("2026-05-18T10:00:00.000Z", now)).toBe(
+      "Yesterday",
+    );
+  });
+});

--- a/apps/web/server/retrieval/service.test.ts
+++ b/apps/web/server/retrieval/service.test.ts
@@ -50,6 +50,7 @@ const createMemoryRepository = () => {
     name,
     isFilesRoot = false,
     deletedAt = null,
+    createdAt,
     updatedAt,
     ownerUsername = ownerUserId,
   }: {
@@ -58,10 +59,11 @@ const createMemoryRepository = () => {
     name: string;
     isFilesRoot?: boolean;
     deletedAt?: Date | null;
+    createdAt?: Date;
     updatedAt?: Date;
     ownerUsername?: string;
   }) => {
-    const timestamp = updatedAt ?? nextDate();
+    const timestamp = createdAt ?? updatedAt ?? nextDate();
     const folder: FolderSummary = {
       id: nextId("folder"),
       ownerUserId,
@@ -71,7 +73,7 @@ const createMemoryRepository = () => {
       isFilesRoot,
       deletedAt,
       createdAt: timestamp,
-      updatedAt: timestamp,
+      updatedAt: updatedAt ?? timestamp,
     };
 
     state.folders.push(folder);
@@ -85,6 +87,7 @@ const createMemoryRepository = () => {
     mimeType = "text/plain",
     sizeBytes = 1024,
     deletedAt = null,
+    createdAt,
     updatedAt,
     ownerUsername = ownerUserId,
   }: {
@@ -94,10 +97,11 @@ const createMemoryRepository = () => {
     mimeType?: string;
     sizeBytes?: number;
     deletedAt?: Date | null;
+    createdAt?: Date;
     updatedAt?: Date;
     ownerUsername?: string;
   }) => {
-    const timestamp = updatedAt ?? nextDate();
+    const timestamp = createdAt ?? updatedAt ?? nextDate();
     const file: FileSummary = {
       id: nextId("file"),
       ownerUserId,
@@ -109,7 +113,7 @@ const createMemoryRepository = () => {
       viewerKind: null,
       deletedAt,
       createdAt: timestamp,
-      updatedAt: timestamp,
+      updatedAt: updatedAt ?? timestamp,
     };
 
     state.files.push(file);
@@ -583,6 +587,62 @@ describe("retrieval service", () => {
       ["file", "notes.txt", true],
       ["folder", "Projects", true],
     ]);
+  });
+
+  it("lists recently added active files and folders by created time", async () => {
+    const { repo, ensureFilesRootRecord, addFolder, addFile } =
+      createMemoryRepository();
+    const root = ensureFilesRootRecord("alice");
+    const folder = addFolder({
+      ownerUserId: "alice",
+      parentId: root.id,
+      name: "Uploads",
+      createdAt: new Date("2026-05-19T11:00:00.000Z"),
+      updatedAt: new Date("2026-05-19T13:00:00.000Z"),
+    });
+    addFile({
+      ownerUserId: "alice",
+      folderId: root.id,
+      name: "older.bin",
+      mimeType: "application/octet-stream",
+      createdAt: new Date("2026-05-19T10:00:00.000Z"),
+      updatedAt: new Date("2026-05-19T15:00:00.000Z"),
+    });
+    addFile({
+      ownerUserId: "alice",
+      folderId: folder.id,
+      name: "newer.bin",
+      mimeType: "application/octet-stream",
+      createdAt: new Date("2026-05-19T12:00:00.000Z"),
+    });
+    addFile({
+      ownerUserId: "alice",
+      folderId: root.id,
+      name: "trashed.bin",
+      mimeType: "application/octet-stream",
+      createdAt: new Date("2026-05-19T13:00:00.000Z"),
+      deletedAt: new Date("2026-05-19T13:05:00.000Z"),
+    });
+    addFile({
+      ownerUserId: "bob",
+      folderId: null,
+      name: "other.bin",
+      mimeType: "application/octet-stream",
+      createdAt: new Date("2026-05-19T14:00:00.000Z"),
+    });
+    const service = createRetrievalService({ repo });
+
+    const items = await service.listRecentlyAdded({
+      actorUserId: "alice",
+      actorRole: "member",
+    });
+
+    expect(items.map((item) => [item.kind, item.name])).toEqual([
+      ["file", "newer.bin"],
+      ["folder", "Uploads"],
+      ["file", "older.bin"],
+    ]);
+    expect(items[2]?.updatedAt.toISOString()).toBe("2026-05-19T10:00:00.000Z");
   });
 
   it("records recent folder and file interactions as one row per item", async () => {

--- a/apps/web/server/retrieval/service.ts
+++ b/apps/web/server/retrieval/service.ts
@@ -475,6 +475,55 @@ export const createRetrievalService = ({
       );
     },
 
+    async listRecentlyAdded({
+      actorUserId,
+    }: FilesActor): Promise<RetrievalItem[]> {
+      const activeRepo = await resolveRepo();
+      const [filesRoot, folders, files, favoriteState] = await Promise.all([
+        activeRepo.ensureFilesRoot(actorUserId),
+        activeRepo.listFoldersByOwner(actorUserId),
+        activeRepo.listFilesByOwner(actorUserId),
+        getFavoriteState(actorUserId),
+      ]);
+      const folderMap = buildFolderMap(folders);
+      const items = [
+        ...folders
+          .filter((folder) => !folder.isFilesRoot)
+          .map((folder) => ({
+            createdAt: folder.createdAt,
+            item: {
+              ...toFolderItem({
+                folder,
+                folderMap,
+                filesRoot,
+                favoriteFolderIds: favoriteState.favoriteFolderIds,
+              }),
+              updatedAt: folder.createdAt,
+            },
+          })),
+        ...files.map((file) => ({
+          createdAt: file.createdAt,
+          item: {
+            ...toFileItem({
+              file,
+              folderMap,
+              filesRoot,
+              favoriteFileIds: favoriteState.favoriteFileIds,
+            }),
+            updatedAt: file.createdAt,
+          },
+        })),
+      ];
+
+      return items
+        .sort(
+          (left, right) =>
+            right.createdAt.getTime() - left.createdAt.getTime() ||
+            compareRetrievalItems(left.item, right.item),
+        )
+        .map((entry) => entry.item);
+    },
+
     async listRecent({ actorUserId }: FilesActor): Promise<RetrievalItem[]> {
       const activeRepo = await resolveRepo();
       const [

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -4,14 +4,14 @@ import { defineConfig } from "vitest/config";
 process.env.AUTH_SECRET ??= "test-placeholder-secret";
 process.env.DATABASE_URL ??=
   "postgresql://staaash:staaash@localhost:5432/staaash";
-process.env.UPLOAD_LOCATION ??= "./.data/files";
+process.env.UPLOAD_LOCATION = path.resolve(__dirname, ".tmp", "vitest-files");
 
 export default defineConfig({
   test: {
     environment: "node",
     setupFiles: ["./vitest.setup.ts"],
     include: ["server/**/*.test.ts"],
-    // Storage-backed integration tests share the same UPLOAD_LOCATION fixture tree.
+    // Storage-backed integration tests share an isolated fixture tree.
     // Run files serially to avoid cross-file races on Windows filesystem ops.
     fileParallelism: false,
   },


### PR DESCRIPTION
## 🚀 Summary

Redesign the Recent page main content and switch it to recently uploaded files and folders instead of last-opened items.

Also isolates web test upload storage so `pnpm --filter web test` cannot delete the local app storage directory.

## 📊 Impacts and Changes

- `/recent` now lists active files and folders by created/uploaded time.
- The Recent table uses an `Uploaded` column and defaults to newest upload first.
- Uploaded `.bin` files now appear even if they were never opened.
- Sidebar, topbar, routes, DPI behavior, and schema stay unchanged.
- Web tests now force `UPLOAD_LOCATION` to `apps/web/.tmp/vitest-files` and refuse destructive cleanup outside that test path.
- Storage behavior changed only for tests; app runtime storage config is unchanged.

## 🧪 Testing Checklist

- [ ] `pnpm lint` passed
- [x] `pnpm --filter web test` passed
- [x] `pnpm --filter web typecheck` passed
- [x] `pnpm format:check` passed
- [x] `pnpm --filter web build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

Existing DB rows whose blobs were already removed by the old test behavior still need manual cleanup or re-upload. This PR prevents the test wipe from happening again.

## 🔗 Linked Issues

None.