### PR TITLE
Redesign shared table view

### DIFF
--- a/apps/web/app/(workspace)/shared/page.tsx
+++ b/apps/web/app/(workspace)/shared/page.tsx
@@ -23,8 +23,19 @@ const shareStatusLabel = {
 function getRelativeExpiry(expiresAt: Date | string): string {
   const d = new Date(expiresAt);
   const diffMs = d.getTime() - Date.now();
+  const diffSeconds = Math.ceil(diffMs / 1000);
+  if (diffSeconds <= 0) return "expired";
+  if (diffSeconds < 60)
+    return `${diffSeconds} second${diffSeconds === 1 ? "" : "s"}`;
+
+  const diffMinutes = Math.ceil(diffSeconds / 60);
+  if (diffMinutes < 60)
+    return `${diffMinutes} minute${diffMinutes === 1 ? "" : "s"}`;
+
+  const diffHours = Math.ceil(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours} hour${diffHours === 1 ? "" : "s"}`;
+
   const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
-  if (diffDays <= 0) return "expired";
   if (diffDays === 1) return "1 day";
   if (diffDays < 7) return `${diffDays} days`;
   if (diffDays < 60)
@@ -33,11 +44,15 @@ function getRelativeExpiry(expiresAt: Date | string): string {
   return `${Math.floor(diffDays / 365)}y`;
 }
 
-function isExpiringSoon(expiresAt: Date | string): boolean {
+function getExpiryTone(
+  expiresAt: Date | string,
+): SharedTableItem["expiryTone"] {
   const d = new Date(expiresAt);
   const diffMs = d.getTime() - Date.now();
-  const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
-  return diffDays > 0 && diffDays < 7;
+  if (diffMs <= 0) return "default";
+  if (diffMs < 1000 * 60 * 60 * 24) return "critical";
+  if (diffMs < 1000 * 60 * 60 * 24 * 7) return "warning";
+  return "default";
 }
 
 type SharedPageProps = {
@@ -68,8 +83,8 @@ export default async function SharedPage({ searchParams }: SharedPageProps) {
       share.status === "active"
         ? getRelativeExpiry(share.expiresAt)
         : formatDateTime(share.expiresAt),
-    isExpiringSoon:
-      share.status === "active" && isExpiringSoon(share.expiresAt),
+    expiryTone:
+      share.status === "active" ? getExpiryTone(share.expiresAt) : "default",
     statusLabel: shareStatusLabel[share.status],
   }));
 

--- a/apps/web/app/(workspace)/shared/page.tsx
+++ b/apps/web/app/(workspace)/shared/page.tsx
@@ -6,19 +6,10 @@ import {
   formatDateTime,
   getSingleSearchParam,
 } from "@/app/auth-ui";
-import { ItemContextMenu } from "@/app/item-context-menu";
-import { getItemVisual } from "@/app/item-visuals";
-import { ItemTypeIcon } from "@/app/item-type-icon";
-import {
-  PAGE_SIZE,
-  PaginationControls,
-  parsePage,
-} from "@/app/pagination-controls";
-import { redirect } from "next/navigation";
 import { requireSignedInPageSession } from "@/server/auth/guards";
 import { getBaseUrl } from "@/server/request";
-import { formatDateTimeLocalValue } from "@/server/sharing/schema";
 import { sharingService } from "@/server/sharing/service";
+import { SharedTable, type SharedTableItem } from "./shared-table";
 
 export const dynamic = "force-dynamic";
 
@@ -42,6 +33,13 @@ function getRelativeExpiry(expiresAt: Date | string): string {
   return `${Math.floor(diffDays / 365)}y`;
 }
 
+function isExpiringSoon(expiresAt: Date | string): boolean {
+  const d = new Date(expiresAt);
+  const diffMs = d.getTime() - Date.now();
+  const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+  return diffDays > 0 && diffDays < 7;
+}
+
 type SharedPageProps = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
@@ -61,57 +59,31 @@ export default async function SharedPage({ searchParams }: SharedPageProps) {
     baseUrl,
   });
 
-  const activePage = parsePage(
-    getSingleSearchParam(resolvedSearchParams, "activePage"),
-  );
-  const inactivePage = parsePage(
-    getSingleSearchParam(resolvedSearchParams, "inactivePage"),
-  );
-
-  const activeTotalPages = Math.ceil(shares.active.length / PAGE_SIZE);
-  const inactiveTotalPages = Math.ceil(shares.inactive.length / PAGE_SIZE);
-
-  const buildActiveHref = (p: number) => {
-    const params = new URLSearchParams();
-    if (p > 1) params.set("activePage", String(p));
-    if (inactivePage > 1) params.set("inactivePage", String(inactivePage));
-    const qs = params.toString();
-    return qs ? `/shared?${qs}` : "/shared";
-  };
-
-  const buildInactiveHref = (p: number) => {
-    const params = new URLSearchParams();
-    if (activePage > 1) params.set("activePage", String(activePage));
-    if (p > 1) params.set("inactivePage", String(p));
-    const qs = params.toString();
-    return qs ? `/shared?${qs}` : "/shared";
-  };
-
-  if (activeTotalPages > 0 && activePage > activeTotalPages)
-    redirect(buildActiveHref(1));
-  if (inactiveTotalPages > 0 && inactivePage > inactiveTotalPages)
-    redirect(buildInactiveHref(1));
-
-  const activeItems = shares.active.slice(
-    (activePage - 1) * PAGE_SIZE,
-    activePage * PAGE_SIZE,
-  );
-  const inactiveItems = shares.inactive.slice(
-    (inactivePage - 1) * PAGE_SIZE,
-    inactivePage * PAGE_SIZE,
-  );
-
   const allShares = [...shares.active, ...shares.inactive];
+
+  const tableItems: SharedTableItem[] = allShares.map((share) => ({
+    share,
+    canManage: share.status !== "target-unavailable",
+    expiresLabel:
+      share.status === "active"
+        ? getRelativeExpiry(share.expiresAt)
+        : formatDateTime(share.expiresAt),
+    isExpiringSoon:
+      share.status === "active" && isExpiringSoon(share.expiresAt),
+    statusLabel: shareStatusLabel[share.status],
+  }));
 
   return (
     <div className="workspace-page">
       <div className="stack">
         {/* Page header */}
-        <div className="split">
-          <h1>Shared</h1>
-          {allShares.length > 0 && (
-            <span className="section-count">{allShares.length}</span>
-          )}
+        <div className="shared-header">
+          <div className="shared-title-row">
+            <h1>Shared</h1>
+            {allShares.length > 0 && (
+              <span className="section-count">{allShares.length}</span>
+            )}
+          </div>
         </div>
 
         {error ? <FlashMessage>{error}</FlashMessage> : null}
@@ -130,349 +102,7 @@ export default async function SharedPage({ searchParams }: SharedPageProps) {
           </div>
         ) : (
           <div className="sl-page">
-            {/* ── Active ── */}
-            {shares.active.length > 0 && (
-              <section className="sl-group">
-                <div className="sl-group-header">
-                  <span className="sl-group-label">Active</span>
-                  <span className="sl-group-count">{shares.active.length}</span>
-                </div>
-
-                <div className="sl-list">
-                  {activeItems.map((share) => (
-                    <ItemContextMenu
-                      href={`/shared#${share.id}`}
-                      id={share.id}
-                      key={share.id}
-                      kind="share"
-                      name={share.target.name}
-                    >
-                      <article className="sl-row" id={share.id}>
-                        {/* ── Row head ── */}
-                        <div className="sl-head">
-                          <div className="sl-identity-row">
-                            <ItemTypeIcon
-                              visual={getItemVisual(
-                                share.target.targetType,
-                                share.target.targetType === "file"
-                                  ? share.target.mimeType
-                                  : null,
-                              )}
-                            />
-                            <div className="sl-identity">
-                              <span className="sl-name">
-                                {share.target.name}
-                              </span>
-                              <span className="sl-meta">
-                                {share.target.pathLabel}
-                                {" · "}
-                                {share.target.targetType}
-                                {" · expires in "}
-                                <strong>
-                                  {getRelativeExpiry(share.expiresAt)}
-                                </strong>
-                              </span>
-                            </div>
-                          </div>
-                          <span className="sl-badge sl-badge--active">
-                            Active
-                          </span>
-                        </div>
-
-                        {/* ── Management panel ── */}
-                        <details className="sl-panel">
-                          <summary className="sl-summary">Manage</summary>
-
-                          <div className="sl-body">
-                            {/* URL row */}
-                            <div className="sl-url-row">
-                              <input
-                                className="sl-url-input"
-                                readOnly
-                                value={share.shareUrl}
-                                aria-label="Share URL"
-                              />
-                              <a
-                                className="sl-open-link"
-                                href={share.shareUrl}
-                                target="_blank"
-                                rel="noreferrer"
-                              >
-                                Open ↗
-                              </a>
-                            </div>
-
-                            {/* Policy — expiry + downloads */}
-                            <form
-                              action={`/api/shares/${share.id}/update`}
-                              method="post"
-                              className="sl-policy-form"
-                            >
-                              <input
-                                name="redirectTo"
-                                type="hidden"
-                                value={`/shared#${share.id}`}
-                              />
-                              <div className="sl-policy-row">
-                                <input
-                                  className="sl-datetime-input"
-                                  defaultValue={formatDateTimeLocalValue(
-                                    share.expiresAt,
-                                  )}
-                                  name="expiresAt"
-                                  type="datetime-local"
-                                  required
-                                />
-                                <label className="sl-toggle-label">
-                                  <input
-                                    type="checkbox"
-                                    name="downloadDisabled"
-                                    value="true"
-                                    defaultChecked={share.downloadDisabled}
-                                    className="share-toggle-check"
-                                  />
-                                  <span
-                                    className="share-toggle-slider"
-                                    aria-hidden
-                                  />
-                                  <span className="sl-toggle-text">
-                                    {share.downloadDisabled
-                                      ? "Downloads blocked"
-                                      : "Downloads allowed"}
-                                  </span>
-                                </label>
-                                <button className="sl-save-btn" type="submit">
-                                  Save
-                                </button>
-                              </div>
-                            </form>
-
-                            {/* Password */}
-                            <div className="sl-pw-section">
-                              <form
-                                action={`/api/shares/${share.id}/password`}
-                                method="post"
-                                className="sl-pw-form"
-                              >
-                                <input
-                                  name="redirectTo"
-                                  type="hidden"
-                                  value={`/shared#${share.id}`}
-                                />
-                                <div className="sl-pw-row">
-                                  <input
-                                    className="sl-pw-input"
-                                    minLength={4}
-                                    name="password"
-                                    type="password"
-                                    placeholder={
-                                      share.hasPassword
-                                        ? "New password…"
-                                        : "Set a password…"
-                                    }
-                                  />
-                                  <button
-                                    className="sl-action-btn"
-                                    type="submit"
-                                  >
-                                    {share.hasPassword ? "Rotate" : "Set"}
-                                  </button>
-                                  {share.hasPassword && (
-                                    <span className="sl-pw-status">
-                                      Password set
-                                    </span>
-                                  )}
-                                </div>
-                              </form>
-                              {share.hasPassword && (
-                                <form
-                                  action={`/api/shares/${share.id}/password`}
-                                  method="post"
-                                >
-                                  <input
-                                    name="redirectTo"
-                                    type="hidden"
-                                    value={`/shared#${share.id}`}
-                                  />
-                                  <input
-                                    name="clear"
-                                    type="hidden"
-                                    value="true"
-                                  />
-                                  <button
-                                    className="sl-action-btn sl-action-btn--danger"
-                                    type="submit"
-                                  >
-                                    Remove password
-                                  </button>
-                                </form>
-                              )}
-                            </div>
-
-                            {/* Danger zone */}
-                            <div className="sl-danger-row">
-                              <form
-                                action={`/api/shares/${share.id}/revoke`}
-                                method="post"
-                              >
-                                <input
-                                  name="redirectTo"
-                                  type="hidden"
-                                  value={`/shared#${share.id}`}
-                                />
-                                <button className="sl-danger-btn" type="submit">
-                                  Revoke link
-                                </button>
-                              </form>
-                              <form
-                                action={`/api/shares/${share.id}/delete`}
-                                method="post"
-                              >
-                                <input
-                                  name="redirectTo"
-                                  type="hidden"
-                                  value="/shared"
-                                />
-                                <button className="sl-danger-btn" type="submit">
-                                  Delete record
-                                </button>
-                              </form>
-                            </div>
-                          </div>
-                        </details>
-                      </article>
-                    </ItemContextMenu>
-                  ))}
-                </div>
-
-                <PaginationControls
-                  buildHref={buildActiveHref}
-                  page={activePage}
-                  totalPages={activeTotalPages}
-                />
-              </section>
-            )}
-
-            {/* ── Inactive ── */}
-            {shares.inactive.length > 0 && (
-              <section className="sl-group">
-                <div className="sl-group-header">
-                  <span className="sl-group-label">Inactive</span>
-                  <span className="sl-group-count">
-                    {shares.inactive.length}
-                  </span>
-                </div>
-
-                <div className="sl-list">
-                  {inactiveItems.map((share) => (
-                    <ItemContextMenu
-                      href={`/shared#${share.id}`}
-                      id={share.id}
-                      key={share.id}
-                      kind="share"
-                      name={share.target.name}
-                    >
-                      <article className="sl-row" id={share.id}>
-                        <div className="sl-head">
-                          <div className="sl-identity-row">
-                            <ItemTypeIcon
-                              visual={getItemVisual(
-                                share.target.targetType,
-                                share.target.targetType === "file"
-                                  ? share.target.mimeType
-                                  : null,
-                              )}
-                            />
-                            <div className="sl-identity">
-                              <span className="sl-name sl-name--inactive">
-                                {share.target.name}
-                              </span>
-                              <span className="sl-meta">
-                                {share.target.pathLabel}
-                                {" · "}
-                                {share.target.targetType}
-                                {" · "}
-                                {formatDateTime(share.expiresAt)}
-                              </span>
-                            </div>
-                          </div>
-                          <span
-                            className={`sl-badge sl-badge--${share.status === "expired" ? "expired" : "revoked"}`}
-                          >
-                            {shareStatusLabel[share.status]}
-                          </span>
-                        </div>
-
-                        <details className="sl-panel">
-                          <summary className="sl-summary">Manage</summary>
-
-                          <div className="sl-body">
-                            {share.status !== "target-unavailable" ? (
-                              <form action="/api/shares" method="post">
-                                <input
-                                  name="mode"
-                                  type="hidden"
-                                  value="reissue"
-                                />
-                                <input
-                                  name="shareId"
-                                  type="hidden"
-                                  value={share.id}
-                                />
-                                <input
-                                  name="redirectTo"
-                                  type="hidden"
-                                  value={`/shared#${share.id}`}
-                                />
-                                <div className="sl-reissue-row">
-                                  <span className="sl-reissue-hint">
-                                    Generate a new link for this{" "}
-                                    {share.target.targetType}.
-                                  </span>
-                                  <button
-                                    className="sl-reissue-btn"
-                                    type="submit"
-                                  >
-                                    Reissue link
-                                  </button>
-                                </div>
-                              </form>
-                            ) : (
-                              <p className="sl-unavailable-hint">
-                                Restore the item in the library before reissuing
-                                this link.
-                              </p>
-                            )}
-
-                            <div className="sl-danger-row">
-                              <form
-                                action={`/api/shares/${share.id}/delete`}
-                                method="post"
-                              >
-                                <input
-                                  name="redirectTo"
-                                  type="hidden"
-                                  value="/shared"
-                                />
-                                <button className="sl-danger-btn" type="submit">
-                                  Delete record
-                                </button>
-                              </form>
-                            </div>
-                          </div>
-                        </details>
-                      </article>
-                    </ItemContextMenu>
-                  ))}
-                </div>
-
-                <PaginationControls
-                  buildHref={buildInactiveHref}
-                  page={inactivePage}
-                  totalPages={inactiveTotalPages}
-                />
-              </section>
-            )}
+            <SharedTable items={tableItems} />
           </div>
         )}
       </div>

--- a/apps/web/app/(workspace)/shared/shared-table.tsx
+++ b/apps/web/app/(workspace)/shared/shared-table.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { KeyRound } from "lucide-react";
+import { useMemo, useState, useTransition } from "react";
+
+import { ShareDialog } from "@/app/(workspace)/files/share-dialog";
+import type { ShareLinkSummary } from "@/server/sharing";
+
+export type SharedTableItem = {
+  share: ShareLinkSummary;
+  canManage: boolean;
+  expiresLabel: string;
+  isExpiringSoon: boolean;
+  statusLabel: string;
+};
+
+type SharedTableProps = {
+  items: SharedTableItem[];
+};
+
+type SharedFilterType =
+  | "all"
+  | "archive"
+  | "audio"
+  | "folder"
+  | "image"
+  | "pdf"
+  | "text"
+  | "video";
+
+const FILTERS: { id: SharedFilterType; label: string }[] = [
+  { id: "all", label: "All" },
+  { id: "folder", label: "Folders" },
+  { id: "image", label: "Images" },
+  { id: "pdf", label: "PDFs" },
+  { id: "video", label: "Videos" },
+  { id: "audio", label: "Audio" },
+  { id: "text", label: "Docs" },
+  { id: "archive", label: "Archives" },
+];
+
+const getStatusClass = (status: ShareLinkSummary["status"]) => {
+  if (status === "target-unavailable") return "unavailable";
+  return status;
+};
+
+function getShareType(share: ShareLinkSummary): SharedFilterType {
+  if (share.target.targetType === "folder") return "folder";
+
+  const mime = share.target.mimeType ?? "";
+  if (mime.startsWith("image/")) return "image";
+  if (mime.startsWith("video/")) return "video";
+  if (mime.startsWith("audio/")) return "audio";
+  if (mime.includes("pdf")) return "pdf";
+  if (
+    mime.startsWith("text/") ||
+    mime.includes("typescript") ||
+    mime.includes("json") ||
+    mime.includes("document")
+  ) {
+    return "text";
+  }
+  if (
+    mime.includes("zip") ||
+    mime.includes("archive") ||
+    mime.includes("tar") ||
+    mime.includes("gzip")
+  ) {
+    return "archive";
+  }
+
+  return "all";
+}
+
+function getShareTypeLabel(share: ShareLinkSummary): string {
+  const type = getShareType(share);
+  if (type === "all")
+    return share.target.targetType === "file" ? "File" : "Folder";
+  if (type === "pdf") return "PDF";
+  return type.charAt(0).toUpperCase() + type.slice(1);
+}
+
+export function SharedTable({ items }: SharedTableProps) {
+  const router = useRouter();
+  const [, startTransition] = useTransition();
+  const [filterType, setFilterType] = useState<SharedFilterType>("all");
+  const [shareDialogTarget, setShareDialogTarget] = useState<{
+    targetType: "file" | "folder";
+    targetId: string;
+    share: ShareLinkSummary;
+  } | null>(null);
+  const visibleItems = useMemo(() => {
+    if (filterType === "all") return items;
+    return items.filter(({ share }) => getShareType(share) === filterType);
+  }, [filterType, items]);
+
+  return (
+    <>
+      <div className="shared-toolbar" aria-label="Shared display controls">
+        <label className="favorites-filter-control">
+          <span>Type</span>
+          <select
+            value={filterType}
+            onChange={(event) =>
+              setFilterType(event.target.value as SharedFilterType)
+            }
+          >
+            {FILTERS.map((filter) => (
+              <option key={filter.id} value={filter.id}>
+                {filter.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <Link className="shared-new-link" href="/files">
+          + New share link
+        </Link>
+      </div>
+
+      {visibleItems.length === 0 ? (
+        <div className="workspace-empty-state">
+          <h2>No shared links match that filter</h2>
+          <p className="muted">Try a different type.</p>
+        </div>
+      ) : (
+        <div className="st-wrap">
+          <table className="st-table">
+            <colgroup>
+              <col className="st-col-name" />
+              <col className="st-col-location" />
+              <col className="st-col-type" />
+              <col className="st-col-expires" />
+              <col className="st-col-status" />
+              <col className="st-col-actions" />
+            </colgroup>
+            <thead>
+              <tr>
+                <th className="st-th" scope="col">
+                  Name
+                </th>
+                <th className="st-th" scope="col">
+                  Location
+                </th>
+                <th className="st-th" scope="col">
+                  Type
+                </th>
+                <th className="st-th" scope="col">
+                  Expires
+                </th>
+                <th className="st-th" scope="col">
+                  Status
+                </th>
+                <th className="st-th" scope="col">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {visibleItems.map(
+                ({
+                  share,
+                  canManage,
+                  expiresLabel,
+                  isExpiringSoon,
+                  statusLabel,
+                }) => (
+                  <tr
+                    className={`st-tr${share.status === "active" ? "" : " st-tr--inactive"}`}
+                    id={share.id}
+                    key={share.id}
+                  >
+                    <td className="st-td st-name-cell">
+                      <span className="st-name">
+                        <span
+                          className="st-name-text"
+                          title={share.target.name}
+                        >
+                          {share.target.name}
+                        </span>
+                        {share.hasPassword ? (
+                          <KeyRound
+                            aria-label="Password protected"
+                            className="st-name-lock"
+                            size={13}
+                          />
+                        ) : null}
+                      </span>
+                    </td>
+                    <td className="st-td st-muted">
+                      <span
+                        className="st-location"
+                        title={share.target.pathLabel}
+                      >
+                        {share.target.pathLabel}
+                      </span>
+                    </td>
+                    <td className="st-td st-muted">
+                      {getShareTypeLabel(share)}
+                    </td>
+                    <td
+                      className={`st-td st-mono${isExpiringSoon ? " st-expires--soon" : ""}`}
+                    >
+                      {expiresLabel}
+                    </td>
+                    <td className="st-td">
+                      <span
+                        className={`sl-badge sl-badge--${getStatusClass(share.status)}`}
+                      >
+                        {statusLabel}
+                      </span>
+                    </td>
+                    <td className="st-td">
+                      <div className="st-actions">
+                        <button
+                          className="st-action"
+                          disabled={!canManage}
+                          onClick={() =>
+                            setShareDialogTarget({
+                              targetType: share.target.targetType,
+                              targetId: share.target.id,
+                              share,
+                            })
+                          }
+                          type="button"
+                        >
+                          Manage
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ),
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {shareDialogTarget ? (
+        <ShareDialog
+          targetType={shareDialogTarget.targetType}
+          targetId={shareDialogTarget.targetId}
+          initialShare={shareDialogTarget.share}
+          onClose={() => {
+            setShareDialogTarget(null);
+            startTransition(() => router.refresh());
+          }}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/app/(workspace)/shared/shared-table.tsx
+++ b/apps/web/app/(workspace)/shared/shared-table.tsx
@@ -179,13 +179,6 @@ export function SharedTable({ items }: SharedTableProps) {
                         >
                           {share.target.name}
                         </span>
-                        {share.hasPassword ? (
-                          <KeyRound
-                            aria-label="Password protected"
-                            className="st-name-lock"
-                            size={13}
-                          />
-                        ) : null}
                       </span>
                     </td>
                     <td className="st-td st-muted">
@@ -227,6 +220,20 @@ export function SharedTable({ items }: SharedTableProps) {
                         >
                           Manage
                         </button>
+                        <span
+                          aria-hidden={!share.hasPassword}
+                          className="st-password-hint"
+                          title={
+                            share.hasPassword ? "Password protected" : undefined
+                          }
+                        >
+                          {share.hasPassword ? (
+                            <KeyRound
+                              aria-label="Password protected"
+                              size={13}
+                            />
+                          ) : null}
+                        </span>
                       </div>
                     </td>
                   </tr>

--- a/apps/web/app/(workspace)/shared/shared-table.tsx
+++ b/apps/web/app/(workspace)/shared/shared-table.tsx
@@ -12,7 +12,7 @@ export type SharedTableItem = {
   share: ShareLinkSummary;
   canManage: boolean;
   expiresLabel: string;
-  isExpiringSoon: boolean;
+  expiryTone: "critical" | "default" | "warning";
   statusLabel: string;
 };
 
@@ -80,6 +80,22 @@ function getShareTypeLabel(share: ShareLinkSummary): string {
     return share.target.targetType === "file" ? "File" : "Folder";
   if (type === "pdf") return "PDF";
   return type.charAt(0).toUpperCase() + type.slice(1);
+}
+
+function splitPathLabel(pathLabel: string): string[] {
+  return pathLabel
+    .split("/")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function getShareLocationLabel(share: ShareLinkSummary): string {
+  const parts = splitPathLabel(share.target.pathLabel);
+  const pathWithoutSelf =
+    parts.at(-1) === share.target.name ? parts.slice(0, -1) : parts;
+  const withoutRoot =
+    pathWithoutSelf.length > 1 ? pathWithoutSelf.slice(1) : [];
+  return withoutRoot.length > 0 ? `/ ${withoutRoot.join(" / ")} /` : "/";
 }
 
 export function SharedTable({ items }: SharedTableProps) {
@@ -163,81 +179,82 @@ export function SharedTable({ items }: SharedTableProps) {
                   share,
                   canManage,
                   expiresLabel,
-                  isExpiringSoon,
+                  expiryTone,
                   statusLabel,
-                }) => (
-                  <tr
-                    className={`st-tr${share.status === "active" ? "" : " st-tr--inactive"}`}
-                    id={share.id}
-                    key={share.id}
-                  >
-                    <td className="st-td st-name-cell">
-                      <span className="st-name">
-                        <span
-                          className="st-name-text"
-                          title={share.target.name}
-                        >
-                          {share.target.name}
-                        </span>
-                      </span>
-                    </td>
-                    <td className="st-td st-muted">
-                      <span
-                        className="st-location"
-                        title={share.target.pathLabel}
-                      >
-                        {share.target.pathLabel}
-                      </span>
-                    </td>
-                    <td className="st-td st-muted">
-                      {getShareTypeLabel(share)}
-                    </td>
-                    <td
-                      className={`st-td st-mono${isExpiringSoon ? " st-expires--soon" : ""}`}
+                }) => {
+                  const locationLabel = getShareLocationLabel(share);
+
+                  return (
+                    <tr
+                      className={`st-tr${share.status === "active" ? "" : " st-tr--inactive"}`}
+                      id={share.id}
+                      key={share.id}
                     >
-                      {expiresLabel}
-                    </td>
-                    <td className="st-td">
-                      <span
-                        className={`sl-badge sl-badge--${getStatusClass(share.status)}`}
-                      >
-                        {statusLabel}
-                      </span>
-                    </td>
-                    <td className="st-td">
-                      <div className="st-actions">
-                        <button
-                          className="st-action"
-                          disabled={!canManage}
-                          onClick={() =>
-                            setShareDialogTarget({
-                              targetType: share.target.targetType,
-                              targetId: share.target.id,
-                              share,
-                            })
-                          }
-                          type="button"
-                        >
-                          Manage
-                        </button>
-                        <span
-                          aria-hidden={!share.hasPassword}
-                          className="st-password-hint"
-                          title={
-                            share.hasPassword ? "Password protected" : undefined
-                          }
-                        >
-                          {share.hasPassword ? (
-                            <KeyRound
-                              aria-label="Password protected"
-                              size={13}
-                            />
-                          ) : null}
+                      <td className="st-td st-name-cell">
+                        <span className="st-name">
+                          <span
+                            className="st-name-text"
+                            title={share.target.name}
+                          >
+                            {share.target.name}
+                          </span>
                         </span>
-                      </div>
-                    </td>
-                  </tr>
-                ),
+                      </td>
+                      <td className="st-td st-muted">
+                        <span className="st-location" title={locationLabel}>
+                          {locationLabel}
+                        </span>
+                      </td>
+                      <td className="st-td st-muted">
+                        {getShareTypeLabel(share)}
+                      </td>
+                      <td className={`st-td st-mono st-expires--${expiryTone}`}>
+                        {expiresLabel}
+                      </td>
+                      <td className="st-td">
+                        <span
+                          className={`sl-badge sl-badge--${getStatusClass(share.status)}`}
+                        >
+                          {statusLabel}
+                        </span>
+                      </td>
+                      <td className="st-td">
+                        <div className="st-actions">
+                          <button
+                            className="st-action"
+                            disabled={!canManage}
+                            onClick={() =>
+                              setShareDialogTarget({
+                                targetType: share.target.targetType,
+                                targetId: share.target.id,
+                                share,
+                              })
+                            }
+                            type="button"
+                          >
+                            Manage
+                          </button>
+                          <span
+                            aria-hidden={!share.hasPassword}
+                            className="st-password-hint"
+                            title={
+                              share.hasPassword
+                                ? "Password protected"
+                                : undefined
+                            }
+                          >
+                            {share.hasPassword ? (
+                              <KeyRound
+                                aria-label="Password protected"
+                                size={13}
+                              />
+                            ) : null}
+                          </span>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                },
               )}
             </tbody>
           </table>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2014,12 +2014,13 @@ h3 {
 }
 
 .recent-header h1,
-.favorites-header h1 {
+.favorites-header h1,
+.shared-header h1 {
   margin: 0;
   font-family: var(--font-cabinet), sans-serif;
-  font-size: 1.7rem;
+  font-size: 1.45rem;
   font-weight: 600;
-  letter-spacing: -0.025em;
+  letter-spacing: -0.02em;
   line-height: 1.1;
 }
 
@@ -4054,6 +4055,20 @@ h3 {
   line-height: 1.1;
 }
 
+.workspace-breadcrumb-active,
+.explorer-title-row h1,
+.recent-header h1,
+.favorites-header h1,
+.shared-header h1 {
+  margin: 0;
+  font-family: var(--font-cabinet), sans-serif;
+  font-size: 1.45rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  color: var(--foreground);
+}
+
 .explorer-header-actions {
   display: flex;
   align-items: center;
@@ -5988,14 +6003,6 @@ main.share-locked-page {
   align-items: center;
   gap: 10px;
   min-width: 0;
-}
-
-.shared-header h1 {
-  font-family: var(--font-cabinet);
-  font-size: 1.45rem;
-  font-weight: 700;
-  line-height: 1;
-  letter-spacing: -0.02em;
 }
 
 .shared-header .section-count {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -5975,7 +5975,73 @@ main.share-locked-page {
 
 .sl-page {
   display: grid;
-  gap: 36px;
+  gap: 16px;
+}
+
+.shared-header {
+  display: flex;
+  align-items: center;
+}
+
+.shared-title-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.shared-header h1 {
+  font-family: var(--font-cabinet);
+  font-size: 1.45rem;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+
+.shared-header .section-count {
+  transform: translateY(1px);
+}
+
+.shared-new-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 36px;
+  padding: 0 18px;
+  border-radius: 8px;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+  transition:
+    background 120ms ease,
+    filter 120ms ease;
+}
+
+.shared-new-link:hover {
+  filter: brightness(1.04);
+}
+
+.shared-new-link:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--primary) 65%, transparent);
+  outline-offset: 3px;
+}
+
+.shared-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.shared-toolbar .favorites-filter-control {
+  min-height: 28px;
+}
+
+.shared-toolbar .favorites-filter-control select {
+  min-width: 96px;
 }
 
 /* Group (Active / Inactive) */
@@ -6112,6 +6178,183 @@ main.share-locked-page {
   background: color-mix(in oklab, var(--destructive) 8%, transparent);
   color: var(--destructive);
   border: 1px solid color-mix(in oklab, var(--destructive) 22%, transparent);
+}
+
+.sl-badge--unavailable {
+  background: color-mix(in oklab, var(--foreground) 7%, transparent);
+  color: var(--muted-foreground);
+  border: 1px solid color-mix(in oklab, var(--foreground) 13%, transparent);
+}
+
+/* Dense table */
+
+.st-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+}
+
+.st-table {
+  width: 100%;
+  min-width: 760px;
+  table-layout: fixed;
+  border-collapse: collapse;
+}
+
+.st-col-name {
+  width: 28%;
+}
+
+.st-col-location {
+  width: 24%;
+}
+
+.st-col-type {
+  width: 12%;
+}
+
+.st-col-expires {
+  width: 16%;
+}
+
+.st-col-status {
+  width: 12%;
+}
+
+.st-col-actions {
+  width: 12%;
+}
+
+.st-th {
+  padding: 8px 14px;
+  text-align: left;
+  font-size: 10.5px;
+  font-weight: 650;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted-foreground);
+  background: color-mix(in oklab, var(--foreground) 2.5%, var(--card));
+  border-bottom: 1px solid var(--border);
+}
+
+.st-td {
+  padding: 10px 14px;
+  font-size: 13px;
+  color: var(--foreground);
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--foreground) 5%, transparent);
+  vertical-align: middle;
+}
+
+.st-tr:last-child .st-td {
+  border-bottom: none;
+}
+
+.st-tr:hover .st-td {
+  background: color-mix(in oklab, var(--foreground) 3%, transparent);
+}
+
+.st-tr--inactive .st-td {
+  opacity: 0.55;
+}
+
+.st-name-cell,
+.st-muted,
+.st-location {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.st-name {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  gap: 6px;
+  white-space: nowrap;
+  font-weight: 600;
+}
+
+.st-name-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.st-name-lock {
+  flex: 0 0 auto;
+  color: color-mix(in oklab, var(--primary) 62%, var(--muted-foreground) 38%);
+  transform: translateY(0.5px);
+}
+
+.st-location {
+  display: block;
+}
+
+.st-muted {
+  color: var(--muted-foreground);
+}
+
+.st-capitalize {
+  text-transform: capitalize;
+}
+
+.st-mono {
+  font-variant-numeric: tabular-nums;
+}
+
+.st-expires--soon {
+  color: oklch(58% 0.16 52);
+  font-weight: 600;
+}
+
+.st-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.st-actions {
+  white-space: nowrap;
+}
+
+.st-action {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 0;
+  border: none;
+  background: transparent;
+  color: var(--primary);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 80ms ease;
+}
+
+.st-action:hover:not(:disabled) {
+  color: color-mix(in oklab, var(--primary) 76%, var(--foreground) 24%);
+}
+
+.st-action:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--primary) 65%, transparent);
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+
+.st-action:disabled {
+  color: color-mix(in oklab, var(--muted-foreground) 55%, transparent);
+  cursor: not-allowed;
+}
+
+.st-action--danger {
+  color: var(--destructive);
+}
+
+.st-action--danger:hover {
+  color: color-mix(in oklab, var(--destructive) 82%, var(--foreground) 18%);
 }
 
 /* Management panel (details/summary) */
@@ -6441,7 +6684,8 @@ main.share-locked-page {
 
 @media (prefers-reduced-motion: reduce) {
   .sl-row,
-  .sl-summary::before {
+  .sl-summary::before,
+  .st-action {
     transition: none;
   }
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -6202,27 +6202,27 @@ main.share-locked-page {
 }
 
 .st-col-name {
-  width: 28%;
+  width: 29%;
 }
 
 .st-col-location {
-  width: 24%;
+  width: 25%;
 }
 
 .st-col-type {
-  width: 12%;
+  width: 11%;
 }
 
 .st-col-expires {
-  width: 16%;
+  width: 15%;
 }
 
 .st-col-status {
-  width: 12%;
+  width: 11%;
 }
 
 .st-col-actions {
-  width: 12%;
+  width: 9%;
 }
 
 .st-th {
@@ -6271,7 +6271,6 @@ main.share-locked-page {
   display: inline-flex;
   align-items: center;
   max-width: 100%;
-  gap: 6px;
   white-space: nowrap;
   font-weight: 600;
 }
@@ -6280,12 +6279,6 @@ main.share-locked-page {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.st-name-lock {
-  flex: 0 0 auto;
-  color: color-mix(in oklab, var(--primary) 62%, var(--muted-foreground) 38%);
-  transform: translateY(0.5px);
 }
 
 .st-location {
@@ -6310,10 +6303,12 @@ main.share-locked-page {
 }
 
 .st-actions {
-  display: flex;
+  display: inline-grid;
+  grid-template-columns: max-content 1fr;
   align-items: center;
-  gap: 6px;
+  column-gap: 8px;
   min-width: 0;
+  width: 100%;
 }
 
 .st-actions {
@@ -6347,6 +6342,16 @@ main.share-locked-page {
 .st-action:disabled {
   color: color-mix(in oklab, var(--muted-foreground) 55%, transparent);
   cursor: not-allowed;
+}
+
+.st-password-hint {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  justify-self: end;
+  width: 16px;
+  height: 16px;
+  color: color-mix(in oklab, var(--primary) 62%, var(--muted-foreground) 38%);
 }
 
 .st-action--danger {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -6297,8 +6297,13 @@ main.share-locked-page {
   font-variant-numeric: tabular-nums;
 }
 
-.st-expires--soon {
-  color: oklch(58% 0.16 52);
+.st-expires--warning {
+  color: color-mix(in oklab, var(--primary) 82%, oklch(76% 0.15 70) 18%);
+  font-weight: 600;
+}
+
+.st-expires--critical {
+  color: oklch(64% 0.22 28);
   font-weight: 600;
 }
 


### PR DESCRIPTION
## 🚀 Summary

Redesigns the `/shared` content area around a dense table view based on the Table mock, while keeping the workspace sidebar and top bar unchanged.

## 📊 Impacts and Changes

- Replaces the split active/inactive shared-link sections with one combined table.
- Adds type filtering, real file-type labels, and a right-aligned new-share entry point to `/files`.
- Moves share management into the reusable share dialog via the row `Manage` action.
- Refines table metadata: route-only locations, password hint placement, relative expiry text, and warning/critical expiry colors.
- Normalizes workspace page title sizing across Files, Recent, Favorites, and Shared.
- No schema, auth, storage, or restore behavior changes.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

Additional checks run:

- [x] `pnpm typecheck` passed
- [x] `pnpm format:check` passed
- [x] `git diff --check` passed

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

- Authenticated browser verification is still needed before marking this ready for review.

## 🔗 Linked Issues

None.
