### PR TITLE
fix(deps): bump qs for security alert

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4884,10 +4884,10 @@ packages:
         integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==,
       }
 
-  qs@6.15.1:
+  qs@6.15.2:
     resolution:
       {
-        integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==,
+        integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==,
       }
     engines: { node: ">=0.6" }
 
@@ -7234,7 +7234,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -7671,7 +7671,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.1
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -8451,7 +8451,7 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 


### PR DESCRIPTION
## 🚀 Summary

Bump the locked `qs` transitive dependency from `6.15.1` to `6.15.2` to address Dependabot alert #2 / GHSA-q8mj-m7cp-5q26.

## 📊 Impacts and Changes

Maintainers: clears the moderate `qs` advisory from `pnpm audit` and the Dependabot alert path through `shadcn` → `@modelcontextprotocol/sdk` → `express`.

Users: no behavior change expected. This is a lockfile-only security patch for a transitive dependency that is not used directly by Staaash app code.

## 🧪 Testing Checklist

- [ ] `pnpm lint` passed
- [ ] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [ ] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

Additional checks run:

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm list qs --recursive --depth 20 --lockfile-only`
- [x] `pnpm audit --json`
- [x] `pnpm format:check`
- [x] `git diff --check`

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

Schema/auth/storage/restore changes: none.

## 🧗 Follow-ups or Limitations

Optional follow-up: consider moving `shadcn` from runtime `dependencies` to `devDependencies`, since it appears to be tooling-only here.

## 🔗 Linked Issues

Resolves Dependabot alert #2.
