### PR TITLE
Improve workspace item actions and deleted-item visibility

### DIFF
--- a/apps/web/app/(workspace)/favorites/favorites-view.tsx
+++ b/apps/web/app/(workspace)/favorites/favorites-view.tsx
@@ -878,6 +878,46 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
       >
         {renderRubberBand()}
 
+        <div
+          className="favorites-toolbar"
+          aria-label="Favorites display controls"
+        >
+          <label className="favorites-filter-control">
+            <span>Type</span>
+            <select
+              value={filterType}
+              onChange={(event) =>
+                setFilterType(event.target.value as FavoriteFilterType)
+              }
+            >
+              {FILTERS.map((filter) => (
+                <option key={filter.id} value={filter.id}>
+                  {filter.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <div className="favorites-view-toggle" aria-label="View mode">
+            <button
+              aria-label="List view"
+              className={viewMode === "list" ? "is-active" : ""}
+              type="button"
+              onClick={() => setViewMode("list")}
+            >
+              <List size={14} aria-hidden />
+            </button>
+            <button
+              aria-label="Grid view"
+              className={viewMode === "grid" ? "is-active" : ""}
+              type="button"
+              onClick={() => setViewMode("grid")}
+            >
+              <Grid2X2 size={14} aria-hidden />
+            </button>
+          </div>
+        </div>
+
         {quickAccessItems.length > 0 ? (
           <section className="favorites-quick-section" aria-labelledby="fav-qa">
             <h2 id="fav-qa" className="favorites-section-eyebrow">
@@ -918,46 +958,6 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
             </div>
           </section>
         ) : null}
-
-        <div
-          className="favorites-toolbar"
-          aria-label="Favorites display controls"
-        >
-          <label className="favorites-filter-control">
-            <span>Type</span>
-            <select
-              value={filterType}
-              onChange={(event) =>
-                setFilterType(event.target.value as FavoriteFilterType)
-              }
-            >
-              {FILTERS.map((filter) => (
-                <option key={filter.id} value={filter.id}>
-                  {filter.label}
-                </option>
-              ))}
-            </select>
-          </label>
-
-          <div className="favorites-view-toggle" aria-label="View mode">
-            <button
-              aria-label="List view"
-              className={viewMode === "list" ? "is-active" : ""}
-              type="button"
-              onClick={() => setViewMode("list")}
-            >
-              <List size={14} aria-hidden />
-            </button>
-            <button
-              aria-label="Grid view"
-              className={viewMode === "grid" ? "is-active" : ""}
-              type="button"
-              onClick={() => setViewMode("grid")}
-            >
-              <Grid2X2 size={14} aria-hidden />
-            </button>
-          </div>
-        </div>
 
         {visibleItems.length === 0 ? (
           <div className="favorites-empty-state">

--- a/apps/web/app/(workspace)/favorites/favorites-view.tsx
+++ b/apps/web/app/(workspace)/favorites/favorites-view.tsx
@@ -7,14 +7,21 @@ import {
   ArrowUp,
   Download,
   ExternalLink,
+  FolderOpen,
   Grid2X2,
   Heart,
   List,
   Pin,
   PinOff,
+  RefreshCw,
 } from "lucide-react";
 
 import { FlashMessage } from "@/app/auth-ui";
+import {
+  DashboardItemContextMenu,
+  DashboardPageContextMenu,
+  type DashboardContextMenuGroup,
+} from "@/app/dashboard-context-menu";
 import { getItemVisual } from "@/app/item-visuals";
 import { ItemTypeIcon } from "@/app/item-type-icon";
 import { startValidatedDownload } from "@/lib/transfers/download";
@@ -359,8 +366,67 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
     );
   };
 
+  const getFavoriteItemContextGroups = (
+    item: FavoriteClientItem,
+  ): DashboardContextMenuGroup[] => {
+    const pinned = item.quickAccessPinnedAt != null;
+
+    return [
+      {
+        actions: [
+          {
+            icon: <ExternalLink size={13} />,
+            label: "Open",
+            shortcut: "↵",
+            onSelect: () => openItem(item),
+          },
+          {
+            icon: <Download size={13} />,
+            label: item.kind === "folder" ? "Download as zip" : "Download",
+            onSelect: () => void downloadItem(item),
+          },
+        ],
+      },
+      {
+        actions: [
+          {
+            icon: pinned ? <PinOff size={13} /> : <Pin size={13} />,
+            label: pinned ? "Remove from quick access" : "Pin to quick access",
+            onSelect: () => void setQuickAccess(item, !pinned),
+          },
+          {
+            destructive: true,
+            icon: <Heart size={13} fill="currentColor" />,
+            label: "Remove from favorites",
+            onSelect: () => void removeFavorite(item),
+          },
+        ],
+      },
+    ];
+  };
+
+  const backgroundMenuGroups: DashboardContextMenuGroup[] = [
+    {
+      actions: [
+        {
+          icon: <RefreshCw size={13} />,
+          label: "Refresh",
+          onSelect: () => startTransition(() => router.refresh()),
+        },
+        {
+          icon: <FolderOpen size={13} />,
+          label: "Open files",
+          onSelect: () => router.push("/files"),
+        },
+      ],
+    },
+  ];
+
   return (
-    <div className="workspace-page favorites-page">
+    <DashboardPageContextMenu
+      className="workspace-page favorites-page"
+      groups={backgroundMenuGroups}
+    >
       <div className="favorites-header">
         <h1>Favorites</h1>
         {activeItems.length > 0 ? (
@@ -384,25 +450,29 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
                 item.kind === "file" ? item.mimeType : null,
               );
               return (
-                <button
-                  className="favorites-quick-card"
+                <DashboardItemContextMenu
+                  groups={getFavoriteItemContextGroups(item)}
                   key={`${item.kind}-${item.id}`}
-                  style={{ background: visual.background }}
-                  type="button"
-                  onClick={() => openItem(item)}
                 >
-                  <span className="favorites-quick-thumb">
-                    <FavoriteIcon item={item} size={18} />
-                  </span>
-                  <span className="favorites-quick-copy">
-                    <span title={item.name}>{item.name}</span>
-                    <small>
-                      {formatFavoriteRelativeTime(
-                        item.quickAccessPinnedAt ?? item.favoritedAt,
-                      )}
-                    </small>
-                  </span>
-                </button>
+                  <button
+                    className="favorites-quick-card"
+                    style={{ background: visual.background }}
+                    type="button"
+                    onClick={() => openItem(item)}
+                  >
+                    <span className="favorites-quick-thumb">
+                      <FavoriteIcon item={item} size={18} />
+                    </span>
+                    <span className="favorites-quick-copy">
+                      <span title={item.name}>{item.name}</span>
+                      <small>
+                        {formatFavoriteRelativeTime(
+                          item.quickAccessPinnedAt ?? item.favoritedAt,
+                        )}
+                      </small>
+                    </span>
+                  </button>
+                </DashboardItemContextMenu>
               );
             })}
           </div>
@@ -480,38 +550,42 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
           </div>
 
           {visibleItems.map((item) => (
-            <article
-              className="favorites-row"
+            <DashboardItemContextMenu
+              groups={getFavoriteItemContextGroups(item)}
               key={`${item.kind}-${item.id}`}
-              onDoubleClick={() => openItem(item)}
             >
-              <span className="favorites-row-thumb">
-                <FavoriteIcon item={item} />
-              </span>
-              <button
-                className="favorites-row-name"
-                title={item.name}
-                type="button"
-                onClick={() => openItem(item)}
+              <article
+                className="favorites-row"
+                onDoubleClick={() => openItem(item)}
               >
-                {item.name}
-              </button>
-              <span
-                className="favorites-row-location"
-                title={item.locationLabel}
-              >
-                {item.locationLabel}
-              </span>
-              <span className="favorites-row-size">
-                {formatFavoriteFileSize(item.sizeBytes)}
-              </span>
-              <span className="favorites-row-time">
-                {formatFavoriteRelativeTime(item.favoritedAt)}
-              </span>
-              <span className="favorites-row-actions">
-                {renderItemActions(item)}
-              </span>
-            </article>
+                <span className="favorites-row-thumb">
+                  <FavoriteIcon item={item} />
+                </span>
+                <button
+                  className="favorites-row-name"
+                  title={item.name}
+                  type="button"
+                  onClick={() => openItem(item)}
+                >
+                  {item.name}
+                </button>
+                <span
+                  className="favorites-row-location"
+                  title={item.locationLabel}
+                >
+                  {item.locationLabel}
+                </span>
+                <span className="favorites-row-size">
+                  {formatFavoriteFileSize(item.sizeBytes)}
+                </span>
+                <span className="favorites-row-time">
+                  {formatFavoriteRelativeTime(item.favoritedAt)}
+                </span>
+                <span className="favorites-row-actions">
+                  {renderItemActions(item)}
+                </span>
+              </article>
+            </DashboardItemContextMenu>
           ))}
         </div>
       ) : (
@@ -522,50 +596,56 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
               item.kind === "file" ? item.mimeType : null,
             );
             return (
-              <article
-                className="favorites-grid-card"
+              <DashboardItemContextMenu
+                groups={getFavoriteItemContextGroups(item)}
                 key={`${item.kind}-${item.id}`}
-                onDoubleClick={() => openItem(item)}
               >
-                <div
-                  className="favorites-grid-preview"
-                  style={{ background: visual.background }}
+                <article
+                  className="favorites-grid-card"
+                  onDoubleClick={() => openItem(item)}
                 >
-                  <FavoriteIcon item={item} size={30} />
-                  <span
-                    className="favorites-type-badge"
-                    style={{
-                      background: visual.background,
-                      color: visual.color,
-                    }}
+                  <div
+                    className="favorites-grid-preview"
+                    style={{ background: visual.background }}
                   >
-                    {getFavoriteType(item) === "all"
-                      ? "FILE"
-                      : getFavoriteType(item).toUpperCase()}
+                    <FavoriteIcon item={item} size={30} />
+                    <span
+                      className="favorites-type-badge"
+                      style={{
+                        background: visual.background,
+                        color: visual.color,
+                      }}
+                    >
+                      {getFavoriteType(item) === "all"
+                        ? "FILE"
+                        : getFavoriteType(item).toUpperCase()}
+                    </span>
+                  </div>
+                  <div className="favorites-grid-body">
+                    <button
+                      className="favorites-grid-name"
+                      title={item.name}
+                      type="button"
+                      onClick={() => openItem(item)}
+                    >
+                      {item.name}
+                    </button>
+                    <span className="favorites-grid-meta">
+                      <span>
+                        {formatFavoriteRelativeTime(item.favoritedAt)}
+                      </span>
+                      <span>{formatFavoriteFileSize(item.sizeBytes)}</span>
+                    </span>
+                  </div>
+                  <span className="favorites-grid-actions">
+                    {renderItemActions(item)}
                   </span>
-                </div>
-                <div className="favorites-grid-body">
-                  <button
-                    className="favorites-grid-name"
-                    title={item.name}
-                    type="button"
-                    onClick={() => openItem(item)}
-                  >
-                    {item.name}
-                  </button>
-                  <span className="favorites-grid-meta">
-                    <span>{formatFavoriteRelativeTime(item.favoritedAt)}</span>
-                    <span>{formatFavoriteFileSize(item.sizeBytes)}</span>
-                  </span>
-                </div>
-                <span className="favorites-grid-actions">
-                  {renderItemActions(item)}
-                </span>
-              </article>
+                </article>
+              </DashboardItemContextMenu>
             );
           })}
         </div>
       )}
-    </div>
+    </DashboardPageContextMenu>
   );
 }

--- a/apps/web/app/(workspace)/favorites/favorites-view.tsx
+++ b/apps/web/app/(workspace)/favorites/favorites-view.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { useEffect, useMemo, useState, useTransition } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+  type KeyboardEvent,
+  type MouseEvent,
+} from "react";
 import { useRouter } from "next/navigation";
 import {
   ArrowDown,
@@ -48,7 +57,15 @@ type FavoritesViewProps = {
   success?: string | null;
 };
 
+type RubberBand = {
+  currentX: number;
+  currentY: number;
+  startX: number;
+  startY: number;
+};
+
 const VIEW_STORAGE_KEY = "staaash:favorites:view";
+const DRAG_THRESHOLD = 5;
 
 const FILTERS: { id: FavoriteFilterType; label: string }[] = [
   { id: "all", label: "All" },
@@ -121,6 +138,18 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
     Record<string, string | null>
   >({});
   const [actionError, setActionError] = useState<string | null>(null);
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
+  const [lastSelectedKey, setLastSelectedKey] = useState<string | null>(null);
+  const [rubberBand, setRubberBand] = useState<RubberBand | null>(null);
+  const didRubberBand = useRef(false);
+  const dragOrigin = useRef<{ onItem: boolean; x: number; y: number } | null>(
+    null,
+  );
+  const isRubberBanding = useRef(false);
+  const listRef = useRef<HTMLDivElement>(null);
+  const rubberBandStart = useRef<{ startX: number; startY: number } | null>(
+    null,
+  );
 
   useEffect(() => {
     const stored = window.localStorage.getItem(VIEW_STORAGE_KEY);
@@ -166,6 +195,34 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
     () => getQuickAccessFavorites(activeItems),
     [activeItems],
   );
+  const visibleKeys = useMemo(
+    () => visibleItems.map((item) => getItemKey(item)),
+    [visibleItems],
+  );
+  const allVisibleSelected =
+    visibleKeys.length > 0 && visibleKeys.every((key) => selectedKeys.has(key));
+  const selectedItems = visibleItems.filter((item) =>
+    selectedKeys.has(getItemKey(item)),
+  );
+  const visibleItemByKey = useMemo(
+    () => new Map(visibleItems.map((item) => [getItemKey(item), item])),
+    [visibleItems],
+  );
+
+  useEffect(() => {
+    setSelectedKeys((current) => {
+      const visibleKeySet = new Set(visibleKeys);
+      const next = new Set(
+        [...current].filter((key) => visibleKeySet.has(key)),
+      );
+      return next.size === current.size ? current : next;
+    });
+  }, [visibleKeys]);
+
+  useEffect(() => {
+    setSelectedKeys(new Set());
+    setLastSelectedKey(null);
+  }, [filterType, viewMode]);
 
   const toggleSort = (key: FavoriteSortKey) => {
     if (sortKey === key) {
@@ -175,6 +232,51 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
 
     setSortKey(key);
     setSortDirection(key === "favoritedAt" || key === "size" ? "desc" : "asc");
+  };
+
+  const clearSelection = () => {
+    setSelectedKeys(new Set());
+    setLastSelectedKey(null);
+  };
+
+  const selectAllVisible = () => {
+    setSelectedKeys((current) => {
+      if (allVisibleSelected) {
+        setLastSelectedKey(null);
+        return new Set();
+      }
+      setLastSelectedKey(visibleKeys.at(-1) ?? null);
+      return new Set([...current, ...visibleKeys]);
+    });
+  };
+
+  const selectItem = (key: string, event: MouseEvent<HTMLElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (event.ctrlKey || event.metaKey) {
+      setSelectedKeys((current) => {
+        const next = new Set(current);
+        if (next.has(key)) next.delete(key);
+        else next.add(key);
+        return next;
+      });
+      setLastSelectedKey(key);
+      return;
+    }
+
+    if (event.shiftKey && lastSelectedKey) {
+      const start = visibleKeys.indexOf(lastSelectedKey);
+      const end = visibleKeys.indexOf(key);
+      if (start >= 0 && end >= 0) {
+        const [from, to] = [Math.min(start, end), Math.max(start, end)];
+        setSelectedKeys(new Set(visibleKeys.slice(from, to + 1)));
+        return;
+      }
+    }
+
+    setSelectedKeys(new Set([key]));
+    setLastSelectedKey(key);
   };
 
   const openItem = (item: FavoriteClientItem) => {
@@ -241,6 +343,58 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
     }
   };
 
+  const removeFavorites = async (targets: FavoriteClientItem[]) => {
+    if (targets.length === 0) return;
+
+    const targetKeys = targets.map(getItemKey);
+    clearSelection();
+    setRemovedKeys((current) => new Set([...current, ...targetKeys]));
+
+    const results = await Promise.allSettled(
+      targets.map(async (item) => {
+        const res = await fetch(getFavoriteEndpoint(item), {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            isFavorite: false,
+            redirectTo: "/favorites",
+          }),
+        });
+
+        if (!res.ok) {
+          const data = (await res.json().catch(() => ({}))) as {
+            error?: string;
+          };
+          throw new Error(
+            data.error ?? `Remove favorite failed (${res.status})`,
+          );
+        }
+      }),
+    );
+
+    const failedKeys = new Set<string>();
+    let removedAny = false;
+
+    results.forEach((result, index) => {
+      if (result.status === "fulfilled") removedAny = true;
+      else failedKeys.add(targetKeys[index]);
+    });
+
+    if (failedKeys.size > 0) {
+      setRemovedKeys((current) => {
+        const next = new Set(current);
+        for (const key of failedKeys) next.delete(key);
+        return next;
+      });
+      setActionError("Some favorites could not be removed.");
+    }
+
+    if (removedAny) startTransition(() => router.refresh());
+  };
+
   const setQuickAccess = async (
     item: FavoriteClientItem,
     quickAccessPinned: boolean,
@@ -287,6 +441,218 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
       );
     }
   };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      clearSelection();
+      return;
+    }
+
+    if (
+      (event.key === "Delete" || event.key === "Backspace") &&
+      selectedItems.length > 0
+    ) {
+      event.preventDefault();
+      void removeFavorites(selectedItems);
+      return;
+    }
+
+    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "a") {
+      event.preventDefault();
+      selectAllVisible();
+      return;
+    }
+
+    if (event.key === "Enter" && selectedItems.length === 1) {
+      event.preventDefault();
+      openItem(selectedItems[0]);
+    }
+  };
+
+  useEffect(() => {
+    const onKey = (event: globalThis.KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (
+        target?.tagName === "INPUT" ||
+        target?.tagName === "TEXTAREA" ||
+        target?.tagName === "SELECT" ||
+        target?.isContentEditable
+      ) {
+        return;
+      }
+
+      if (event.key === "Escape") {
+        clearSelection();
+        return;
+      }
+
+      if (
+        (event.key === "Delete" || event.key === "Backspace") &&
+        selectedItems.length > 0
+      ) {
+        event.preventDefault();
+        void removeFavorites(selectedItems);
+        return;
+      }
+
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "a") {
+        event.preventDefault();
+        selectAllVisible();
+        return;
+      }
+
+      if (event.key === "Enter" && selectedItems.length === 1) {
+        event.preventDefault();
+        openItem(selectedItems[0]);
+      }
+    };
+
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [selectedItems, visibleKeys, allVisibleSelected]);
+
+  const handleFavoritesSurfaceClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (didRubberBand.current) return;
+    const target = event.target as HTMLElement;
+    if (target.closest("button, input, select, textarea")) return;
+
+    const item = target.closest<HTMLElement>("[data-favorite-item]");
+    const key = item?.dataset.favoriteItem;
+    if (key && visibleItemByKey.has(key)) {
+      selectItem(key, event);
+      return;
+    }
+
+    clearSelection();
+  };
+
+  const handleFavoritesMouseDown = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (event.button !== 0) return;
+
+      const target = event.target as HTMLElement;
+      if (target.closest("button, input, select, textarea")) return;
+      if (target.closest(".favorites-toolbar, .favorites-col-head")) return;
+
+      const container = listRef.current;
+      if (!container) return;
+
+      const onItem = Boolean(target.closest("[data-favorite-item]"));
+      const rect = container.getBoundingClientRect();
+      const x = event.clientX - rect.left;
+      const y = event.clientY - rect.top;
+
+      dragOrigin.current = { onItem, x, y };
+
+      if (!onItem) {
+        event.preventDefault();
+        rubberBandStart.current = { startX: x, startY: y };
+        isRubberBanding.current = true;
+        setRubberBand({ startX: x, startY: y, currentX: x, currentY: y });
+        if (!event.shiftKey && !event.ctrlKey && !event.metaKey) {
+          clearSelection();
+        }
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const onMove = (event: globalThis.MouseEvent) => {
+      const container = listRef.current;
+      if (!container) return;
+
+      const rect = container.getBoundingClientRect();
+      const currentX = event.clientX - rect.left;
+      const currentY = event.clientY - rect.top;
+
+      if (!isRubberBanding.current) {
+        const origin = dragOrigin.current;
+        if (!origin?.onItem) return;
+
+        const dist = Math.hypot(currentX - origin.x, currentY - origin.y);
+        if (dist < DRAG_THRESHOLD) return;
+
+        isRubberBanding.current = true;
+        didRubberBand.current = true;
+        rubberBandStart.current = { startX: origin.x, startY: origin.y };
+        setRubberBand({
+          startX: origin.x,
+          startY: origin.y,
+          currentX,
+          currentY,
+        });
+        clearSelection();
+        return;
+      }
+
+      didRubberBand.current = true;
+      const start = rubberBandStart.current;
+      if (!start) return;
+
+      setRubberBand({
+        startX: start.startX,
+        startY: start.startY,
+        currentX,
+        currentY,
+      });
+
+      const selLeft = Math.min(start.startX, currentX);
+      const selTop = Math.min(start.startY, currentY);
+      const selRight = Math.max(start.startX, currentX);
+      const selBottom = Math.max(start.startY, currentY);
+      const next = new Set<string>();
+
+      container
+        .querySelectorAll<HTMLElement>("[data-favorite-item]")
+        .forEach((element) => {
+          const key = element.dataset.favoriteItem;
+          if (!key) return;
+
+          const itemRect = element.getBoundingClientRect();
+          const rowTop = itemRect.top - rect.top;
+          const rowBottom = itemRect.bottom - rect.top;
+          const rowLeft = itemRect.left - rect.left;
+          const rowRight = itemRect.right - rect.left;
+
+          if (
+            !(
+              rowRight < selLeft ||
+              rowLeft > selRight ||
+              rowBottom < selTop ||
+              rowTop > selBottom
+            )
+          ) {
+            next.add(key);
+          }
+        });
+
+      setSelectedKeys(next);
+      setLastSelectedKey(
+        next.size > 0 ? (Array.from(next).at(-1) ?? null) : null,
+      );
+    };
+
+    const onUp = () => {
+      dragOrigin.current = null;
+      if (!isRubberBanding.current) return;
+
+      isRubberBanding.current = false;
+      rubberBandStart.current = null;
+      setRubberBand(null);
+      window.setTimeout(() => {
+        didRubberBand.current = false;
+      }, 0);
+    };
+
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+  }, []);
 
   const renderSortButton = (
     key: FavoriteSortKey,
@@ -370,11 +736,18 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
     item: FavoriteClientItem,
   ): DashboardContextMenuGroup[] => {
     const pinned = item.quickAccessPinnedAt != null;
+    const key = getItemKey(item);
+    const targets =
+      selectedKeys.has(key) && selectedItems.length > 1
+        ? selectedItems
+        : [item];
+    const bulk = targets.length > 1;
 
     return [
       {
         actions: [
           {
+            disabled: bulk,
             icon: <ExternalLink size={13} />,
             label: "Open",
             shortcut: "↵",
@@ -382,14 +755,22 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
           },
           {
             icon: <Download size={13} />,
-            label: item.kind === "folder" ? "Download as zip" : "Download",
-            onSelect: () => void downloadItem(item),
+            label: bulk
+              ? `Download ${targets.length} selected`
+              : item.kind === "folder"
+                ? "Download as zip"
+                : "Download",
+            onSelect: () =>
+              bulk
+                ? void handleDownload(targets.map((target) => target.id))
+                : void downloadItem(item),
           },
         ],
       },
       {
         actions: [
           {
+            disabled: bulk,
             icon: pinned ? <PinOff size={13} /> : <Pin size={13} />,
             label: pinned ? "Remove from quick access" : "Pin to quick access",
             onSelect: () => void setQuickAccess(item, !pinned),
@@ -397,8 +778,10 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
           {
             destructive: true,
             icon: <Heart size={13} fill="currentColor" />,
-            label: "Remove from favorites",
-            onSelect: () => void removeFavorite(item),
+            label: bulk
+              ? `Remove ${targets.length} selected from favorites`
+              : "Remove from favorites",
+            onSelect: () => void removeFavorites(targets),
           },
         ],
       },
@@ -418,19 +801,68 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
           label: "Open files",
           onSelect: () => router.push("/files"),
         },
+        {
+          disabled: visibleKeys.length === 0,
+          label: allVisibleSelected ? "Clear selection" : "Select all",
+          onSelect: selectAllVisible,
+        },
+        {
+          hidden: selectedItems.length === 0 || allVisibleSelected,
+          label: "Clear selection",
+          onSelect: clearSelection,
+        },
+      ],
+    },
+    {
+      actions: [
+        {
+          hidden: selectedItems.length === 0,
+          icon: <Download size={13} />,
+          label: "Download selected",
+          onSelect: () =>
+            void handleDownload(selectedItems.map((item) => item.id)),
+        },
+        {
+          destructive: true,
+          hidden: selectedItems.length === 0,
+          icon: <Heart size={13} fill="currentColor" />,
+          label: "Remove selected from favorites",
+          onSelect: () => void removeFavorites(selectedItems),
+        },
       ],
     },
   ];
+
+  const renderRubberBand = () =>
+    rubberBand ? (
+      <div
+        className="rubber-band-rect"
+        style={{
+          left: Math.min(rubberBand.startX, rubberBand.currentX),
+          top: Math.min(rubberBand.startY, rubberBand.currentY),
+          width: Math.abs(rubberBand.currentX - rubberBand.startX),
+          height: Math.abs(rubberBand.currentY - rubberBand.startY),
+        }}
+        aria-hidden
+      />
+    ) : null;
 
   return (
     <DashboardPageContextMenu
       className="workspace-page favorites-page"
       groups={backgroundMenuGroups}
+      tabIndex={-1}
+      onKeyDown={handleKeyDown}
     >
       <div className="favorites-header">
         <h1>Favorites</h1>
         {activeItems.length > 0 ? (
           <span className="section-count">{activeItems.length}</span>
+        ) : null}
+        {selectedItems.length > 0 ? (
+          <span className="selection-badge">
+            {selectedItems.length} selected
+          </span>
         ) : null}
       </div>
 
@@ -438,13 +870,173 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
       {success ? <FlashMessage tone="success">{success}</FlashMessage> : null}
       {actionError ? <FlashMessage>{actionError}</FlashMessage> : null}
 
-      {quickAccessItems.length > 0 ? (
-        <section className="favorites-quick-section" aria-labelledby="fav-qa">
-          <h2 id="fav-qa" className="favorites-section-eyebrow">
-            Quick access
-          </h2>
-          <div className="favorites-quick-grid">
-            {quickAccessItems.map((item) => {
+      <div
+        ref={listRef}
+        className="favorites-selection-surface"
+        onClickCapture={handleFavoritesSurfaceClick}
+        onMouseDownCapture={handleFavoritesMouseDown}
+      >
+        {renderRubberBand()}
+
+        {quickAccessItems.length > 0 ? (
+          <section className="favorites-quick-section" aria-labelledby="fav-qa">
+            <h2 id="fav-qa" className="favorites-section-eyebrow">
+              Quick access
+            </h2>
+            <div className="favorites-quick-grid">
+              {quickAccessItems.map((item) => {
+                const visual = getItemVisual(
+                  item.kind,
+                  item.kind === "file" ? item.mimeType : null,
+                );
+                return (
+                  <DashboardItemContextMenu
+                    groups={getFavoriteItemContextGroups(item)}
+                    key={`${item.kind}-${item.id}`}
+                  >
+                    <button
+                      className="favorites-quick-card"
+                      style={{ background: visual.background }}
+                      type="button"
+                      onClick={() => openItem(item)}
+                    >
+                      <span className="favorites-quick-thumb">
+                        <FavoriteIcon item={item} size={18} />
+                      </span>
+                      <span className="favorites-quick-copy">
+                        <span title={item.name}>{item.name}</span>
+                        <small>
+                          {formatFavoriteRelativeTime(
+                            item.quickAccessPinnedAt ?? item.favoritedAt,
+                          )}
+                        </small>
+                      </span>
+                    </button>
+                  </DashboardItemContextMenu>
+                );
+              })}
+            </div>
+          </section>
+        ) : null}
+
+        <div
+          className="favorites-toolbar"
+          aria-label="Favorites display controls"
+        >
+          <label className="favorites-filter-control">
+            <span>Type</span>
+            <select
+              value={filterType}
+              onChange={(event) =>
+                setFilterType(event.target.value as FavoriteFilterType)
+              }
+            >
+              {FILTERS.map((filter) => (
+                <option key={filter.id} value={filter.id}>
+                  {filter.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <div className="favorites-view-toggle" aria-label="View mode">
+            <button
+              aria-label="List view"
+              className={viewMode === "list" ? "is-active" : ""}
+              type="button"
+              onClick={() => setViewMode("list")}
+            >
+              <List size={14} aria-hidden />
+            </button>
+            <button
+              aria-label="Grid view"
+              className={viewMode === "grid" ? "is-active" : ""}
+              type="button"
+              onClick={() => setViewMode("grid")}
+            >
+              <Grid2X2 size={14} aria-hidden />
+            </button>
+          </div>
+        </div>
+
+        {visibleItems.length === 0 ? (
+          <div className="favorites-empty-state">
+            <span className="favorites-empty-icon">
+              <Heart size={26} aria-hidden />
+            </span>
+            <p>
+              {activeItems.length === 0
+                ? "No favorites yet"
+                : "No favorites match that filter"}
+            </p>
+            <span>
+              {activeItems.length === 0
+                ? "Add favorites from files, search, or recent views. Pin favorites here for quick access."
+                : "Try a different type."}
+            </span>
+          </div>
+        ) : viewMode === "list" ? (
+          <div className="favorites-list-wrap">
+            <div
+              className="favorites-col-head"
+              role="row"
+              aria-label="Favorites columns"
+            >
+              <span aria-hidden />
+              {renderSortButton("name", "Name")}
+              {renderSortButton("path", "Location")}
+              {renderSortButton("size", "Size", "right")}
+              {renderSortButton("favoritedAt", "Added", "right")}
+            </div>
+
+            {visibleItems.map((item) => {
+              const key = getItemKey(item);
+              const selected = selectedKeys.has(key);
+
+              return (
+                <DashboardItemContextMenu
+                  groups={getFavoriteItemContextGroups(item)}
+                  key={key}
+                >
+                  <article
+                    data-favorite-item={key}
+                    className={`favorites-row${selected ? " is-selected" : ""}`}
+                    onDoubleClick={(event) => {
+                      event.stopPropagation();
+                      openItem(item);
+                    }}
+                  >
+                    <span className="favorites-row-thumb">
+                      <FavoriteIcon item={item} />
+                    </span>
+                    <span className="favorites-row-name" title={item.name}>
+                      {item.name}
+                    </span>
+                    <span
+                      className="favorites-row-location"
+                      title={item.locationLabel}
+                    >
+                      {item.locationLabel}
+                    </span>
+                    <span className="favorites-row-size">
+                      {formatFavoriteFileSize(item.sizeBytes)}
+                    </span>
+                    <span className="favorites-row-time">
+                      {formatFavoriteRelativeTime(item.favoritedAt)}
+                    </span>
+                    <span className="favorites-row-actions">
+                      {renderItemActions(item)}
+                    </span>
+                  </article>
+                </DashboardItemContextMenu>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="favorites-grid-cards">
+            {visibleItems.map((item) => {
+              const key = getItemKey(item);
+              const selected = selectedKeys.has(key);
               const visual = getItemVisual(
                 item.kind,
                 item.kind === "file" ? item.mimeType : null,
@@ -452,200 +1044,54 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
               return (
                 <DashboardItemContextMenu
                   groups={getFavoriteItemContextGroups(item)}
-                  key={`${item.kind}-${item.id}`}
+                  key={key}
                 >
-                  <button
-                    className="favorites-quick-card"
-                    style={{ background: visual.background }}
-                    type="button"
-                    onClick={() => openItem(item)}
+                  <article
+                    data-favorite-item={key}
+                    className={`favorites-grid-card${selected ? " is-selected" : ""}`}
+                    onDoubleClick={(event) => {
+                      event.stopPropagation();
+                      openItem(item);
+                    }}
                   >
-                    <span className="favorites-quick-thumb">
-                      <FavoriteIcon item={item} size={18} />
+                    <div
+                      className="favorites-grid-preview"
+                      style={{ background: visual.background }}
+                    >
+                      <FavoriteIcon item={item} size={30} />
+                      <span
+                        className="favorites-type-badge"
+                        style={{
+                          background: visual.background,
+                          color: visual.color,
+                        }}
+                      >
+                        {getFavoriteType(item) === "all"
+                          ? "FILE"
+                          : getFavoriteType(item).toUpperCase()}
+                      </span>
+                    </div>
+                    <div className="favorites-grid-body">
+                      <span className="favorites-grid-name" title={item.name}>
+                        {item.name}
+                      </span>
+                      <span className="favorites-grid-meta">
+                        <span>
+                          {formatFavoriteRelativeTime(item.favoritedAt)}
+                        </span>
+                        <span>{formatFavoriteFileSize(item.sizeBytes)}</span>
+                      </span>
+                    </div>
+                    <span className="favorites-grid-actions">
+                      {renderItemActions(item)}
                     </span>
-                    <span className="favorites-quick-copy">
-                      <span title={item.name}>{item.name}</span>
-                      <small>
-                        {formatFavoriteRelativeTime(
-                          item.quickAccessPinnedAt ?? item.favoritedAt,
-                        )}
-                      </small>
-                    </span>
-                  </button>
+                  </article>
                 </DashboardItemContextMenu>
               );
             })}
           </div>
-        </section>
-      ) : null}
-
-      <div
-        className="favorites-toolbar"
-        aria-label="Favorites display controls"
-      >
-        <label className="favorites-filter-control">
-          <span>Type</span>
-          <select
-            value={filterType}
-            onChange={(event) =>
-              setFilterType(event.target.value as FavoriteFilterType)
-            }
-          >
-            {FILTERS.map((filter) => (
-              <option key={filter.id} value={filter.id}>
-                {filter.label}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <div className="favorites-view-toggle" aria-label="View mode">
-          <button
-            aria-label="List view"
-            className={viewMode === "list" ? "is-active" : ""}
-            type="button"
-            onClick={() => setViewMode("list")}
-          >
-            <List size={14} aria-hidden />
-          </button>
-          <button
-            aria-label="Grid view"
-            className={viewMode === "grid" ? "is-active" : ""}
-            type="button"
-            onClick={() => setViewMode("grid")}
-          >
-            <Grid2X2 size={14} aria-hidden />
-          </button>
-        </div>
+        )}
       </div>
-
-      {visibleItems.length === 0 ? (
-        <div className="favorites-empty-state">
-          <span className="favorites-empty-icon">
-            <Heart size={26} aria-hidden />
-          </span>
-          <p>
-            {activeItems.length === 0
-              ? "No favorites yet"
-              : "No favorites match that filter"}
-          </p>
-          <span>
-            {activeItems.length === 0
-              ? "Add favorites from files, search, or recent views. Pin favorites here for quick access."
-              : "Try a different type."}
-          </span>
-        </div>
-      ) : viewMode === "list" ? (
-        <div className="favorites-list-wrap">
-          <div
-            className="favorites-col-head"
-            role="row"
-            aria-label="Favorites columns"
-          >
-            <span aria-hidden />
-            {renderSortButton("name", "Name")}
-            {renderSortButton("path", "Location")}
-            {renderSortButton("size", "Size", "right")}
-            {renderSortButton("favoritedAt", "Added", "right")}
-          </div>
-
-          {visibleItems.map((item) => (
-            <DashboardItemContextMenu
-              groups={getFavoriteItemContextGroups(item)}
-              key={`${item.kind}-${item.id}`}
-            >
-              <article
-                className="favorites-row"
-                onDoubleClick={() => openItem(item)}
-              >
-                <span className="favorites-row-thumb">
-                  <FavoriteIcon item={item} />
-                </span>
-                <button
-                  className="favorites-row-name"
-                  title={item.name}
-                  type="button"
-                  onClick={() => openItem(item)}
-                >
-                  {item.name}
-                </button>
-                <span
-                  className="favorites-row-location"
-                  title={item.locationLabel}
-                >
-                  {item.locationLabel}
-                </span>
-                <span className="favorites-row-size">
-                  {formatFavoriteFileSize(item.sizeBytes)}
-                </span>
-                <span className="favorites-row-time">
-                  {formatFavoriteRelativeTime(item.favoritedAt)}
-                </span>
-                <span className="favorites-row-actions">
-                  {renderItemActions(item)}
-                </span>
-              </article>
-            </DashboardItemContextMenu>
-          ))}
-        </div>
-      ) : (
-        <div className="favorites-grid-cards">
-          {visibleItems.map((item) => {
-            const visual = getItemVisual(
-              item.kind,
-              item.kind === "file" ? item.mimeType : null,
-            );
-            return (
-              <DashboardItemContextMenu
-                groups={getFavoriteItemContextGroups(item)}
-                key={`${item.kind}-${item.id}`}
-              >
-                <article
-                  className="favorites-grid-card"
-                  onDoubleClick={() => openItem(item)}
-                >
-                  <div
-                    className="favorites-grid-preview"
-                    style={{ background: visual.background }}
-                  >
-                    <FavoriteIcon item={item} size={30} />
-                    <span
-                      className="favorites-type-badge"
-                      style={{
-                        background: visual.background,
-                        color: visual.color,
-                      }}
-                    >
-                      {getFavoriteType(item) === "all"
-                        ? "FILE"
-                        : getFavoriteType(item).toUpperCase()}
-                    </span>
-                  </div>
-                  <div className="favorites-grid-body">
-                    <button
-                      className="favorites-grid-name"
-                      title={item.name}
-                      type="button"
-                      onClick={() => openItem(item)}
-                    >
-                      {item.name}
-                    </button>
-                    <span className="favorites-grid-meta">
-                      <span>
-                        {formatFavoriteRelativeTime(item.favoritedAt)}
-                      </span>
-                      <span>{formatFavoriteFileSize(item.sizeBytes)}</span>
-                    </span>
-                  </div>
-                  <span className="favorites-grid-actions">
-                    {renderItemActions(item)}
-                  </span>
-                </article>
-              </DashboardItemContextMenu>
-            );
-          })}
-        </div>
-      )}
     </DashboardPageContextMenu>
   );
 }

--- a/apps/web/app/(workspace)/files/files-row.tsx
+++ b/apps/web/app/(workspace)/files/files-row.tsx
@@ -16,17 +16,7 @@ import {
 
 import { getItemVisual } from "@/app/item-visuals";
 import { ItemTypeIcon } from "@/app/item-type-icon";
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuSeparator,
-  ContextMenuShortcut,
-  ContextMenuSub,
-  ContextMenuSubContent,
-  ContextMenuSubTrigger,
-  ContextMenuTrigger,
-} from "@/components/ui/context-menu";
+import { DashboardItemContextMenu } from "@/app/dashboard-context-menu";
 import { formatDateTime } from "@/app/auth-ui";
 import type { FileSummary, FolderSummary } from "@/server/files/types";
 import type { ShareLinkSummary } from "@/server/sharing";
@@ -200,162 +190,166 @@ export function FilesRow(props: FilesRowProps) {
     : null;
 
   return (
-    <ContextMenu>
-      <ContextMenuTrigger>
-        <div
-          ref={rowRef}
-          data-file-row={props.data.id}
-          className={rowClasses}
-          onClick={onClick}
-          onDoubleClick={onOpen}
-          role="row"
-          aria-selected={isSelected}
-          tabIndex={isSelected ? 0 : -1}
-        >
-          {/* Icon */}
-          <div className="explorer-row-icon">
-            <ItemTypeIcon
-              icon={props.kind === "folder" ? IconComponent : undefined}
-              size={16}
-              visual={visual}
-            />
-          </div>
-
-          {/* Name */}
-          <div className="explorer-row-name-cell">
-            {isRenaming ? (
-              <input
-                ref={renameInputRef}
-                className="explorer-row-rename"
-                value={renameValue}
-                autoFocus
-                onChange={(e) => onRenameChange(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    onRenameSubmit();
-                  }
-                  if (e.key === "Escape") {
-                    e.preventDefault();
-                    onRenameCancel();
-                  }
-                  // Stop propagation so row keyboard handlers don't fire
-                  e.stopPropagation();
-                }}
-                onBlur={onRenameSubmit}
-                onClick={(e) => e.stopPropagation()}
-              />
-            ) : (
-              <>
-                <span className="explorer-row-name" title={name}>
-                  {name}
-                </span>
-                {shareProps.share?.status === "active" && (
-                  <Share2
-                    size={10}
-                    className="explorer-row-share-badge"
-                    aria-label="Shared"
-                  />
-                )}
-              </>
-            )}
-          </div>
-
-          {/* Size */}
-          <span className="explorer-row-meta">{size}</span>
-
-          {/* Date */}
-          <span className="explorer-row-meta" suppressHydrationWarning>
-            {date}
-          </span>
+    <DashboardItemContextMenu
+      groups={[
+        {
+          actions: [
+            {
+              label:
+                props.kind === "folder"
+                  ? "Open"
+                  : props.data.viewerKind
+                    ? "Open"
+                    : "Download",
+              shortcut: "↵",
+              onSelect: onOpen,
+            },
+            {
+              hidden: !(
+                isMultiSelected ||
+                props.kind === "folder" ||
+                props.data.viewerKind
+              ),
+              label: isMultiSelected
+                ? `Download ${selectedCount} items as zip`
+                : props.kind === "folder"
+                  ? "Download as zip"
+                  : "Download",
+              onSelect: onDownload,
+            },
+          ],
+        },
+        {
+          actions: [
+            {
+              disabled: isMultiSelected,
+              label: "Rename",
+              shortcut: "F2",
+              onSelect: onStartRename,
+            },
+            {
+              label: isFavorite
+                ? "Remove from favourites"
+                : "Add to favourites",
+              onSelect: onFavorite,
+            },
+            {
+              label: shareLabel ? "Share — manage link" : "Share",
+              onSelect: shareProps.onShare,
+            },
+            {
+              hidden: props.kind !== "folder",
+              label: "Change icon…",
+              onSelect: onProperties,
+            },
+            {
+              label: "Properties",
+              onSelect: onProperties,
+            },
+          ],
+        },
+        {
+          actions: [
+            {
+              label: isMultiSelected ? `Cut ${selectedCount} items` : "Cut",
+              shortcut: "⌘X",
+              onSelect: onCut,
+            },
+            availableMoveTargets.length > 0
+              ? {
+                  label: "Move to…",
+                  subActions: availableMoveTargets.map((target) => ({
+                    label: target.pathLabel,
+                    onSelect: () => onMoveTo(target.id),
+                  })),
+                }
+              : {
+                  disabled: true,
+                  label: "Move to…",
+                },
+          ],
+        },
+        {
+          actions: [
+            {
+              destructive: true,
+              label: isMultiSelected
+                ? `Move ${selectedCount} items to trash`
+                : "Move to trash",
+              shortcut: "Del",
+              onSelect: onTrash,
+            },
+          ],
+        },
+      ]}
+    >
+      <div
+        ref={rowRef}
+        data-file-row={props.data.id}
+        className={rowClasses}
+        onClick={onClick}
+        onDoubleClick={onOpen}
+        role="row"
+        aria-selected={isSelected}
+        tabIndex={isSelected ? 0 : -1}
+      >
+        {/* Icon */}
+        <div className="explorer-row-icon">
+          <ItemTypeIcon
+            icon={props.kind === "folder" ? IconComponent : undefined}
+            size={16}
+            visual={visual}
+          />
         </div>
-      </ContextMenuTrigger>
 
-      {/* ---- Context menu ---- */}
-      <ContextMenuContent>
-        {/* Group 1 — primary action */}
-        <ContextMenuItem onClick={onOpen}>
-          {props.kind === "folder"
-            ? "Open"
-            : props.data.viewerKind
-              ? "Open"
-              : "Download"}
-          <ContextMenuShortcut>↵</ContextMenuShortcut>
-        </ContextMenuItem>
+        {/* Name */}
+        <div className="explorer-row-name-cell">
+          {isRenaming ? (
+            <input
+              ref={renameInputRef}
+              className="explorer-row-rename"
+              value={renameValue}
+              autoFocus
+              onChange={(e) => onRenameChange(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  onRenameSubmit();
+                }
+                if (e.key === "Escape") {
+                  e.preventDefault();
+                  onRenameCancel();
+                }
+                // Stop propagation so row keyboard handlers don't fire
+                e.stopPropagation();
+              }}
+              onBlur={onRenameSubmit}
+              onClick={(e) => e.stopPropagation()}
+            />
+          ) : (
+            <>
+              <span className="explorer-row-name" title={name}>
+                {name}
+              </span>
+              {shareProps.share?.status === "active" && (
+                <Share2
+                  size={10}
+                  className="explorer-row-share-badge"
+                  aria-label="Shared"
+                />
+              )}
+            </>
+          )}
+        </div>
 
-        {isMultiSelected ? (
-          <ContextMenuItem onClick={onDownload}>
-            {`Download ${selectedCount} items as zip`}
-          </ContextMenuItem>
-        ) : props.kind === "folder" ? (
-          <ContextMenuItem onClick={onDownload}>
-            Download as zip
-          </ContextMenuItem>
-        ) : props.data.viewerKind ? (
-          <ContextMenuItem onClick={onDownload}>Download</ContextMenuItem>
-        ) : null}
+        {/* Size */}
+        <span className="explorer-row-meta">{size}</span>
 
-        <ContextMenuSeparator />
-
-        {/* Group 2 — item management */}
-        <ContextMenuItem onClick={onStartRename} disabled={isMultiSelected}>
-          Rename
-          <ContextMenuShortcut>F2</ContextMenuShortcut>
-        </ContextMenuItem>
-
-        <ContextMenuItem onClick={onFavorite}>
-          {isFavorite ? "Remove from favourites" : "Add to favourites"}
-        </ContextMenuItem>
-
-        {shareLabel ? (
-          <ContextMenuItem onClick={shareProps.onShare}>
-            Share — manage link
-          </ContextMenuItem>
-        ) : (
-          <ContextMenuItem onClick={shareProps.onShare}>Share</ContextMenuItem>
-        )}
-
-        {props.kind === "folder" && (
-          <ContextMenuItem onClick={onProperties}>Change icon…</ContextMenuItem>
-        )}
-
-        <ContextMenuItem onClick={onProperties}>Properties</ContextMenuItem>
-
-        <ContextMenuSeparator />
-
-        {/* Group 3 — clipboard and destructive */}
-        <ContextMenuItem onClick={onCut}>
-          {isMultiSelected ? `Cut ${selectedCount} items` : "Cut"}
-          <ContextMenuShortcut>⌘X</ContextMenuShortcut>
-        </ContextMenuItem>
-
-        {availableMoveTargets.length > 0 ? (
-          <ContextMenuSub>
-            <ContextMenuSubTrigger>Move to…</ContextMenuSubTrigger>
-            <ContextMenuSubContent>
-              {availableMoveTargets.map((target) => (
-                <ContextMenuItem
-                  key={target.id}
-                  onClick={() => onMoveTo(target.id)}
-                >
-                  {target.pathLabel}
-                </ContextMenuItem>
-              ))}
-            </ContextMenuSubContent>
-          </ContextMenuSub>
-        ) : (
-          <ContextMenuItem disabled>Move to…</ContextMenuItem>
-        )}
-
-        <ContextMenuSeparator />
-
-        <ContextMenuItem variant="destructive" onClick={onTrash}>
-          {isMultiSelected
-            ? `Move ${selectedCount} items to trash`
-            : "Move to trash"}
-          <ContextMenuShortcut>Del</ContextMenuShortcut>
-        </ContextMenuItem>
-      </ContextMenuContent>
-    </ContextMenu>
+        {/* Date */}
+        <span className="explorer-row-meta" suppressHydrationWarning>
+          {date}
+        </span>
+      </div>
+    </DashboardItemContextMenu>
   );
 }

--- a/apps/web/app/(workspace)/files/files-view.tsx
+++ b/apps/web/app/(workspace)/files/files-view.tsx
@@ -755,6 +755,7 @@ export function FilesView({
       const start = rubberBandStart.current;
       if (!start) return;
 
+      didRubberBand.current = true;
       setRubberBand({
         startX: start.startX,
         startY: start.startY,
@@ -768,24 +769,33 @@ export function FilesView({
       const selBottom = Math.max(start.startY, currentY);
 
       const next = new Set<string>();
-      rowRefs.current.forEach((el, id) => {
-        const r = el.getBoundingClientRect();
-        const rowTop = r.top - rect.top;
-        const rowBottom = r.bottom - rect.top;
-        const rowLeft = r.left - rect.left;
-        const rowRight = r.right - rect.left;
-        if (
-          !(
-            rowRight < selLeft ||
-            rowLeft > selRight ||
-            rowBottom < selTop ||
-            rowTop > selBottom
-          )
-        ) {
-          next.add(id);
-        }
-      });
+      container
+        .querySelectorAll<HTMLElement>("[data-file-row]")
+        .forEach((el) => {
+          const id = el.dataset.fileRow;
+          if (!id) return;
+
+          const rowRect = el.getBoundingClientRect();
+          const rowTop = rowRect.top - rect.top;
+          const rowBottom = rowRect.bottom - rect.top;
+          const rowLeft = rowRect.left - rect.left;
+          const rowRight = rowRect.right - rect.left;
+
+          if (
+            !(
+              rowRight < selLeft ||
+              rowLeft > selRight ||
+              rowBottom < selTop ||
+              rowTop > selBottom
+            )
+          ) {
+            next.add(id);
+          }
+        });
       setSelectedIds(next);
+      setLastSelectedId(
+        next.size > 0 ? (Array.from(next).at(-1) ?? null) : null,
+      );
     };
 
     const onUp = () => {

--- a/apps/web/app/(workspace)/files/files-view.tsx
+++ b/apps/web/app/(workspace)/files/files-view.tsx
@@ -4,11 +4,9 @@ import {
   startTransition,
   useCallback,
   useEffect,
-  useLayoutEffect,
   useRef,
   useState,
 } from "react";
-import { createPortal } from "react-dom";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { Download, FolderPlus, RefreshCw, Upload } from "lucide-react";
@@ -21,6 +19,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { FlashMessage } from "@/app/auth-ui";
+import { DashboardPageContextMenu } from "@/app/dashboard-context-menu";
 import { startValidatedDownload } from "@/lib/transfers/download";
 import type { FilesListing } from "@/server/files/types";
 import type { ShareFilesLookup } from "@/server/sharing";
@@ -221,12 +220,6 @@ export function FilesView({
   // ---- New folder popover ----
   const [newFolderOpen, setNewFolderOpen] = useState(false);
   const [newFolderName, setNewFolderName] = useState("");
-
-  // ---- Background context menu (right-click on empty space) ----
-  const [bgCtxMenu, setBgCtxMenu] = useState<{ x: number; y: number } | null>(
-    null,
-  );
-  const bgCtxMenuRef = useRef<HTMLDivElement>(null);
 
   // ---- Flash messages ----
   const error =
@@ -442,38 +435,6 @@ export function FilesView({
     return () => document.removeEventListener("keydown", onKey);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allItems, selectedIds, cutItems, lastSelectedId, showShortcutLegend]);
-
-  // Close background context menu on any pointer-down outside it, or Escape.
-  useEffect(() => {
-    if (!bgCtxMenu) return;
-    const close = () => setBgCtxMenu(null);
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") close();
-    };
-    window.addEventListener("pointerdown", close);
-    window.addEventListener("keydown", onKey);
-    return () => {
-      window.removeEventListener("pointerdown", close);
-      window.removeEventListener("keydown", onKey);
-    };
-  }, [bgCtxMenu]);
-
-  // Clamp background context menu to the viewport.
-  // useLayoutEffect fires before paint so there is no visible flicker —
-  // the user only ever sees the corrected position.
-  useLayoutEffect(() => {
-    if (!bgCtxMenu || !bgCtxMenuRef.current) return;
-    const el = bgCtxMenuRef.current;
-    const { width, height } = el.getBoundingClientRect();
-    const pad = 8;
-    const vw = window.innerWidth;
-    const vh = window.innerHeight;
-    const x = Math.max(pad, Math.min(bgCtxMenu.x, vw - width - pad));
-    const y = Math.max(pad, Math.min(bgCtxMenu.y, vh - height - pad));
-    if (x !== bgCtxMenu.x || y !== bgCtxMenu.y) {
-      setBgCtxMenu({ x, y });
-    }
-  }, [bgCtxMenu]);
 
   // ---------------------------------------------------------------------------
   // Item actions
@@ -907,6 +868,79 @@ export function FilesView({
     return na.localeCompare(nb, undefined, { sensitivity: "base" });
   });
 
+  const cutSelectedItems = () => {
+    const items = allItems.filter((item) => selectedIds.has(item.id));
+    const cut = items.map((item) => {
+      const data =
+        item.kind === "folder"
+          ? listing.childFolders.find((folder) => folder.id === item.id)
+          : listing.files.find((file) => file.id === item.id);
+      return { id: item.id, kind: item.kind, name: data?.name ?? "" };
+    });
+    setCutItems(cut);
+    persistCutItems(cut);
+  };
+
+  const backgroundMenuGroups = [
+    {
+      actions: [
+        {
+          icon: <FolderPlus size={13} />,
+          label: "New folder",
+          onSelect: () => setNewFolderOpen(true),
+        },
+        {
+          icon: <Upload size={13} />,
+          label: "Upload files",
+          onSelect: () => fileInputRef.current?.click(),
+        },
+        {
+          icon: <RefreshCw size={13} />,
+          label: "Refresh",
+          onSelect: () => startTransition(() => router.refresh()),
+        },
+      ],
+    },
+    {
+      actions: [
+        {
+          hidden: cutItems.length === 0,
+          label: `Paste ${cutItems.length} item${cutItems.length !== 1 ? "s" : ""}`,
+          shortcut: "⌘V",
+          onSelect: handlePaste,
+        },
+        {
+          label: "Select all",
+          onSelect: () =>
+            setSelectedIds(new Set(allItems.map((item) => item.id))),
+        },
+      ],
+    },
+    {
+      actions: [
+        {
+          hidden: selectedIds.size === 0,
+          icon: <Download size={13} />,
+          label: `Download ${selectedIds.size} item${selectedIds.size !== 1 ? "s" : ""} as zip`,
+          onSelect: () => handleDownload(Array.from(selectedIdsRef.current)),
+        },
+        {
+          hidden: selectedIds.size === 0,
+          label: `Cut ${selectedIds.size} item${selectedIds.size !== 1 ? "s" : ""}`,
+          shortcut: "⌘X",
+          onSelect: cutSelectedItems,
+        },
+        {
+          destructive: true,
+          hidden: selectedIds.size === 0,
+          label: "Move to trash",
+          shortcut: "Del",
+          onSelect: handleTrashSelected,
+        },
+      ],
+    },
+  ];
+
   // ---------------------------------------------------------------------------
   // Render
   // ---------------------------------------------------------------------------
@@ -919,18 +953,11 @@ export function FilesView({
         {success ? <FlashMessage tone="success">{success}</FlashMessage> : null}
         {trashError ? <FlashMessage>{trashError}</FlashMessage> : null}
 
-        <div
+        <DashboardPageContextMenu
           className="explorer-root"
+          groups={backgroundMenuGroups}
+          ignoreSelector=".explorer-header"
           onMouseDown={handleListMouseDown}
-          onContextMenu={(e) => {
-            // Radix's ContextMenuTrigger calls e.preventDefault() synchronously,
-            // so if a row context menu already handled this event, skip.
-            if (e.defaultPrevented) return;
-            // Don't capture right-clicks on the header toolbar
-            if ((e.target as HTMLElement).closest(".explorer-header")) return;
-            e.preventDefault();
-            setBgCtxMenu({ x: e.clientX, y: e.clientY });
-          }}
           onDragEnter={handleDragEnter}
           onDragLeave={handleDragLeave}
           onDragOver={handleDragOver}
@@ -1331,7 +1358,7 @@ export function FilesView({
               </div>
             </div>
           )}
-        </div>
+        </DashboardPageContextMenu>
 
         {/* ---- Properties panel ---- */}
         <FilesPropertiesPanel
@@ -1371,119 +1398,6 @@ export function FilesView({
           <ShortcutLegend onClose={() => setShowShortcutLegend(false)} />
         )}
       </div>
-
-      {/* ---- Background context menu (right-click on empty space) ---- */}
-      {bgCtxMenu &&
-        createPortal(
-          <div
-            ref={bgCtxMenuRef}
-            className="bg-ctx-menu"
-            style={{ top: bgCtxMenu.y, left: bgCtxMenu.x }}
-            onPointerDown={(e) => e.stopPropagation()}
-          >
-            <button
-              className="bg-ctx-item"
-              onClick={() => {
-                setNewFolderOpen(true);
-                setBgCtxMenu(null);
-              }}
-            >
-              <FolderPlus size={13} />
-              New folder
-            </button>
-            <button
-              className="bg-ctx-item"
-              onClick={() => {
-                fileInputRef.current?.click();
-                setBgCtxMenu(null);
-              }}
-            >
-              <Upload size={13} />
-              Upload files
-            </button>
-            <button
-              className="bg-ctx-item"
-              onClick={() => {
-                setBgCtxMenu(null);
-                startTransition(() => {
-                  router.refresh();
-                });
-              }}
-            >
-              <RefreshCw size={13} />
-              Refresh
-            </button>
-            <div className="bg-ctx-sep" />
-            {cutItems.length > 0 && (
-              <button
-                className="bg-ctx-item"
-                onClick={() => {
-                  handlePaste();
-                  setBgCtxMenu(null);
-                }}
-              >
-                Paste {cutItems.length} item{cutItems.length !== 1 ? "s" : ""}
-                <span className="bg-ctx-shortcut">⌘V</span>
-              </button>
-            )}
-            <button
-              className="bg-ctx-item"
-              onClick={() => {
-                setSelectedIds(new Set(allItems.map((i) => i.id)));
-                setBgCtxMenu(null);
-              }}
-            >
-              Select all
-              <span className="bg-ctx-shortcut">⌘A</span>
-            </button>
-            {selectedIds.size > 0 && (
-              <>
-                <div className="bg-ctx-sep" />
-                <button
-                  className="bg-ctx-item"
-                  onClick={() => {
-                    handleDownload(Array.from(selectedIdsRef.current));
-                    setBgCtxMenu(null);
-                  }}
-                >
-                  <Download size={13} />
-                  Download {selectedIds.size} item
-                  {selectedIds.size !== 1 ? "s" : ""} as zip
-                </button>
-                <button
-                  className="bg-ctx-item"
-                  onClick={() => {
-                    const items = allItems.filter((i) => selectedIds.has(i.id));
-                    const cut = items.map((i) => {
-                      const data =
-                        i.kind === "folder"
-                          ? listing.childFolders.find((f) => f.id === i.id)
-                          : listing.files.find((f) => f.id === i.id);
-                      return { id: i.id, kind: i.kind, name: data?.name ?? "" };
-                    });
-                    setCutItems(cut);
-                    persistCutItems(cut);
-                    setBgCtxMenu(null);
-                  }}
-                >
-                  Cut {selectedIds.size} item{selectedIds.size !== 1 ? "s" : ""}
-                  <span className="bg-ctx-shortcut">⌘X</span>
-                </button>
-                <button
-                  className="bg-ctx-item bg-ctx-item--danger"
-                  onClick={() => {
-                    handleTrashSelected();
-                    setBgCtxMenu(null);
-                  }}
-                >
-                  Move to trash
-                  <span className="bg-ctx-shortcut">Del</span>
-                </button>
-              </>
-            )}
-          </div>,
-          document.body,
-        )}
     </>
   );
 }

--- a/apps/web/app/(workspace)/home/page.tsx
+++ b/apps/web/app/(workspace)/home/page.tsx
@@ -6,6 +6,7 @@ import { requireSignedInPageSession } from "@/server/auth/guards";
 import { filesService } from "@/server/files/service";
 import type { FolderSummary } from "@/server/files/types";
 import { ItemContextMenu } from "@/app/item-context-menu";
+import { WorkspacePresetPageContextMenu } from "@/app/dashboard-context-menu";
 import { ItemTypeIcon, itemVisualIconMap } from "@/app/item-type-icon";
 import { retrievalService } from "@/server/retrieval/service";
 import type { RetrievalItem } from "@/server/retrieval/types";
@@ -388,7 +389,10 @@ export default async function HomePage() {
   const currentPath = "/home";
 
   return (
-    <div className="workspace-page home-page">
+    <WorkspacePresetPageContextMenu
+      className="workspace-page home-page"
+      preset="home"
+    >
       <header className="home-greeting">
         <h1>{`${greeting}, ${displayName}.`}</h1>
       </header>
@@ -437,6 +441,6 @@ export default async function HomePage() {
           <SharedList shares={shares.active.slice(0, 3)} />
         </section>
       </div>
-    </div>
+    </WorkspacePresetPageContextMenu>
   );
 }

--- a/apps/web/app/(workspace)/recent/recent-helpers.ts
+++ b/apps/web/app/(workspace)/recent/recent-helpers.ts
@@ -2,6 +2,7 @@ import type { ItemVisualKind } from "@/app/item-visuals";
 import type { RetrievalItem } from "@/server/retrieval/types";
 
 export type RecentClientItem = {
+  deletedAt: string | null;
   folderId?: string | null;
   href: string;
   id: string;
@@ -62,6 +63,7 @@ export function getRecentLocationLabel(item: RetrievalItem): string {
 export function toRecentClientItem(item: RetrievalItem): RecentClientItem {
   return {
     folderId: item.kind === "file" ? item.folderId : undefined,
+    deletedAt: item.deletedAt?.toISOString() ?? null,
     href: item.href,
     id: item.id,
     isFavorite: item.isFavorite,

--- a/apps/web/app/(workspace)/recent/recent-view.tsx
+++ b/apps/web/app/(workspace)/recent/recent-view.tsx
@@ -15,12 +15,19 @@ import {
   ExternalLink,
   Grid2X2,
   List,
+  RefreshCw,
   RotateCcw,
   Trash2,
   X,
 } from "lucide-react";
 
 import { FlashMessage } from "@/app/auth-ui";
+import {
+  DashboardItemContextMenu,
+  DashboardPageContextMenu,
+  submitDashboardPostForm,
+  type DashboardContextMenuGroup,
+} from "@/app/dashboard-context-menu";
 import { getItemVisual } from "@/app/item-visuals";
 import { ItemTypeIcon } from "@/app/item-type-icon";
 import { startValidatedDownload } from "@/lib/transfers/download";
@@ -397,9 +404,99 @@ export function RecentView({ error, items, success }: RecentViewProps) {
     </>
   );
 
+  const getRecentItemContextGroups = (
+    item: RecentClientItem,
+  ): DashboardContextMenuGroup[] =>
+    item.deletedAt
+      ? [
+          {
+            actions: [
+              {
+                icon: <RotateCcw size={13} />,
+                label: "Restore",
+                onSelect: () =>
+                  submitDashboardPostForm({
+                    action: getRestoreHref(item),
+                    fields: { redirectTo: "/recent" },
+                  }),
+              },
+              {
+                destructive: true,
+                icon: <Trash2 size={13} />,
+                label: "Open in Trash",
+                onSelect: () => router.push(getTrashItemHref(item)),
+              },
+            ],
+          },
+        ]
+      : [
+          {
+            actions: [
+              {
+                icon: <ExternalLink size={13} />,
+                label: "Open",
+                shortcut: "↵",
+                onSelect: () => openItem(item),
+              },
+              {
+                icon: <Download size={13} />,
+                label: item.kind === "folder" ? "Download as zip" : "Download",
+                onSelect: () => void downloadItem(item),
+              },
+            ],
+          },
+          {
+            actions: [
+              {
+                destructive: true,
+                icon: <Trash2 size={13} />,
+                label: "Move to trash",
+                shortcut: "Del",
+                onSelect: () => void trashItems([item]),
+              },
+            ],
+          },
+        ];
+
+  const backgroundMenuGroups: DashboardContextMenuGroup[] = [
+    {
+      actions: [
+        {
+          icon: <RefreshCw size={13} />,
+          label: "Refresh",
+          onSelect: () => startTransition(() => router.refresh()),
+        },
+        {
+          disabled: visibleIdSet.size === 0,
+          label: allVisibleSelected ? "Clear selection" : "Select all",
+          onSelect: selectAllVisible,
+        },
+      ],
+    },
+    {
+      actions: [
+        {
+          hidden: selectedItems.length === 0,
+          icon: <Download size={13} />,
+          label: "Download selected",
+          onSelect: () =>
+            void handleDownload(selectedItems.map((item) => item.id)),
+        },
+        {
+          destructive: true,
+          hidden: selectedItems.length === 0,
+          icon: <Trash2 size={13} />,
+          label: "Move selected to trash",
+          onSelect: () => void trashItems(selectedItems),
+        },
+      ],
+    },
+  ];
+
   return (
-    <div
+    <DashboardPageContextMenu
       className="workspace-page recent-page"
+      groups={backgroundMenuGroups}
       tabIndex={-1}
       onKeyDown={handleKeyDown}
     >
@@ -498,75 +595,79 @@ export function RecentView({ error, items, success }: RecentViewProps) {
                 const deleted = Boolean(item.deletedAt);
                 const selected = !deleted && selectedIds.has(item.id);
                 return (
-                  <article
-                    className={`recent-row${selected ? " is-selected" : ""}${deleted ? " is-deleted" : ""}`}
+                  <DashboardItemContextMenu
+                    groups={getRecentItemContextGroups(item)}
                     key={`${item.kind}-${item.id}`}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      if (deleted) return;
-                      toggleItem(item.id);
-                    }}
-                    onDoubleClick={(event) => {
-                      event.stopPropagation();
-                      if (deleted) return;
-                      openItem(item);
-                    }}
                   >
-                    <button
-                      aria-label={
-                        selected
-                          ? `Deselect ${item.name}`
-                          : `Select ${item.name}`
-                      }
-                      aria-pressed={selected}
-                      className={`recent-select-box${selected ? " is-checked" : ""}`}
-                      disabled={deleted}
-                      type="button"
+                    <article
+                      className={`recent-row${selected ? " is-selected" : ""}${deleted ? " is-deleted" : ""}`}
                       onClick={(event) => {
                         event.stopPropagation();
                         if (deleted) return;
                         toggleItem(item.id);
                       }}
-                    />
-                    <span className="recent-row-thumb">
-                      <ItemIcon item={item} />
-                    </span>
-                    <span className="recent-row-name" title={item.name}>
-                      {item.name}
-                      {item.isFavorite ? (
-                        <span
-                          aria-label="Favorited"
-                          className="recent-favorite-dot"
-                        />
-                      ) : null}
-                      {deleted ? (
-                        <span className="recent-deleted-badge">Deleted</span>
-                      ) : null}
-                    </span>
-                    <span
-                      className="recent-row-location"
-                      title={item.locationLabel}
+                      onDoubleClick={(event) => {
+                        event.stopPropagation();
+                        if (deleted) return;
+                        openItem(item);
+                      }}
                     >
-                      {item.locationLabel}
-                    </span>
-                    <span className="recent-row-size">
-                      {formatRecentFileSize(item.sizeBytes)}
-                    </span>
-                    <span className="recent-row-time">
-                      {deleted ? (
-                        <span className="recent-row-inline-actions">
+                      <button
+                        aria-label={
+                          selected
+                            ? `Deselect ${item.name}`
+                            : `Select ${item.name}`
+                        }
+                        aria-pressed={selected}
+                        className={`recent-select-box${selected ? " is-checked" : ""}`}
+                        disabled={deleted}
+                        type="button"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          if (deleted) return;
+                          toggleItem(item.id);
+                        }}
+                      />
+                      <span className="recent-row-thumb">
+                        <ItemIcon item={item} />
+                      </span>
+                      <span className="recent-row-name" title={item.name}>
+                        {item.name}
+                        {item.isFavorite ? (
+                          <span
+                            aria-label="Favorited"
+                            className="recent-favorite-dot"
+                          />
+                        ) : null}
+                        {deleted ? (
+                          <span className="recent-deleted-badge">Deleted</span>
+                        ) : null}
+                      </span>
+                      <span
+                        className="recent-row-location"
+                        title={item.locationLabel}
+                      >
+                        {item.locationLabel}
+                      </span>
+                      <span className="recent-row-size">
+                        {formatRecentFileSize(item.sizeBytes)}
+                      </span>
+                      <span className="recent-row-time">
+                        {deleted ? (
+                          <span className="recent-row-inline-actions">
+                            {renderItemActions(item)}
+                          </span>
+                        ) : (
+                          formatRecentRelativeTime(item.uploadedAt)
+                        )}
+                      </span>
+                      {!deleted ? (
+                        <span className="recent-row-actions">
                           {renderItemActions(item)}
                         </span>
-                      ) : (
-                        formatRecentRelativeTime(item.uploadedAt)
-                      )}
-                    </span>
-                    {!deleted ? (
-                      <span className="recent-row-actions">
-                        {renderItemActions(item)}
-                      </span>
-                    ) : null}
-                  </article>
+                      ) : null}
+                    </article>
+                  </DashboardItemContextMenu>
                 );
               })}
             </section>
@@ -593,65 +694,71 @@ export function RecentView({ error, items, success }: RecentViewProps) {
                     item.kind === "file" ? item.mimeType : null,
                   );
                   return (
-                    <article
-                      className={`recent-grid-card${selected ? " is-selected" : ""}${deleted ? " is-deleted" : ""}`}
+                    <DashboardItemContextMenu
+                      groups={getRecentItemContextGroups(item)}
                       key={`${item.kind}-${item.id}`}
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        if (deleted) return;
-                        toggleItem(item.id);
-                      }}
-                      onDoubleClick={(event) => {
-                        event.stopPropagation();
-                        if (deleted) return;
-                        openItem(item);
-                      }}
                     >
-                      <button
-                        aria-label={
-                          selected
-                            ? `Deselect ${item.name}`
-                            : `Select ${item.name}`
-                        }
-                        aria-pressed={selected}
-                        className={`recent-select-box recent-grid-card-check${
-                          selected ? " is-checked" : ""
-                        }`}
-                        disabled={deleted}
-                        type="button"
+                      <article
+                        className={`recent-grid-card${selected ? " is-selected" : ""}${deleted ? " is-deleted" : ""}`}
                         onClick={(event) => {
                           event.stopPropagation();
                           if (deleted) return;
                           toggleItem(item.id);
                         }}
-                      />
-                      <div
-                        className="recent-grid-card-preview"
-                        style={{ background: visual.background }}
+                        onDoubleClick={(event) => {
+                          event.stopPropagation();
+                          if (deleted) return;
+                          openItem(item);
+                        }}
                       >
-                        <ItemIcon item={item} size={30} />
-                      </div>
-                      <div className="recent-grid-card-body">
-                        <span
-                          className="recent-grid-card-name"
-                          title={item.name}
+                        <button
+                          aria-label={
+                            selected
+                              ? `Deselect ${item.name}`
+                              : `Select ${item.name}`
+                          }
+                          aria-pressed={selected}
+                          className={`recent-select-box recent-grid-card-check${
+                            selected ? " is-checked" : ""
+                          }`}
+                          disabled={deleted}
+                          type="button"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            if (deleted) return;
+                            toggleItem(item.id);
+                          }}
+                        />
+                        <div
+                          className="recent-grid-card-preview"
+                          style={{ background: visual.background }}
                         >
-                          {item.name}
-                        </span>
-                        {deleted ? (
-                          <span className="recent-deleted-badge">Deleted</span>
-                        ) : null}
-                        <span className="recent-grid-card-meta">
-                          <span>
-                            {formatRecentRelativeTime(item.uploadedAt)}
+                          <ItemIcon item={item} size={30} />
+                        </div>
+                        <div className="recent-grid-card-body">
+                          <span
+                            className="recent-grid-card-name"
+                            title={item.name}
+                          >
+                            {item.name}
                           </span>
-                          <span>{formatRecentFileSize(item.sizeBytes)}</span>
+                          {deleted ? (
+                            <span className="recent-deleted-badge">
+                              Deleted
+                            </span>
+                          ) : null}
+                          <span className="recent-grid-card-meta">
+                            <span>
+                              {formatRecentRelativeTime(item.uploadedAt)}
+                            </span>
+                            <span>{formatRecentFileSize(item.sizeBytes)}</span>
+                          </span>
+                        </div>
+                        <span className="recent-grid-card-actions">
+                          {renderItemActions(item)}
                         </span>
-                      </div>
-                      <span className="recent-grid-card-actions">
-                        {renderItemActions(item)}
-                      </span>
-                    </article>
+                      </article>
+                    </DashboardItemContextMenu>
                   );
                 })}
               </div>
@@ -691,6 +798,6 @@ export function RecentView({ error, items, success }: RecentViewProps) {
           </button>
         </div>
       ) : null}
-    </div>
+    </DashboardPageContextMenu>
   );
 }

--- a/apps/web/app/(workspace)/recent/recent-view.tsx
+++ b/apps/web/app/(workspace)/recent/recent-view.tsx
@@ -15,6 +15,7 @@ import {
   ExternalLink,
   Grid2X2,
   List,
+  RotateCcw,
   Trash2,
   X,
 } from "lucide-react";
@@ -67,6 +68,16 @@ function getDownloadHref(item: RecentClientItem): string {
   return `/api/files/files/${item.id}/download`;
 }
 
+function getRestoreHref(item: RecentClientItem): string {
+  return item.kind === "folder"
+    ? `/api/files/folders/${item.id}/restore`
+    : `/api/files/files/${item.id}/restore`;
+}
+
+function getTrashItemHref(item: RecentClientItem): string {
+  return `/trash#${item.kind}-${item.id}`;
+}
+
 function SortIcon({
   active,
   direction,
@@ -110,27 +121,40 @@ export function RecentView({ error, items, success }: RecentViewProps) {
   const [sortDirection, setSortDirection] =
     useState<RecentSortDirection>("desc");
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [trashedIds, setTrashedIds] = useState<Set<string>>(new Set());
+  const [optimisticDeletedAtById, setOptimisticDeletedAtById] = useState<
+    Record<string, string>
+  >({});
   const [actionError, setActionError] = useState<string | null>(null);
 
   const visibleItems = useMemo(() => {
-    const activeItems = items.filter((item) => !trashedIds.has(item.id));
+    const itemsWithOptimisticState = items.map((item) => {
+      const deletedAt = optimisticDeletedAtById[item.id];
+      return deletedAt && !item.deletedAt ? { ...item, deletedAt } : item;
+    });
+
     return sortRecentItems(
-      filterRecentItems(activeItems, filterType),
+      filterRecentItems(itemsWithOptimisticState, filterType),
       sortKey,
       sortDirection,
     );
-  }, [filterType, items, sortDirection, sortKey, trashedIds]);
+  }, [filterType, items, optimisticDeletedAtById, sortDirection, sortKey]);
 
   const groups = useMemo(() => groupRecentItems(visibleItems), [visibleItems]);
   const visibleIdSet = useMemo(
-    () => new Set(visibleItems.map((item) => item.id)),
+    () =>
+      new Set(
+        visibleItems.filter((item) => !item.deletedAt).map((item) => item.id),
+      ),
     [visibleItems],
   );
   const allVisibleSelected =
-    visibleItems.length > 0 &&
-    visibleItems.every((item) => selectedIds.has(item.id));
-  const selectedItems = visibleItems.filter((item) => selectedIds.has(item.id));
+    visibleIdSet.size > 0 &&
+    visibleItems
+      .filter((item) => !item.deletedAt)
+      .every((item) => selectedIds.has(item.id));
+  const selectedItems = visibleItems.filter(
+    (item) => !item.deletedAt && selectedIds.has(item.id),
+  );
 
   useEffect(() => {
     setSelectedIds((current) => {
@@ -171,11 +195,18 @@ export function RecentView({ error, items, success }: RecentViewProps) {
   const selectAllVisible = () => {
     setSelectedIds((current) => {
       if (allVisibleSelected) return new Set();
-      return new Set([...current, ...visibleItems.map((item) => item.id)]);
+      return new Set([
+        ...current,
+        ...visibleItems
+          .filter((item) => !item.deletedAt)
+          .map((item) => item.id),
+      ]);
     });
   };
 
   const openItem = (item: RecentClientItem) => {
+    if (item.deletedAt) return;
+
     const href = getOpenHref(item);
     if (href.startsWith("/files/")) {
       router.push(href);
@@ -185,6 +216,8 @@ export function RecentView({ error, items, success }: RecentViewProps) {
   };
 
   const downloadItem = async (item: RecentClientItem) => {
+    if (item.deletedAt) return;
+
     if (item.kind === "folder") {
       await handleDownload([item.id]);
       return;
@@ -219,30 +252,32 @@ export function RecentView({ error, items, success }: RecentViewProps) {
   };
 
   const trashItems = async (targets: RecentClientItem[]) => {
-    if (targets.length === 0) return;
+    const activeTargets = targets.filter((item) => !item.deletedAt);
+    if (activeTargets.length === 0) return;
 
     setSelectedIds(new Set());
-    setTrashedIds((current) => {
-      const next = new Set(current);
-      for (const item of targets) next.add(item.id);
+    setOptimisticDeletedAtById((current) => {
+      const next = { ...current };
+      const deletedAt = new Date().toISOString();
+      for (const item of activeTargets) next[item.id] = deletedAt;
       return next;
     });
 
     const results = await Promise.allSettled(
-      targets.map((item) => moveToTrash(item)),
+      activeTargets.map((item) => moveToTrash(item)),
     );
     const failedIds = new Set<string>();
     let movedAny = false;
 
     results.forEach((result, index) => {
       if (result.status === "fulfilled") movedAny = true;
-      else failedIds.add(targets[index].id);
+      else failedIds.add(activeTargets[index].id);
     });
 
     if (failedIds.size > 0) {
-      setTrashedIds((current) => {
-        const next = new Set(current);
-        for (const id of failedIds) next.delete(id);
+      setOptimisticDeletedAtById((current) => {
+        const next = { ...current };
+        for (const id of failedIds) delete next[id];
         return next;
       });
       setActionError("Some items could not be moved to trash.");
@@ -297,39 +332,68 @@ export function RecentView({ error, items, success }: RecentViewProps) {
 
   const renderItemActions = (item: RecentClientItem) => (
     <>
-      <button
-        aria-label={`Open ${item.name}`}
-        className="recent-action-btn"
-        type="button"
-        onClick={(event) => {
-          event.stopPropagation();
-          openItem(item);
-        }}
-      >
-        <ExternalLink size={13} aria-hidden />
-      </button>
-      <button
-        aria-label={`Download ${item.name}`}
-        className="recent-action-btn"
-        type="button"
-        onClick={(event) => {
-          event.stopPropagation();
-          void downloadItem(item);
-        }}
-      >
-        <Download size={13} aria-hidden />
-      </button>
-      <button
-        aria-label={`Move ${item.name} to trash`}
-        className="recent-action-btn recent-action-btn-danger"
-        type="button"
-        onClick={(event) => {
-          event.stopPropagation();
-          void trashItems([item]);
-        }}
-      >
-        <Trash2 size={13} aria-hidden />
-      </button>
+      {item.deletedAt ? (
+        <>
+          <form action={getRestoreHref(item)} method="post">
+            <input name="redirectTo" type="hidden" value="/recent" />
+            <button
+              aria-label={`Restore ${item.name}`}
+              className="recent-action-btn"
+              type="submit"
+              onClick={(event) => event.stopPropagation()}
+            >
+              <RotateCcw size={13} aria-hidden />
+            </button>
+          </form>
+          <button
+            aria-label={`Delete ${item.name} from Trash`}
+            className="recent-action-btn recent-action-btn-danger"
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              router.push(getTrashItemHref(item));
+            }}
+          >
+            <Trash2 size={13} aria-hidden />
+          </button>
+        </>
+      ) : (
+        <>
+          <button
+            aria-label={`Open ${item.name}`}
+            className="recent-action-btn"
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              openItem(item);
+            }}
+          >
+            <ExternalLink size={13} aria-hidden />
+          </button>
+          <button
+            aria-label={`Download ${item.name}`}
+            className="recent-action-btn"
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              void downloadItem(item);
+            }}
+          >
+            <Download size={13} aria-hidden />
+          </button>
+          <button
+            aria-label={`Move ${item.name} to trash`}
+            className="recent-action-btn recent-action-btn-danger"
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              void trashItems([item]);
+            }}
+          >
+            <Trash2 size={13} aria-hidden />
+          </button>
+        </>
+      )}
     </>
   );
 
@@ -431,17 +495,20 @@ export function RecentView({ error, items, success }: RecentViewProps) {
               </div>
 
               {group.items.map((item) => {
-                const selected = selectedIds.has(item.id);
+                const deleted = Boolean(item.deletedAt);
+                const selected = !deleted && selectedIds.has(item.id);
                 return (
                   <article
-                    className={`recent-row${selected ? " is-selected" : ""}`}
+                    className={`recent-row${selected ? " is-selected" : ""}${deleted ? " is-deleted" : ""}`}
                     key={`${item.kind}-${item.id}`}
                     onClick={(event) => {
                       event.stopPropagation();
+                      if (deleted) return;
                       toggleItem(item.id);
                     }}
                     onDoubleClick={(event) => {
                       event.stopPropagation();
+                      if (deleted) return;
                       openItem(item);
                     }}
                   >
@@ -453,9 +520,11 @@ export function RecentView({ error, items, success }: RecentViewProps) {
                       }
                       aria-pressed={selected}
                       className={`recent-select-box${selected ? " is-checked" : ""}`}
+                      disabled={deleted}
                       type="button"
                       onClick={(event) => {
                         event.stopPropagation();
+                        if (deleted) return;
                         toggleItem(item.id);
                       }}
                     />
@@ -470,6 +539,9 @@ export function RecentView({ error, items, success }: RecentViewProps) {
                           className="recent-favorite-dot"
                         />
                       ) : null}
+                      {deleted ? (
+                        <span className="recent-deleted-badge">Deleted</span>
+                      ) : null}
                     </span>
                     <span
                       className="recent-row-location"
@@ -481,11 +553,19 @@ export function RecentView({ error, items, success }: RecentViewProps) {
                       {formatRecentFileSize(item.sizeBytes)}
                     </span>
                     <span className="recent-row-time">
-                      {formatRecentRelativeTime(item.uploadedAt)}
+                      {deleted ? (
+                        <span className="recent-row-inline-actions">
+                          {renderItemActions(item)}
+                        </span>
+                      ) : (
+                        formatRecentRelativeTime(item.uploadedAt)
+                      )}
                     </span>
-                    <span className="recent-row-actions">
-                      {renderItemActions(item)}
-                    </span>
+                    {!deleted ? (
+                      <span className="recent-row-actions">
+                        {renderItemActions(item)}
+                      </span>
+                    ) : null}
                   </article>
                 );
               })}
@@ -506,21 +586,24 @@ export function RecentView({ error, items, success }: RecentViewProps) {
 
               <div className="recent-grid-cards">
                 {group.items.map((item) => {
-                  const selected = selectedIds.has(item.id);
+                  const deleted = Boolean(item.deletedAt);
+                  const selected = !deleted && selectedIds.has(item.id);
                   const visual = getItemVisual(
                     item.kind,
                     item.kind === "file" ? item.mimeType : null,
                   );
                   return (
                     <article
-                      className={`recent-grid-card${selected ? " is-selected" : ""}`}
+                      className={`recent-grid-card${selected ? " is-selected" : ""}${deleted ? " is-deleted" : ""}`}
                       key={`${item.kind}-${item.id}`}
                       onClick={(event) => {
                         event.stopPropagation();
+                        if (deleted) return;
                         toggleItem(item.id);
                       }}
                       onDoubleClick={(event) => {
                         event.stopPropagation();
+                        if (deleted) return;
                         openItem(item);
                       }}
                     >
@@ -534,9 +617,11 @@ export function RecentView({ error, items, success }: RecentViewProps) {
                         className={`recent-select-box recent-grid-card-check${
                           selected ? " is-checked" : ""
                         }`}
+                        disabled={deleted}
                         type="button"
                         onClick={(event) => {
                           event.stopPropagation();
+                          if (deleted) return;
                           toggleItem(item.id);
                         }}
                       />
@@ -553,6 +638,9 @@ export function RecentView({ error, items, success }: RecentViewProps) {
                         >
                           {item.name}
                         </span>
+                        {deleted ? (
+                          <span className="recent-deleted-badge">Deleted</span>
+                        ) : null}
                         <span className="recent-grid-card-meta">
                           <span>
                             {formatRecentRelativeTime(item.uploadedAt)}

--- a/apps/web/app/(workspace)/recent/recent-view.tsx
+++ b/apps/web/app/(workspace)/recent/recent-view.tsx
@@ -723,6 +723,11 @@ export function RecentView({ error, items, success }: RecentViewProps) {
         {items.length > 0 ? (
           <span className="section-count">{items.length}</span>
         ) : null}
+        {selectedItems.length > 0 ? (
+          <span className="selection-badge">
+            {selectedItems.length} selected
+          </span>
+        ) : null}
       </div>
 
       {error ? <FlashMessage>{error}</FlashMessage> : null}

--- a/apps/web/app/(workspace)/recent/recent-view.tsx
+++ b/apps/web/app/(workspace)/recent/recent-view.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import {
+  useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   useTransition,
   type KeyboardEvent,
+  type MouseEvent,
 } from "react";
 import { useRouter } from "next/navigation";
 import {
@@ -18,7 +21,6 @@ import {
   RefreshCw,
   RotateCcw,
   Trash2,
-  X,
 } from "lucide-react";
 
 import { FlashMessage } from "@/app/auth-ui";
@@ -53,6 +55,13 @@ type RecentViewProps = {
   success?: string | null;
 };
 
+type RubberBand = {
+  currentX: number;
+  currentY: number;
+  startX: number;
+  startY: number;
+};
+
 const FILTERS: { id: RecentFilterType; label: string }[] = [
   { id: "all", label: "All" },
   { id: "folder", label: "Folders" },
@@ -63,6 +72,8 @@ const FILTERS: { id: RecentFilterType; label: string }[] = [
   { id: "text", label: "Docs" },
   { id: "archive", label: "Archives" },
 ];
+
+const DRAG_THRESHOLD = 5;
 
 function getOpenHref(item: RecentClientItem): string {
   if (item.kind === "folder") return item.href;
@@ -128,10 +139,21 @@ export function RecentView({ error, items, success }: RecentViewProps) {
   const [sortDirection, setSortDirection] =
     useState<RecentSortDirection>("desc");
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [lastSelectedId, setLastSelectedId] = useState<string | null>(null);
   const [optimisticDeletedAtById, setOptimisticDeletedAtById] = useState<
     Record<string, string>
   >({});
   const [actionError, setActionError] = useState<string | null>(null);
+  const [rubberBand, setRubberBand] = useState<RubberBand | null>(null);
+  const didRubberBand = useRef(false);
+  const dragOrigin = useRef<{ onItem: boolean; x: number; y: number } | null>(
+    null,
+  );
+  const isRubberBanding = useRef(false);
+  const listRef = useRef<HTMLDivElement>(null);
+  const rubberBandStart = useRef<{ startX: number; startY: number } | null>(
+    null,
+  );
 
   const visibleItems = useMemo(() => {
     const itemsWithOptimisticState = items.map((item) => {
@@ -147,18 +169,21 @@ export function RecentView({ error, items, success }: RecentViewProps) {
   }, [filterType, items, optimisticDeletedAtById, sortDirection, sortKey]);
 
   const groups = useMemo(() => groupRecentItems(visibleItems), [visibleItems]);
-  const visibleIdSet = useMemo(
-    () =>
-      new Set(
-        visibleItems.filter((item) => !item.deletedAt).map((item) => item.id),
-      ),
+  const activeVisibleItems = useMemo(
+    () => visibleItems.filter((item) => !item.deletedAt),
     [visibleItems],
+  );
+  const activeVisibleIds = useMemo(
+    () => activeVisibleItems.map((item) => item.id),
+    [activeVisibleItems],
+  );
+  const visibleIdSet = useMemo(
+    () => new Set(activeVisibleIds),
+    [activeVisibleIds],
   );
   const allVisibleSelected =
     visibleIdSet.size > 0 &&
-    visibleItems
-      .filter((item) => !item.deletedAt)
-      .every((item) => selectedIds.has(item.id));
+    activeVisibleIds.every((id) => selectedIds.has(id));
   const selectedItems = visibleItems.filter(
     (item) => !item.deletedAt && selectedIds.has(item.id),
   );
@@ -172,6 +197,7 @@ export function RecentView({ error, items, success }: RecentViewProps) {
 
   useEffect(() => {
     setSelectedIds(new Set());
+    setLastSelectedId(null);
   }, [filterType, viewMode]);
 
   useEffect(() => {
@@ -190,25 +216,48 @@ export function RecentView({ error, items, success }: RecentViewProps) {
     setSortDirection(key === "uploadedAt" || key === "size" ? "desc" : "asc");
   };
 
-  const toggleItem = (id: string) => {
+  const selectAllVisible = () => {
     setSelectedIds((current) => {
-      const next = new Set(current);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
+      if (allVisibleSelected) {
+        setLastSelectedId(null);
+        return new Set();
+      }
+      setLastSelectedId(activeVisibleIds.at(-1) ?? null);
+      return new Set([...current, ...activeVisibleIds]);
     });
   };
 
-  const selectAllVisible = () => {
-    setSelectedIds((current) => {
-      if (allVisibleSelected) return new Set();
-      return new Set([
-        ...current,
-        ...visibleItems
-          .filter((item) => !item.deletedAt)
-          .map((item) => item.id),
-      ]);
-    });
+  const handleItemClick = (
+    item: RecentClientItem,
+    event: MouseEvent<HTMLElement>,
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (didRubberBand.current || item.deletedAt) return;
+
+    if (event.ctrlKey || event.metaKey) {
+      setSelectedIds((current) => {
+        const next = new Set(current);
+        if (next.has(item.id)) next.delete(item.id);
+        else next.add(item.id);
+        return next;
+      });
+      setLastSelectedId(item.id);
+      return;
+    }
+
+    if (event.shiftKey && lastSelectedId) {
+      const start = activeVisibleIds.indexOf(lastSelectedId);
+      const end = activeVisibleIds.indexOf(item.id);
+      if (start >= 0 && end >= 0) {
+        const [from, to] = [Math.min(start, end), Math.max(start, end)];
+        setSelectedIds(new Set(activeVisibleIds.slice(from, to + 1)));
+        return;
+      }
+    }
+
+    setSelectedIds(new Set([item.id]));
+    setLastSelectedId(item.id);
   };
 
   const openItem = (item: RecentClientItem) => {
@@ -263,6 +312,7 @@ export function RecentView({ error, items, success }: RecentViewProps) {
     if (activeTargets.length === 0) return;
 
     setSelectedIds(new Set());
+    setLastSelectedId(null);
     setOptimisticDeletedAtById((current) => {
       const next = { ...current };
       const deletedAt = new Date().toISOString();
@@ -296,6 +346,7 @@ export function RecentView({ error, items, success }: RecentViewProps) {
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === "Escape") {
       setSelectedIds(new Set());
+      setLastSelectedId(null);
       return;
     }
 
@@ -319,6 +370,145 @@ export function RecentView({ error, items, success }: RecentViewProps) {
       openItem(selectedItems[0]);
     }
   };
+
+  const handleRecentListClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (didRubberBand.current) return;
+    const target = event.target as HTMLElement;
+    if (!target.closest("[data-recent-item]")) {
+      setSelectedIds(new Set());
+      setLastSelectedId(null);
+    }
+  };
+
+  const handleRecentMouseDown = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (event.button !== 0) return;
+
+      const target = event.target as HTMLElement;
+      if (target.closest("button, input, select, textarea")) return;
+      if (target.closest(".recent-toolbar, .recent-col-head")) return;
+
+      const container = listRef.current;
+      if (!container) return;
+
+      const onItem = Boolean(target.closest("[data-recent-item]"));
+      const rect = container.getBoundingClientRect();
+      const x = event.clientX - rect.left;
+      const y = event.clientY - rect.top;
+
+      dragOrigin.current = { onItem, x, y };
+
+      if (!onItem) {
+        event.preventDefault();
+        rubberBandStart.current = { startX: x, startY: y };
+        isRubberBanding.current = true;
+        setRubberBand({ startX: x, startY: y, currentX: x, currentY: y });
+        if (!event.shiftKey && !event.ctrlKey && !event.metaKey) {
+          setSelectedIds(new Set());
+          setLastSelectedId(null);
+        }
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const onMove = (event: globalThis.MouseEvent) => {
+      const container = listRef.current;
+      if (!container) return;
+
+      const rect = container.getBoundingClientRect();
+      const currentX = event.clientX - rect.left;
+      const currentY = event.clientY - rect.top;
+
+      if (!isRubberBanding.current) {
+        const origin = dragOrigin.current;
+        if (!origin?.onItem) return;
+
+        const dist = Math.hypot(currentX - origin.x, currentY - origin.y);
+        if (dist < DRAG_THRESHOLD) return;
+
+        isRubberBanding.current = true;
+        didRubberBand.current = true;
+        rubberBandStart.current = { startX: origin.x, startY: origin.y };
+        setRubberBand({
+          startX: origin.x,
+          startY: origin.y,
+          currentX,
+          currentY,
+        });
+        setSelectedIds(new Set());
+        setLastSelectedId(null);
+        return;
+      }
+
+      didRubberBand.current = true;
+      const start = rubberBandStart.current;
+      if (!start) return;
+
+      setRubberBand({
+        startX: start.startX,
+        startY: start.startY,
+        currentX,
+        currentY,
+      });
+
+      const selLeft = Math.min(start.startX, currentX);
+      const selTop = Math.min(start.startY, currentY);
+      const selRight = Math.max(start.startX, currentX);
+      const selBottom = Math.max(start.startY, currentY);
+      const next = new Set<string>();
+
+      container
+        .querySelectorAll<HTMLElement>('[data-recent-active="true"]')
+        .forEach((element) => {
+          const id = element.dataset.recentItem;
+          if (!id) return;
+
+          const itemRect = element.getBoundingClientRect();
+          const rowTop = itemRect.top - rect.top;
+          const rowBottom = itemRect.bottom - rect.top;
+          const rowLeft = itemRect.left - rect.left;
+          const rowRight = itemRect.right - rect.left;
+
+          if (
+            !(
+              rowRight < selLeft ||
+              rowLeft > selRight ||
+              rowBottom < selTop ||
+              rowTop > selBottom
+            )
+          ) {
+            next.add(id);
+          }
+        });
+
+      setSelectedIds(next);
+      setLastSelectedId(
+        next.size > 0 ? (Array.from(next).at(-1) ?? null) : null,
+      );
+    };
+
+    const onUp = () => {
+      dragOrigin.current = null;
+      if (!isRubberBanding.current) return;
+
+      isRubberBanding.current = false;
+      rubberBandStart.current = null;
+      setRubberBand(null);
+      window.setTimeout(() => {
+        didRubberBand.current = false;
+      }, 0);
+    };
+
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+  }, []);
 
   const renderSortButton = (
     key: RecentSortKey,
@@ -406,57 +596,76 @@ export function RecentView({ error, items, success }: RecentViewProps) {
 
   const getRecentItemContextGroups = (
     item: RecentClientItem,
-  ): DashboardContextMenuGroup[] =>
-    item.deletedAt
-      ? [
+  ): DashboardContextMenuGroup[] => {
+    if (item.deletedAt) {
+      return [
+        {
+          actions: [
+            {
+              icon: <RotateCcw size={13} />,
+              label: "Restore",
+              onSelect: () =>
+                submitDashboardPostForm({
+                  action: getRestoreHref(item),
+                  fields: { redirectTo: "/recent" },
+                }),
+            },
+            {
+              destructive: true,
+              icon: <Trash2 size={13} />,
+              label: "Open in Trash",
+              onSelect: () => router.push(getTrashItemHref(item)),
+            },
+          ],
+        },
+      ];
+    }
+
+    const targets =
+      selectedIds.has(item.id) && selectedItems.length > 1
+        ? selectedItems
+        : [item];
+    const bulk = targets.length > 1;
+
+    return [
+      {
+        actions: [
           {
-            actions: [
-              {
-                icon: <RotateCcw size={13} />,
-                label: "Restore",
-                onSelect: () =>
-                  submitDashboardPostForm({
-                    action: getRestoreHref(item),
-                    fields: { redirectTo: "/recent" },
-                  }),
-              },
-              {
-                destructive: true,
-                icon: <Trash2 size={13} />,
-                label: "Open in Trash",
-                onSelect: () => router.push(getTrashItemHref(item)),
-              },
-            ],
-          },
-        ]
-      : [
-          {
-            actions: [
-              {
-                icon: <ExternalLink size={13} />,
-                label: "Open",
-                shortcut: "↵",
-                onSelect: () => openItem(item),
-              },
-              {
-                icon: <Download size={13} />,
-                label: item.kind === "folder" ? "Download as zip" : "Download",
-                onSelect: () => void downloadItem(item),
-              },
-            ],
+            disabled: bulk,
+            icon: <ExternalLink size={13} />,
+            label: "Open",
+            shortcut: "↵",
+            onSelect: () => openItem(item),
           },
           {
-            actions: [
-              {
-                destructive: true,
-                icon: <Trash2 size={13} />,
-                label: "Move to trash",
-                shortcut: "Del",
-                onSelect: () => void trashItems([item]),
-              },
-            ],
+            icon: <Download size={13} />,
+            label: bulk
+              ? `Download ${targets.length} selected`
+              : item.kind === "folder"
+                ? "Download as zip"
+                : "Download",
+            onSelect: () =>
+              bulk
+                ? void handleDownload(targets.map((target) => target.id))
+                : void downloadItem(item),
           },
-        ];
+        ],
+      },
+      {
+        actions: [
+          {
+            destructive: true,
+            icon: <Trash2 size={13} />,
+            label: bulk
+              ? `Move ${targets.length} selected to trash`
+              : "Move to trash",
+            shortcut: "Del",
+            onSelect: () => void trashItems(targets),
+          },
+        ],
+      },
+    ];
+  };
 
   const backgroundMenuGroups: DashboardContextMenuGroup[] = [
     {
@@ -470,6 +679,15 @@ export function RecentView({ error, items, success }: RecentViewProps) {
           disabled: visibleIdSet.size === 0,
           label: allVisibleSelected ? "Clear selection" : "Select all",
           onSelect: selectAllVisible,
+        },
+        {
+          disabled: selectedItems.length === 0,
+          hidden: selectedItems.length === 0 || allVisibleSelected,
+          label: "Clear selection",
+          onSelect: () => {
+            setSelectedIds(new Set());
+            setLastSelectedId(null);
+          },
         },
       ],
     },
@@ -559,30 +777,35 @@ export function RecentView({ error, items, success }: RecentViewProps) {
         </div>
       ) : viewMode === "list" ? (
         <div
+          ref={listRef}
           className="recent-table-wrap"
-          onClick={() => setSelectedIds(new Set())}
+          onClick={handleRecentListClick}
+          onMouseDown={handleRecentMouseDown}
         >
           <div
             className="recent-col-head"
             role="row"
             aria-label="Recent columns"
           >
-            <button
-              aria-label={allVisibleSelected ? "Clear selection" : "Select all"}
-              aria-pressed={allVisibleSelected}
-              className={`recent-select-box${allVisibleSelected ? " is-checked" : ""}`}
-              type="button"
-              onClick={(event) => {
-                event.stopPropagation();
-                selectAllVisible();
-              }}
-            />
             <span aria-hidden />
             {renderSortButton("name", "Name")}
             {renderSortButton("path", "Location")}
             {renderSortButton("size", "Size", "right")}
             {renderSortButton("uploadedAt", "Uploaded", "right")}
           </div>
+
+          {rubberBand ? (
+            <div
+              className="rubber-band-rect"
+              style={{
+                left: Math.min(rubberBand.startX, rubberBand.currentX),
+                top: Math.min(rubberBand.startY, rubberBand.currentY),
+                width: Math.abs(rubberBand.currentX - rubberBand.startX),
+                height: Math.abs(rubberBand.currentY - rubberBand.startY),
+              }}
+              aria-hidden
+            />
+          ) : null}
 
           {groups.map((group) => (
             <section className="recent-group-section" key={group.label}>
@@ -600,34 +823,16 @@ export function RecentView({ error, items, success }: RecentViewProps) {
                     key={`${item.kind}-${item.id}`}
                   >
                     <article
+                      data-recent-active={deleted ? undefined : "true"}
+                      data-recent-item={item.id}
                       className={`recent-row${selected ? " is-selected" : ""}${deleted ? " is-deleted" : ""}`}
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        if (deleted) return;
-                        toggleItem(item.id);
-                      }}
+                      onClick={(event) => handleItemClick(item, event)}
                       onDoubleClick={(event) => {
                         event.stopPropagation();
                         if (deleted) return;
                         openItem(item);
                       }}
                     >
-                      <button
-                        aria-label={
-                          selected
-                            ? `Deselect ${item.name}`
-                            : `Select ${item.name}`
-                        }
-                        aria-pressed={selected}
-                        className={`recent-select-box${selected ? " is-checked" : ""}`}
-                        disabled={deleted}
-                        type="button"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          if (deleted) return;
-                          toggleItem(item.id);
-                        }}
-                      />
                       <span className="recent-row-thumb">
                         <ItemIcon item={item} />
                       </span>
@@ -675,9 +880,24 @@ export function RecentView({ error, items, success }: RecentViewProps) {
         </div>
       ) : (
         <div
+          ref={listRef}
           className="recent-grid-wrap"
-          onClick={() => setSelectedIds(new Set())}
+          onClick={handleRecentListClick}
+          onMouseDown={handleRecentMouseDown}
         >
+          {rubberBand ? (
+            <div
+              className="rubber-band-rect"
+              style={{
+                left: Math.min(rubberBand.startX, rubberBand.currentX),
+                top: Math.min(rubberBand.startY, rubberBand.currentY),
+                width: Math.abs(rubberBand.currentX - rubberBand.startX),
+                height: Math.abs(rubberBand.currentY - rubberBand.startY),
+              }}
+              aria-hidden
+            />
+          ) : null}
+
           {groups.map((group) => (
             <section className="recent-grid-group" key={group.label}>
               <div className="recent-grid-group-header">
@@ -699,36 +919,16 @@ export function RecentView({ error, items, success }: RecentViewProps) {
                       key={`${item.kind}-${item.id}`}
                     >
                       <article
+                        data-recent-active={deleted ? undefined : "true"}
+                        data-recent-item={item.id}
                         className={`recent-grid-card${selected ? " is-selected" : ""}${deleted ? " is-deleted" : ""}`}
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          if (deleted) return;
-                          toggleItem(item.id);
-                        }}
+                        onClick={(event) => handleItemClick(item, event)}
                         onDoubleClick={(event) => {
                           event.stopPropagation();
                           if (deleted) return;
                           openItem(item);
                         }}
                       >
-                        <button
-                          aria-label={
-                            selected
-                              ? `Deselect ${item.name}`
-                              : `Select ${item.name}`
-                          }
-                          aria-pressed={selected}
-                          className={`recent-select-box recent-grid-card-check${
-                            selected ? " is-checked" : ""
-                          }`}
-                          disabled={deleted}
-                          type="button"
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            if (deleted) return;
-                            toggleItem(item.id);
-                          }}
-                        />
                         <div
                           className="recent-grid-card-preview"
                           style={{ background: visual.background }}
@@ -766,38 +966,6 @@ export function RecentView({ error, items, success }: RecentViewProps) {
           ))}
         </div>
       )}
-
-      {selectedItems.length > 0 ? (
-        <div className="recent-float-bar" role="status">
-          <span>{selectedItems.length} selected</span>
-          <span className="recent-float-divider" aria-hidden />
-          <button
-            type="button"
-            onClick={() =>
-              void handleDownload(selectedItems.map((item) => item.id))
-            }
-          >
-            <Download size={13} aria-hidden />
-            Download
-          </button>
-          <button
-            className="recent-float-danger"
-            type="button"
-            onClick={() => void trashItems(selectedItems)}
-          >
-            <Trash2 size={13} aria-hidden />
-            Move to trash
-          </button>
-          <span className="recent-float-divider" aria-hidden />
-          <button
-            aria-label="Clear selection"
-            type="button"
-            onClick={() => setSelectedIds(new Set())}
-          >
-            <X size={13} aria-hidden />
-          </button>
-        </div>
-      ) : null}
     </DashboardPageContextMenu>
   );
 }

--- a/apps/web/app/(workspace)/search/page.tsx
+++ b/apps/web/app/(workspace)/search/page.tsx
@@ -1,4 +1,5 @@
 import { FlashMessage, getSingleSearchParam } from "@/app/auth-ui";
+import { WorkspacePresetPageContextMenu } from "@/app/dashboard-context-menu";
 import { requireSignedInPageSession } from "@/server/auth/guards";
 import { retrievalService } from "@/server/retrieval/service";
 
@@ -50,7 +51,7 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
   const success = getSingleSearchParam(resolvedSearchParams, "success");
 
   return (
-    <div className="workspace-page">
+    <WorkspacePresetPageContextMenu className="workspace-page" preset="search">
       <section className="panel stack">
         <div className="pill">Search</div>
         <h1>Files search</h1>
@@ -108,6 +109,6 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
           </>
         )}
       </section>
-    </div>
+    </WorkspacePresetPageContextMenu>
   );
 }

--- a/apps/web/app/(workspace)/shared/page.tsx
+++ b/apps/web/app/(workspace)/shared/page.tsx
@@ -6,6 +6,7 @@ import {
   formatDateTime,
   getSingleSearchParam,
 } from "@/app/auth-ui";
+import { WorkspacePresetPageContextMenu } from "@/app/dashboard-context-menu";
 import { requireSignedInPageSession } from "@/server/auth/guards";
 import { getBaseUrl } from "@/server/request";
 import { sharingService } from "@/server/sharing/service";
@@ -89,7 +90,7 @@ export default async function SharedPage({ searchParams }: SharedPageProps) {
   }));
 
   return (
-    <div className="workspace-page">
+    <WorkspacePresetPageContextMenu className="workspace-page" preset="shared">
       <div className="stack">
         {/* Page header */}
         <div className="shared-header">
@@ -121,6 +122,6 @@ export default async function SharedPage({ searchParams }: SharedPageProps) {
           </div>
         )}
       </div>
-    </div>
+    </WorkspacePresetPageContextMenu>
   );
 }

--- a/apps/web/app/(workspace)/shared/shared-table.tsx
+++ b/apps/web/app/(workspace)/shared/shared-table.tsx
@@ -6,6 +6,10 @@ import { KeyRound } from "lucide-react";
 import { useMemo, useState, useTransition } from "react";
 
 import { ShareDialog } from "@/app/(workspace)/files/share-dialog";
+import {
+  DashboardItemContextMenu,
+  type DashboardContextMenuGroup,
+} from "@/app/dashboard-context-menu";
 import type { ShareLinkSummary } from "@/server/sharing";
 
 export type SharedTableItem = {
@@ -111,6 +115,35 @@ export function SharedTable({ items }: SharedTableProps) {
     if (filterType === "all") return items;
     return items.filter(({ share }) => getShareType(share) === filterType);
   }, [filterType, items]);
+  const getShareItemContextGroups = ({
+    canManage,
+    share,
+  }: SharedTableItem): DashboardContextMenuGroup[] => [
+    {
+      actions: [
+        {
+          disabled: !canManage,
+          label: "Manage link",
+          onSelect: () =>
+            setShareDialogTarget({
+              targetType: share.target.targetType,
+              targetId: share.target.id,
+              share,
+            }),
+        },
+      ],
+    },
+    {
+      actions: [
+        {
+          label: "Copy name",
+          onSelect: () => {
+            void navigator.clipboard?.writeText(share.target.name);
+          },
+        },
+      ],
+    },
+  ];
 
   return (
     <>
@@ -185,74 +218,86 @@ export function SharedTable({ items }: SharedTableProps) {
                   const locationLabel = getShareLocationLabel(share);
 
                   return (
-                    <tr
-                      className={`st-tr${share.status === "active" ? "" : " st-tr--inactive"}`}
-                      id={share.id}
+                    <DashboardItemContextMenu
+                      groups={getShareItemContextGroups({
+                        share,
+                        canManage,
+                        expiresLabel,
+                        expiryTone,
+                        statusLabel,
+                      })}
                       key={share.id}
                     >
-                      <td className="st-td st-name-cell">
-                        <span className="st-name">
-                          <span
-                            className="st-name-text"
-                            title={share.target.name}
-                          >
-                            {share.target.name}
+                      <tr
+                        className={`st-tr${share.status === "active" ? "" : " st-tr--inactive"}`}
+                        id={share.id}
+                      >
+                        <td className="st-td st-name-cell">
+                          <span className="st-name">
+                            <span
+                              className="st-name-text"
+                              title={share.target.name}
+                            >
+                              {share.target.name}
+                            </span>
                           </span>
-                        </span>
-                      </td>
-                      <td className="st-td st-muted">
-                        <span className="st-location" title={locationLabel}>
-                          {locationLabel}
-                        </span>
-                      </td>
-                      <td className="st-td st-muted">
-                        {getShareTypeLabel(share)}
-                      </td>
-                      <td className={`st-td st-mono st-expires--${expiryTone}`}>
-                        {expiresLabel}
-                      </td>
-                      <td className="st-td">
-                        <span
-                          className={`sl-badge sl-badge--${getStatusClass(share.status)}`}
+                        </td>
+                        <td className="st-td st-muted">
+                          <span className="st-location" title={locationLabel}>
+                            {locationLabel}
+                          </span>
+                        </td>
+                        <td className="st-td st-muted">
+                          {getShareTypeLabel(share)}
+                        </td>
+                        <td
+                          className={`st-td st-mono st-expires--${expiryTone}`}
                         >
-                          {statusLabel}
-                        </span>
-                      </td>
-                      <td className="st-td">
-                        <div className="st-actions">
-                          <button
-                            className="st-action"
-                            disabled={!canManage}
-                            onClick={() =>
-                              setShareDialogTarget({
-                                targetType: share.target.targetType,
-                                targetId: share.target.id,
-                                share,
-                              })
-                            }
-                            type="button"
-                          >
-                            Manage
-                          </button>
+                          {expiresLabel}
+                        </td>
+                        <td className="st-td">
                           <span
-                            aria-hidden={!share.hasPassword}
-                            className="st-password-hint"
-                            title={
-                              share.hasPassword
-                                ? "Password protected"
-                                : undefined
-                            }
+                            className={`sl-badge sl-badge--${getStatusClass(share.status)}`}
                           >
-                            {share.hasPassword ? (
-                              <KeyRound
-                                aria-label="Password protected"
-                                size={13}
-                              />
-                            ) : null}
+                            {statusLabel}
                           </span>
-                        </div>
-                      </td>
-                    </tr>
+                        </td>
+                        <td className="st-td">
+                          <div className="st-actions">
+                            <button
+                              className="st-action"
+                              disabled={!canManage}
+                              onClick={() =>
+                                setShareDialogTarget({
+                                  targetType: share.target.targetType,
+                                  targetId: share.target.id,
+                                  share,
+                                })
+                              }
+                              type="button"
+                            >
+                              Manage
+                            </button>
+                            <span
+                              aria-hidden={!share.hasPassword}
+                              className="st-password-hint"
+                              title={
+                                share.hasPassword
+                                  ? "Password protected"
+                                  : undefined
+                              }
+                            >
+                              {share.hasPassword ? (
+                                <KeyRound
+                                  aria-label="Password protected"
+                                  size={13}
+                                />
+                              ) : null}
+                            </span>
+                          </div>
+                        </td>
+                      </tr>
+                    </DashboardItemContextMenu>
                   );
                 },
               )}

--- a/apps/web/app/(workspace)/trash/page.tsx
+++ b/apps/web/app/(workspace)/trash/page.tsx
@@ -3,6 +3,7 @@ import {
   formatDateTime,
   getSingleSearchParam,
 } from "@/app/auth-ui";
+import { WorkspacePresetPageContextMenu } from "@/app/dashboard-context-menu";
 import { getItemVisual } from "@/app/item-visuals";
 import { ItemTypeIcon } from "@/app/item-type-icon";
 import { requireSignedInPageSession } from "@/server/auth/guards";
@@ -20,6 +21,7 @@ import {
 } from "@/app/pagination-controls";
 import { redirect } from "next/navigation";
 import { EmptyTrashAction, TrashFileActions } from "./trash-file-actions";
+import { TrashContextMenu } from "./trash-context-menu";
 
 export const dynamic = "force-dynamic";
 
@@ -78,7 +80,11 @@ export default async function TrashPage({ searchParams }: TrashPageProps) {
   );
 
   return (
-    <div className="workspace-page">
+    <WorkspacePresetPageContextMenu
+      className="workspace-page"
+      isTrashEmpty={isEmpty}
+      preset="trash"
+    >
       <section className="panel stack">
         <div className="split">
           <div className="stack">
@@ -119,48 +125,59 @@ export default async function TrashPage({ searchParams }: TrashPageProps) {
 
                 <div className="folder-list">
                   {folders.map((item) => (
-                    <article
-                      className="folder-row"
-                      id={`folder-${item.folder.id}`}
+                    <TrashContextMenu
+                      itemId={item.folder.id}
+                      itemName={item.folder.name}
+                      kind="folder"
                       key={item.folder.id}
                     >
-                      <div className="folder-row-head">
-                        <div className="item-row-title">
-                          <ItemTypeIcon visual={getItemVisual("folder")} />
-                          <div className="stack">
-                            <h2>{item.folder.name}</h2>
-                            <p className="folder-meta">
-                              Deleted{" "}
-                              {formatDateTime(
-                                item.folder.deletedAt ?? item.folder.updatedAt,
-                              )}
-                            </p>
+                      <article
+                        className="folder-row"
+                        id={`folder-${item.folder.id}`}
+                      >
+                        <div className="folder-row-head">
+                          <div className="item-row-title">
+                            <ItemTypeIcon visual={getItemVisual("folder")} />
+                            <div className="stack">
+                              <h2>{item.folder.name}</h2>
+                              <p className="folder-meta">
+                                Deleted{" "}
+                                {formatDateTime(
+                                  item.folder.deletedAt ??
+                                    item.folder.updatedAt,
+                                )}
+                              </p>
+                            </div>
+                          </div>
+                          <span className="pill">Restore ready</span>
+                        </div>
+
+                        <div className="meta-list muted">
+                          <div className="meta-row">
+                            <span>Original path</span>
+                            <strong>{item.originalPathLabel}</strong>
+                          </div>
+                          <div className="meta-row">
+                            <span>Restore target</span>
+                            <strong>{item.restoreLocation.pathLabel}</strong>
                           </div>
                         </div>
-                        <span className="pill">Restore ready</span>
-                      </div>
 
-                      <div className="meta-list muted">
-                        <div className="meta-row">
-                          <span>Original path</span>
-                          <strong>{item.originalPathLabel}</strong>
-                        </div>
-                        <div className="meta-row">
-                          <span>Restore target</span>
-                          <strong>{item.restoreLocation.pathLabel}</strong>
-                        </div>
-                      </div>
-
-                      <form
-                        action={`/api/files/folders/${item.folder.id}/restore`}
-                        method="post"
-                      >
-                        <input name="redirectTo" type="hidden" value="/trash" />
-                        <button className="button" type="submit">
-                          Restore folder
-                        </button>
-                      </form>
-                    </article>
+                        <form
+                          action={`/api/files/folders/${item.folder.id}/restore`}
+                          method="post"
+                        >
+                          <input
+                            name="redirectTo"
+                            type="hidden"
+                            value="/trash"
+                          />
+                          <button className="button" type="submit">
+                            Restore folder
+                          </button>
+                        </form>
+                      </article>
+                    </TrashContextMenu>
                   ))}
                 </div>
               </div>
@@ -178,45 +195,51 @@ export default async function TrashPage({ searchParams }: TrashPageProps) {
 
                 <div className="folder-list">
                   {files.map((item) => (
-                    <article
-                      className="folder-row"
-                      id={`file-${item.file.id}`}
+                    <TrashContextMenu
+                      itemId={item.file.id}
+                      itemName={item.file.name}
+                      kind="file"
                       key={item.file.id}
                     >
-                      <div className="folder-row-head">
-                        <div className="item-row-title">
-                          <ItemTypeIcon
-                            visual={getItemVisual("file", item.file.mimeType)}
-                          />
-                          <div className="stack">
-                            <h2>{item.file.name}</h2>
-                            <p className="folder-meta">
-                              Deleted{" "}
-                              {formatDateTime(
-                                item.file.deletedAt ?? item.file.updatedAt,
-                              )}
-                            </p>
+                      <article
+                        className="folder-row"
+                        id={`file-${item.file.id}`}
+                      >
+                        <div className="folder-row-head">
+                          <div className="item-row-title">
+                            <ItemTypeIcon
+                              visual={getItemVisual("file", item.file.mimeType)}
+                            />
+                            <div className="stack">
+                              <h2>{item.file.name}</h2>
+                              <p className="folder-meta">
+                                Deleted{" "}
+                                {formatDateTime(
+                                  item.file.deletedAt ?? item.file.updatedAt,
+                                )}
+                              </p>
+                            </div>
+                          </div>
+                          <span className="pill">File</span>
+                        </div>
+
+                        <div className="meta-list muted">
+                          <div className="meta-row">
+                            <span>Original path</span>
+                            <strong>{item.originalPathLabel}</strong>
+                          </div>
+                          <div className="meta-row">
+                            <span>Restore target</span>
+                            <strong>{item.restoreLocation.pathLabel}</strong>
                           </div>
                         </div>
-                        <span className="pill">File</span>
-                      </div>
 
-                      <div className="meta-list muted">
-                        <div className="meta-row">
-                          <span>Original path</span>
-                          <strong>{item.originalPathLabel}</strong>
-                        </div>
-                        <div className="meta-row">
-                          <span>Restore target</span>
-                          <strong>{item.restoreLocation.pathLabel}</strong>
-                        </div>
-                      </div>
-
-                      <TrashFileActions
-                        fileId={item.file.id}
-                        fileName={item.file.name}
-                      />
-                    </article>
+                        <TrashFileActions
+                          fileId={item.file.id}
+                          fileName={item.file.name}
+                        />
+                      </article>
+                    </TrashContextMenu>
                   ))}
                 </div>
               </div>
@@ -230,6 +253,6 @@ export default async function TrashPage({ searchParams }: TrashPageProps) {
           </>
         )}
       </section>
-    </div>
+    </WorkspacePresetPageContextMenu>
   );
 }

--- a/apps/web/app/(workspace)/trash/page.tsx
+++ b/apps/web/app/(workspace)/trash/page.tsx
@@ -119,7 +119,11 @@ export default async function TrashPage({ searchParams }: TrashPageProps) {
 
                 <div className="folder-list">
                   {folders.map((item) => (
-                    <article className="folder-row" key={item.folder.id}>
+                    <article
+                      className="folder-row"
+                      id={`folder-${item.folder.id}`}
+                      key={item.folder.id}
+                    >
                       <div className="folder-row-head">
                         <div className="item-row-title">
                           <ItemTypeIcon visual={getItemVisual("folder")} />
@@ -174,7 +178,11 @@ export default async function TrashPage({ searchParams }: TrashPageProps) {
 
                 <div className="folder-list">
                   {files.map((item) => (
-                    <article className="folder-row" key={item.file.id}>
+                    <article
+                      className="folder-row"
+                      id={`file-${item.file.id}`}
+                      key={item.file.id}
+                    >
                       <div className="folder-row-head">
                         <div className="item-row-title">
                           <ItemTypeIcon

--- a/apps/web/app/(workspace)/trash/trash-context-menu.tsx
+++ b/apps/web/app/(workspace)/trash/trash-context-menu.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import type { ReactElement } from "react";
+
+import {
+  DashboardItemContextMenu,
+  submitDashboardPostForm,
+} from "@/app/dashboard-context-menu";
+
+type TrashContextMenuProps = {
+  children: ReactElement;
+  itemId: string;
+  itemName: string;
+  kind: "file" | "folder";
+};
+
+export function TrashContextMenu({
+  children,
+  itemId,
+  itemName,
+  kind,
+}: TrashContextMenuProps) {
+  return (
+    <DashboardItemContextMenu
+      groups={[
+        {
+          actions: [
+            {
+              label: kind === "folder" ? "Restore folder" : "Restore file",
+              onSelect: () =>
+                submitDashboardPostForm({
+                  action: `/api/files/${kind === "folder" ? "folders" : "files"}/${itemId}/restore`,
+                  fields: { redirectTo: "/trash" },
+                }),
+            },
+          ],
+        },
+        {
+          actions: [
+            {
+              destructive: true,
+              hidden: kind !== "file",
+              label: "Delete permanently",
+              onSelect: () =>
+                submitDashboardPostForm({
+                  action: `/api/files/files/${itemId}/delete`,
+                  confirmMessage: `Permanently delete ${itemName}? This cannot be undone.`,
+                  fields: { redirectTo: "/trash" },
+                }),
+            },
+          ],
+        },
+      ]}
+    >
+      {children}
+    </DashboardItemContextMenu>
+  );
+}

--- a/apps/web/app/dashboard-context-menu-model.ts
+++ b/apps/web/app/dashboard-context-menu-model.ts
@@ -1,0 +1,22 @@
+export type DashboardContextMenuActionModel = {
+  disabled?: boolean;
+  hidden?: boolean;
+};
+
+export type DashboardContextMenuGroupModel<
+  TAction extends DashboardContextMenuActionModel,
+> = {
+  actions: TAction[];
+};
+
+export function getVisibleDashboardMenuGroups<
+  TAction extends DashboardContextMenuActionModel,
+  TGroup extends DashboardContextMenuGroupModel<TAction>,
+>(groups: TGroup[]): TGroup[] {
+  return groups
+    .map((group) => ({
+      ...group,
+      actions: group.actions.filter((action) => !action.hidden),
+    }))
+    .filter((group) => group.actions.length > 0);
+}

--- a/apps/web/app/dashboard-context-menu.tsx
+++ b/apps/web/app/dashboard-context-menu.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+import {
+  cloneElement,
+  Fragment,
+  isValidElement,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type HTMLAttributes,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import { useRouter } from "next/navigation";
+import { FolderOpen, RefreshCw } from "lucide-react";
+
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+
+import {
+  getVisibleDashboardMenuGroups,
+  type DashboardContextMenuActionModel,
+  type DashboardContextMenuGroupModel,
+} from "./dashboard-context-menu-model";
+
+const ITEM_CONTEXT_TRIGGER_ATTR = "data-dashboard-item-context-trigger";
+
+export type DashboardContextMenuAction = DashboardContextMenuActionModel & {
+  icon?: ReactNode;
+  label: string;
+  onSelect?: () => void;
+  shortcut?: string;
+  destructive?: boolean;
+  subActions?: DashboardContextMenuAction[];
+};
+
+export type DashboardContextMenuGroup =
+  DashboardContextMenuGroupModel<DashboardContextMenuAction>;
+
+type DashboardContextMenuItemsProps = {
+  groups: DashboardContextMenuGroup[];
+  onActionSelected?: () => void;
+};
+
+function DashboardContextMenuItems({
+  groups,
+  onActionSelected,
+}: DashboardContextMenuItemsProps) {
+  const visibleGroups = getVisibleDashboardMenuGroups(groups);
+
+  return (
+    <>
+      {visibleGroups.map((group, groupIndex) => (
+        <Fragment key={groupIndex}>
+          {groupIndex > 0 ? <ContextMenuSeparator /> : null}
+          {group.actions.map((action) => (
+            <Fragment key={action.label}>
+              {action.subActions && action.subActions.length > 0 ? (
+                <ContextMenuSub>
+                  <ContextMenuSubTrigger>
+                    {action.icon}
+                    {action.label}
+                  </ContextMenuSubTrigger>
+                  <ContextMenuSubContent>
+                    <DashboardContextMenuItems
+                      groups={[{ actions: action.subActions }]}
+                      onActionSelected={onActionSelected}
+                    />
+                  </ContextMenuSubContent>
+                </ContextMenuSub>
+              ) : (
+                <ContextMenuItem
+                  disabled={action.disabled}
+                  variant={action.destructive ? "destructive" : "default"}
+                  onClick={() => {
+                    if (action.disabled) return;
+                    action.onSelect?.();
+                    onActionSelected?.();
+                  }}
+                >
+                  {action.icon}
+                  {action.label}
+                  {action.shortcut ? (
+                    <ContextMenuShortcut>{action.shortcut}</ContextMenuShortcut>
+                  ) : null}
+                </ContextMenuItem>
+              )}
+            </Fragment>
+          ))}
+        </Fragment>
+      ))}
+    </>
+  );
+}
+
+function DashboardFloatingMenuItems({
+  groups,
+  onActionSelected,
+}: DashboardContextMenuItemsProps) {
+  const visibleGroups = getVisibleDashboardMenuGroups(groups);
+
+  return (
+    <>
+      {visibleGroups.map((group, groupIndex) => (
+        <div key={groupIndex}>
+          {groupIndex > 0 ? <div className="bg-ctx-sep" /> : null}
+          {group.actions.map((action) => (
+            <button
+              className={`bg-ctx-item${action.destructive ? " bg-ctx-item--danger" : ""}`}
+              disabled={action.disabled}
+              key={action.label}
+              type="button"
+              onClick={() => {
+                if (action.disabled) return;
+                action.onSelect?.();
+                onActionSelected?.();
+              }}
+            >
+              {action.icon}
+              {action.label}
+              {action.shortcut ? (
+                <span className="bg-ctx-shortcut">{action.shortcut}</span>
+              ) : null}
+            </button>
+          ))}
+        </div>
+      ))}
+    </>
+  );
+}
+
+export function DashboardItemContextMenu({
+  children,
+  groups,
+}: {
+  children: ReactElement;
+  groups: DashboardContextMenuGroup[];
+}) {
+  const trigger = isValidElement<Record<string, unknown>>(children)
+    ? cloneElement(children, {
+        [ITEM_CONTEXT_TRIGGER_ATTR]: "",
+      })
+    : children;
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger render={trigger} />
+      <ContextMenuContent>
+        <DashboardContextMenuItems groups={groups} />
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}
+
+type DashboardPageContextMenuProps = HTMLAttributes<HTMLDivElement> & {
+  groups: DashboardContextMenuGroup[];
+  ignoreSelector?: string;
+};
+
+export function DashboardPageContextMenu({
+  children,
+  groups,
+  ignoreSelector,
+  ...props
+}: DashboardPageContextMenuProps) {
+  const [position, setPosition] = useState<{ x: number; y: number } | null>(
+    null,
+  );
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const onDocumentContextMenu = (event: MouseEvent) => {
+      if (event.defaultPrevented) return;
+
+      const target = event.target instanceof Element ? event.target : null;
+      if (!target?.closest(".workspace-content")) return;
+      if (target.closest(`[${ITEM_CONTEXT_TRIGGER_ATTR}]`)) return;
+      if (ignoreSelector && target.closest(ignoreSelector)) return;
+
+      event.preventDefault();
+      setPosition({ x: event.clientX, y: event.clientY });
+    };
+
+    document.addEventListener("contextmenu", onDocumentContextMenu);
+    return () =>
+      document.removeEventListener("contextmenu", onDocumentContextMenu);
+  }, [ignoreSelector]);
+
+  useEffect(() => {
+    if (!position) return;
+    const close = () => setPosition(null);
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") close();
+    };
+    window.addEventListener("pointerdown", close);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("pointerdown", close);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [position]);
+
+  useLayoutEffect(() => {
+    if (!position || !menuRef.current) return;
+    const { width, height } = menuRef.current.getBoundingClientRect();
+    const pad = 8;
+    const x = Math.max(
+      pad,
+      Math.min(position.x, window.innerWidth - width - pad),
+    );
+    const y = Math.max(
+      pad,
+      Math.min(position.y, window.innerHeight - height - pad),
+    );
+    if (x !== position.x || y !== position.y) setPosition({ x, y });
+  }, [position]);
+
+  return (
+    <>
+      <div {...props}>{children}</div>
+
+      {position
+        ? createPortal(
+            <div
+              ref={menuRef}
+              className="bg-ctx-menu"
+              style={{ top: position.y, left: position.x }}
+              onPointerDown={(event) => event.stopPropagation()}
+            >
+              <DashboardFloatingMenuItems
+                groups={groups}
+                onActionSelected={() => setPosition(null)}
+              />
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+}
+
+export function submitDashboardPostForm({
+  action,
+  confirmMessage,
+  fields,
+}: {
+  action: string;
+  confirmMessage?: string;
+  fields?: Record<string, string>;
+}) {
+  if (confirmMessage && !window.confirm(confirmMessage)) return;
+
+  const form = document.createElement("form");
+  form.method = "post";
+  form.action = action;
+
+  for (const [name, value] of Object.entries(fields ?? {})) {
+    const input = document.createElement("input");
+    input.type = "hidden";
+    input.name = name;
+    input.value = value;
+    form.appendChild(input);
+  }
+
+  document.body.appendChild(form);
+  form.submit();
+}
+
+export function WorkspacePresetPageContextMenu({
+  children,
+  isTrashEmpty,
+  preset,
+  ...props
+}: HTMLAttributes<HTMLDivElement> & {
+  isTrashEmpty?: boolean;
+  preset: "home" | "search" | "shared" | "trash";
+}) {
+  const router = useRouter();
+  const groups: DashboardContextMenuGroup[] = [
+    {
+      actions: [
+        {
+          icon: <RefreshCw size={13} />,
+          label: "Refresh",
+          onSelect: () => router.refresh(),
+        },
+        {
+          hidden: preset === "shared" || preset === "trash",
+          icon: <FolderOpen size={13} />,
+          label: "Open files",
+          onSelect: () => router.push("/files"),
+        },
+        {
+          hidden: preset !== "shared",
+          label: "New share link",
+          onSelect: () => router.push("/files"),
+        },
+        {
+          destructive: true,
+          disabled: isTrashEmpty,
+          hidden: preset !== "trash",
+          label: "Empty trash",
+          onSelect: () =>
+            submitDashboardPostForm({
+              action: "/api/files/trash/clear",
+              confirmMessage:
+                "Empty trash? This permanently deletes all trashed folder trees and standalone files.",
+              fields: { redirectTo: "/trash" },
+            }),
+        },
+      ],
+    },
+  ];
+
+  return (
+    <DashboardPageContextMenu groups={groups} {...props}>
+      {children}
+    </DashboardPageContextMenu>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2041,19 +2041,22 @@ h3 {
   gap: 8px;
 }
 
-.recent-filter-label {
+.recent-filter-label,
+.favorites-filter-control {
   display: inline-flex;
   align-items: center;
   gap: 8px;
   min-height: 30px;
-  padding: 0 0 0 10px;
+  padding: 0 9px 0 10px;
   border: 1px solid var(--border);
   border-radius: 7px;
   color: color-mix(in oklab, var(--foreground) 76%, transparent);
   background: transparent;
+  white-space: nowrap;
 }
 
-.recent-filter-label span {
+.recent-filter-label span,
+.favorites-filter-control span {
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.05em;
@@ -2062,9 +2065,10 @@ h3 {
   color: color-mix(in oklab, var(--foreground) 45%, transparent);
 }
 
-.recent-type-select {
+.recent-type-select,
+.favorites-filter-control select {
   min-height: 28px;
-  padding: 0 28px 0 0;
+  padding: 0 22px 0 0;
   border: 0;
   color: var(--foreground);
   background: transparent;
@@ -2638,38 +2642,6 @@ h3 {
   gap: 8px;
 }
 
-.favorites-filter-control {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  min-height: 30px;
-  padding: 0 9px;
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  color: color-mix(in oklab, var(--foreground) 76%, transparent);
-  white-space: nowrap;
-}
-
-.favorites-filter-control span {
-  color: color-mix(in oklab, var(--muted-foreground) 70%, transparent);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  line-height: 1;
-  text-transform: uppercase;
-}
-
-.favorites-filter-control select {
-  min-height: 28px;
-  padding: 0 18px 0 0;
-  border: 0;
-  background: transparent;
-  color: var(--foreground);
-  font: inherit;
-  font-size: 13px;
-  line-height: 1;
-}
-
 .favorites-filter-control select:focus {
   outline: none;
 }
@@ -2707,6 +2679,9 @@ h3 {
 }
 
 .favorites-selection-surface {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
   position: relative;
   min-height: calc(100vh - 120px);
   user-select: none;
@@ -6072,14 +6047,6 @@ main.share-locked-page {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-}
-
-.shared-toolbar .favorites-filter-control {
-  min-height: 28px;
-}
-
-.shared-toolbar .favorites-filter-control select {
-  min-width: 96px;
 }
 
 /* Group (Active / Inactive) */

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2108,13 +2108,15 @@ h3 {
 .recent-table-wrap {
   display: grid;
   min-height: 0;
+  position: relative;
+  user-select: none;
 }
 
 .recent-col-head,
 .recent-row {
   display: grid;
   grid-template-columns:
-    28px 28px minmax(180px, 1fr) minmax(140px, 180px) minmax(70px, 80px)
+    28px minmax(180px, 1fr) minmax(140px, 180px) minmax(70px, 80px)
     minmax(86px, 110px);
   align-items: center;
   gap: 0 10px;
@@ -2211,6 +2213,11 @@ h3 {
   background: color-mix(in oklab, var(--primary) 8%, transparent);
 }
 
+.recent-row.is-selected:hover,
+.recent-row.is-selected:focus-within {
+  background: color-mix(in oklab, var(--primary) 10%, transparent);
+}
+
 .recent-row.is-deleted {
   color: var(--muted-foreground);
   background: color-mix(in oklab, var(--foreground) 2%, transparent);
@@ -2219,38 +2226,6 @@ h3 {
 .recent-row.is-deleted:hover,
 .recent-row.is-deleted:focus-within {
   background: color-mix(in oklab, var(--foreground) 3%, transparent);
-}
-
-.recent-select-box {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  justify-self: center;
-  width: 15px;
-  height: 15px;
-  border: 1.5px solid color-mix(in oklab, var(--foreground) 28%, transparent);
-  border-radius: 4px;
-  background: transparent;
-}
-
-.recent-select-box:disabled {
-  border-color: color-mix(in oklab, var(--foreground) 14%, transparent);
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-.recent-select-box.is-checked {
-  border-color: var(--primary);
-  background: var(--primary);
-}
-
-.recent-select-box.is-checked::after {
-  width: 7px;
-  height: 4px;
-  border-bottom: 1.6px solid var(--primary-foreground);
-  border-left: 1.6px solid var(--primary-foreground);
-  content: "";
-  transform: translateY(-1px) rotate(-45deg);
 }
 
 .recent-row-thumb {
@@ -2398,6 +2373,8 @@ h3 {
   display: grid;
   gap: 4px;
   padding-bottom: 56px;
+  position: relative;
+  user-select: none;
 }
 
 .recent-grid-cards {
@@ -2490,21 +2467,6 @@ h3 {
   line-height: 1.3;
 }
 
-.recent-grid-card-check {
-  position: absolute;
-  top: 7px;
-  left: 7px;
-  z-index: 1;
-  opacity: 0;
-  transition: opacity 100ms ease;
-}
-
-.recent-grid-card:hover .recent-grid-card-check,
-.recent-grid-card.is-selected .recent-grid-card-check,
-.recent-grid-card:focus-within .recent-grid-card-check {
-  opacity: 1;
-}
-
 .recent-grid-card-actions {
   position: absolute;
   top: 7px;
@@ -2547,57 +2509,10 @@ h3 {
   opacity: 0.45;
 }
 
-.recent-float-bar {
-  position: fixed;
-  bottom: 24px;
-  left: 50%;
-  z-index: 40;
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  padding: 10px 8px 10px 16px;
-  border-radius: 12px;
-  color: var(--background);
-  background: var(--foreground);
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.22);
-  font-size: 13px;
-  font-weight: 650;
-  transform: translateX(-50%);
-}
-
-.recent-float-bar button {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  min-height: 32px;
-  padding: 0 12px;
-  border: 0;
-  border-radius: 8px;
-  color: inherit;
-  background: rgba(255, 255, 255, 0.12);
-  font: inherit;
-  font-size: 12.5px;
-}
-
-.recent-float-bar button:hover {
-  background: rgba(255, 255, 255, 0.2);
-}
-
-.recent-float-danger {
-  color: var(--background);
-}
-
-.recent-float-divider {
-  width: 1px;
-  height: 20px;
-  margin: 0 2px;
-  background: rgba(255, 255, 255, 0.18);
-}
-
 @media (max-width: 860px) {
   .recent-col-head,
   .recent-row {
-    grid-template-columns: 28px 28px minmax(140px, 1fr) minmax(78px, 96px);
+    grid-template-columns: 28px minmax(140px, 1fr) minmax(78px, 96px);
   }
 
   .recent-col-head-cell[data-column="path"],
@@ -2610,14 +2525,6 @@ h3 {
   .recent-row-actions {
     opacity: 1;
     pointer-events: auto;
-  }
-
-  .recent-float-bar {
-    right: 14px;
-    bottom: 14px;
-    left: 14px;
-    justify-content: center;
-    transform: none;
   }
 }
 
@@ -2633,10 +2540,6 @@ h3 {
 
   .recent-type-select {
     flex: 1;
-  }
-
-  .recent-float-bar {
-    flex-wrap: wrap;
   }
 }
 

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1504,6 +1504,7 @@ h3 {
 
 .explorer-badges {
   display: flex;
+  align-items: center;
   gap: 8px;
 }
 
@@ -2031,7 +2032,7 @@ h3 {
 
 .recent-header .section-count,
 .favorites-header .section-count {
-  transform: translateY(1px);
+  transform: none;
 }
 
 .recent-toolbar {
@@ -2556,6 +2557,7 @@ h3 {
   display: flex;
   align-items: center;
   gap: 10px;
+  flex-wrap: wrap;
 }
 
 .favorites-section-eyebrow {
@@ -2704,9 +2706,17 @@ h3 {
   background: color-mix(in oklab, var(--foreground) 10%, transparent);
 }
 
+.favorites-selection-surface {
+  position: relative;
+  min-height: calc(100vh - 120px);
+  user-select: none;
+}
+
 .favorites-list-wrap {
   display: grid;
   min-height: 0;
+  position: relative;
+  user-select: none;
 }
 
 .favorites-col-head,
@@ -2761,6 +2771,7 @@ h3 {
   padding: 0 8px 0 4px;
   border-bottom: 1px solid
     color-mix(in oklab, var(--foreground) 5%, transparent);
+  cursor: default;
   transition: background 80ms ease;
 }
 
@@ -2773,8 +2784,18 @@ h3 {
   background: color-mix(in oklab, var(--foreground) 4%, transparent);
 }
 
+.favorites-row.is-selected {
+  background: color-mix(in oklab, var(--primary) 8%, transparent);
+}
+
+.favorites-row.is-selected:hover,
+.favorites-row.is-selected:focus-within {
+  background: color-mix(in oklab, var(--primary) 10%, transparent);
+}
+
 .favorites-row-name,
 .favorites-grid-name {
+  display: block;
   min-width: 0;
   overflow: hidden;
   padding: 0;
@@ -2886,6 +2907,8 @@ h3 {
   grid-template-columns: repeat(auto-fill, minmax(168px, 1fr));
   gap: 10px;
   padding-bottom: 56px;
+  position: relative;
+  user-select: none;
 }
 
 .favorites-grid-card {
@@ -2895,6 +2918,7 @@ h3 {
   border-radius: 10px;
   background: color-mix(in oklab, var(--foreground) 3%, transparent);
   color: var(--foreground);
+  cursor: default;
   transition:
     background 100ms ease,
     border-color 100ms ease;
@@ -2904,6 +2928,11 @@ h3 {
 .favorites-grid-card:focus-within {
   border-color: color-mix(in oklab, var(--foreground) 14%, transparent);
   background: color-mix(in oklab, var(--foreground) 5%, transparent);
+}
+
+.favorites-grid-card.is-selected {
+  border-color: color-mix(in oklab, var(--primary) 32%, transparent);
+  background: color-mix(in oklab, var(--primary) 8%, transparent);
 }
 
 .favorites-grid-preview {
@@ -3740,12 +3769,18 @@ h3 {
 }
 
 .section-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
   font-size: 12px;
   font-weight: 600;
+  line-height: 1;
   color: var(--muted-foreground);
   background: color-mix(in oklab, var(--foreground) 7%, var(--card));
   border-radius: 999px;
-  padding: 2px 8px;
+  padding: 0 8px;
 }
 
 /* ---- Upload zone ---- */
@@ -4027,7 +4062,7 @@ h3 {
 
 .explorer-title-row {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 12px;
   flex-wrap: wrap;
 }
@@ -4061,22 +4096,32 @@ h3 {
 }
 
 .selection-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 22px;
   font-size: 12px;
   font-weight: 500;
+  line-height: 1;
   color: color-mix(in oklab, var(--primary) 76%, var(--foreground) 24%);
   background: color-mix(in oklab, var(--primary) 8%, var(--card));
   border-radius: 999px;
-  padding: 3px 10px;
+  padding: 0 10px;
   white-space: nowrap;
 }
 
 .cut-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 22px;
   font-size: 12px;
   font-weight: 600;
+  line-height: 1;
   color: var(--muted-foreground);
   background: color-mix(in oklab, var(--foreground) 8%, var(--card));
   border-radius: 999px;
-  padding: 3px 10px;
+  padding: 0 10px;
   white-space: nowrap;
   cursor: pointer;
 }
@@ -4084,13 +4129,16 @@ h3 {
 .download-badge {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 4px;
+  height: 22px;
   font-size: 12px;
   font-weight: 600;
+  line-height: 1;
   color: var(--muted-foreground);
   background: color-mix(in oklab, var(--foreground) 8%, var(--card));
   border-radius: 999px;
-  padding: 3px 10px;
+  padding: 0 10px;
   white-space: nowrap;
   cursor: pointer;
   border: none;
@@ -5989,7 +6037,7 @@ main.share-locked-page {
 }
 
 .shared-header .section-count {
-  transform: translateY(1px);
+  transform: none;
 }
 
 .shared-new-link {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1903,6 +1903,11 @@ h3 {
   border-color: color-mix(in oklab, var(--foreground) 7%, transparent);
 }
 
+.folder-row:target {
+  border-color: color-mix(in oklab, var(--primary) 38%, transparent);
+  background: color-mix(in oklab, var(--primary) 8%, var(--card));
+}
+
 .folder-row-head {
   display: flex;
   flex-wrap: wrap;
@@ -2206,6 +2211,16 @@ h3 {
   background: color-mix(in oklab, var(--primary) 8%, transparent);
 }
 
+.recent-row.is-deleted {
+  color: var(--muted-foreground);
+  background: color-mix(in oklab, var(--foreground) 2%, transparent);
+}
+
+.recent-row.is-deleted:hover,
+.recent-row.is-deleted:focus-within {
+  background: color-mix(in oklab, var(--foreground) 3%, transparent);
+}
+
 .recent-select-box {
   display: inline-flex;
   align-items: center;
@@ -2216,6 +2231,12 @@ h3 {
   border: 1.5px solid color-mix(in oklab, var(--foreground) 28%, transparent);
   border-radius: 4px;
   background: transparent;
+}
+
+.recent-select-box:disabled {
+  border-color: color-mix(in oklab, var(--foreground) 14%, transparent);
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 
 .recent-select-box.is-checked {
@@ -2289,6 +2310,19 @@ h3 {
   opacity: 0.75;
 }
 
+.recent-deleted-badge {
+  flex: 0 0 auto;
+  padding: 2px 6px;
+  border: 1px solid
+    color-mix(in oklab, var(--muted-foreground) 20%, transparent);
+  border-radius: 999px;
+  color: color-mix(in oklab, var(--muted-foreground) 86%, transparent);
+  background: color-mix(in oklab, var(--foreground) 5%, transparent);
+  font-size: 10.5px;
+  font-weight: 650;
+  line-height: 1.1;
+}
+
 .recent-row-actions,
 .recent-grid-card-actions {
   display: inline-flex;
@@ -2299,6 +2333,11 @@ h3 {
   border-radius: 7px;
   background: color-mix(in oklab, var(--card) 94%, var(--foreground) 6%);
   box-shadow: 0 1px 4px color-mix(in oklab, var(--foreground) 8%, transparent);
+}
+
+.recent-row-actions form,
+.recent-grid-card-actions form {
+  display: inline-flex;
 }
 
 .recent-row-actions {
@@ -2327,6 +2366,22 @@ h3 {
   border-radius: 5px;
   color: var(--muted-foreground);
   background: transparent;
+}
+
+.recent-row-inline-actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: color-mix(in oklab, var(--card) 94%, var(--foreground) 6%);
+  box-shadow: 0 1px 4px color-mix(in oklab, var(--foreground) 8%, transparent);
+}
+
+.recent-row-inline-actions form {
+  display: inline-flex;
 }
 
 .recent-action-btn:hover {
@@ -2373,6 +2428,16 @@ h3 {
   background: color-mix(in oklab, var(--primary) 8%, transparent);
 }
 
+.recent-grid-card.is-deleted {
+  border-color: color-mix(in oklab, var(--foreground) 7%, transparent);
+  background: color-mix(in oklab, var(--foreground) 2%, transparent);
+}
+
+.recent-grid-card.is-deleted:hover {
+  border-color: color-mix(in oklab, var(--foreground) 10%, transparent);
+  background: color-mix(in oklab, var(--foreground) 3%, transparent);
+}
+
 .recent-grid-card-preview {
   display: flex;
   align-items: center;
@@ -2401,6 +2466,19 @@ h3 {
   line-height: 1.35;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.recent-grid-card.is-deleted .recent-grid-card-name,
+.recent-row.is-deleted .recent-row-name,
+.recent-row.is-deleted .recent-row-location,
+.recent-row.is-deleted .recent-row-size,
+.recent-row.is-deleted .recent-row-time {
+  color: color-mix(in oklab, var(--muted-foreground) 72%, transparent);
+}
+
+.recent-grid-card.is-deleted .recent-grid-card-preview .item-type-icon,
+.recent-row.is-deleted .recent-row-thumb {
+  opacity: 0.52;
 }
 
 .recent-grid-card-meta {
@@ -2437,7 +2515,8 @@ h3 {
 }
 
 .recent-grid-card:hover .recent-grid-card-actions,
-.recent-grid-card:focus-within .recent-grid-card-actions {
+.recent-grid-card:focus-within .recent-grid-card-actions,
+.recent-grid-card.is-deleted .recent-grid-card-actions {
   opacity: 1;
   pointer-events: auto;
 }
@@ -2693,6 +2772,7 @@ h3 {
 .favorites-view-toggle {
   display: inline-flex;
   flex-shrink: 0;
+  margin-left: auto;
   overflow: hidden;
   border: 1px solid color-mix(in oklab, var(--foreground) 10%, transparent);
   border-radius: 7px;
@@ -2703,8 +2783,8 @@ h3 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 30px;
+  width: 34px;
+  min-height: 30px;
   color: var(--muted-foreground);
   transition:
     background 100ms ease,

--- a/apps/web/app/item-context-menu.tsx
+++ b/apps/web/app/item-context-menu.tsx
@@ -2,14 +2,7 @@
 
 import type { ReactElement } from "react";
 
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuSeparator,
-  ContextMenuShortcut,
-  ContextMenuTrigger,
-} from "@/components/ui/context-menu";
+import { DashboardItemContextMenu } from "@/app/dashboard-context-menu";
 
 type ItemContextMenuProps = {
   children: ReactElement;
@@ -76,64 +69,63 @@ export function ItemContextMenu({
   const effectiveDownloadHref = downloadHref;
 
   return (
-    <ContextMenu>
-      <ContextMenuTrigger render={children} />
-      <ContextMenuContent>
-        <ContextMenuItem
-          onClick={() => {
-            window.location.href = href;
-          }}
-        >
-          {openLabel}
-          <ContextMenuShortcut>↵</ContextMenuShortcut>
-        </ContextMenuItem>
-
-        {effectiveDownloadHref ? (
-          <ContextMenuItem
-            onClick={() => {
-              window.location.href = effectiveDownloadHref;
-            }}
-          >
-            {kind === "folder" ? "Download as zip" : "Download"}
-          </ContextMenuItem>
-        ) : null}
-
-        {canFavorite || shareHref ? <ContextMenuSeparator /> : null}
-
-        {canFavorite ? (
-          <ContextMenuItem
-            onClick={() =>
-              submitFavorite({
-                id,
-                isFavorite: Boolean(isFavorite),
-                kind,
-                redirectTo,
-              })
-            }
-          >
-            {isFavorite ? "Remove from favorites" : "Add to favorites"}
-          </ContextMenuItem>
-        ) : null}
-
-        {shareHref ? (
-          <ContextMenuItem
-            onClick={() => {
-              window.location.href = shareHref;
-            }}
-          >
-            Manage shared link
-          </ContextMenuItem>
-        ) : null}
-
-        <ContextMenuSeparator />
-        <ContextMenuItem
-          onClick={() => {
-            void navigator.clipboard?.writeText(name);
-          }}
-        >
-          Copy name
-        </ContextMenuItem>
-      </ContextMenuContent>
-    </ContextMenu>
+    <DashboardItemContextMenu
+      groups={[
+        {
+          actions: [
+            {
+              label: openLabel,
+              shortcut: "↵",
+              onSelect: () => {
+                window.location.href = href;
+              },
+            },
+            {
+              hidden: !effectiveDownloadHref,
+              label: kind === "folder" ? "Download as zip" : "Download",
+              onSelect: () => {
+                if (!effectiveDownloadHref) return;
+                window.location.href = effectiveDownloadHref;
+              },
+            },
+          ],
+        },
+        {
+          actions: [
+            {
+              hidden: !canFavorite,
+              label: isFavorite ? "Remove from favorites" : "Add to favorites",
+              onSelect: () =>
+                submitFavorite({
+                  id,
+                  isFavorite: Boolean(isFavorite),
+                  kind: kind as "file" | "folder",
+                  redirectTo,
+                }),
+            },
+            {
+              hidden: !shareHref,
+              label: "Manage shared link",
+              onSelect: () => {
+                if (!shareHref) return;
+                window.location.href = shareHref;
+              },
+            },
+          ],
+        },
+        {
+          actions: [
+            {
+              label: "Copy name",
+              onSelect: () => {
+                void navigator.clipboard?.writeText(name);
+              },
+            },
+          ],
+        },
+      ]}
+    >
+      {children}
+    </DashboardItemContextMenu>
   );
 }

--- a/apps/web/components/ui/context-menu.tsx
+++ b/apps/web/components/ui/context-menu.tsx
@@ -44,10 +44,10 @@ function ContextMenuTrigger({
               return elementProps
                 ? React.cloneElement(
                     element,
-                    mergeProps(triggerProps, {
+                    mergeProps(elementProps, triggerProps, {
                       className: cn(
-                        triggerProps.className,
                         elementProps.className,
+                        triggerProps.className,
                       ),
                     }),
                   )

--- a/apps/web/server/dashboard-context-menu-model.test.ts
+++ b/apps/web/server/dashboard-context-menu-model.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { getVisibleDashboardMenuGroups } from "@/app/dashboard-context-menu-model";
+
+describe("dashboard context menu model", () => {
+  it("removes hidden actions and empty groups", () => {
+    expect(
+      getVisibleDashboardMenuGroups([
+        { actions: [{ hidden: true }, {}] },
+        { actions: [{ hidden: true }] },
+        { actions: [{}] },
+      ]),
+    ).toEqual([{ actions: [{}] }, { actions: [{}] }]);
+  });
+
+  it("keeps disabled actions visible", () => {
+    expect(
+      getVisibleDashboardMenuGroups([{ actions: [{ disabled: true }] }]),
+    ).toEqual([{ actions: [{ disabled: true }] }]);
+  });
+});

--- a/apps/web/server/favorites-page-helpers.test.ts
+++ b/apps/web/server/favorites-page-helpers.test.ts
@@ -28,6 +28,7 @@ const makeFile = (
   quickAccessPinnedAt: null,
   sizeBytes: 2400000,
   updatedAt: new Date("2026-05-19T10:00:00.000Z"),
+  deletedAt: null,
   ...overrides,
 });
 
@@ -44,6 +45,7 @@ const makeFolder = (
   pathLabel: "Files / Design",
   quickAccessPinnedAt: null,
   updatedAt: new Date("2026-05-19T09:00:00.000Z"),
+  deletedAt: null,
   ...overrides,
 });
 

--- a/apps/web/server/recent-page-helpers.test.ts
+++ b/apps/web/server/recent-page-helpers.test.ts
@@ -27,6 +27,7 @@ const makeFile = (
   pathLabel: "Files / Design / hero.png",
   sizeBytes: 2400000,
   updatedAt: new Date("2026-05-19T10:00:00.000Z"),
+  deletedAt: null,
   ...overrides,
 });
 
@@ -41,6 +42,7 @@ const makeFolder = (
   parentId: "root",
   pathLabel: "Files / Design",
   updatedAt: new Date("2026-05-19T09:00:00.000Z"),
+  deletedAt: null,
   ...overrides,
 });
 
@@ -56,6 +58,7 @@ const clientItem = (
   name: "hero.png",
   sizeBytes: 2400000,
   uploadedAt: "2026-05-19T10:00:00.000Z",
+  deletedAt: null,
   ...overrides,
 });
 
@@ -67,6 +70,7 @@ describe("recent page helpers", () => {
     expect(
       toRecentClientItem(
         makeFile({
+          deletedAt: new Date("2026-05-20T08:00:00.000Z"),
           pathLabel: "Files / Client / Reports / Q1.pdf",
           name: "Q1.pdf",
           mimeType: "application/pdf",
@@ -74,6 +78,7 @@ describe("recent page helpers", () => {
       ),
     ).toMatchObject({
       kind: "file",
+      deletedAt: "2026-05-20T08:00:00.000Z",
       locationLabel: "Client / Reports",
       mimeType: "application/pdf",
       uploadedAt: "2026-05-19T10:00:00.000Z",

--- a/apps/web/server/retrieval/repository.ts
+++ b/apps/web/server/retrieval/repository.ts
@@ -44,15 +44,15 @@ export const createPrismaRetrievalRepository = ({
       return getFilesRepo().findFileById(fileId);
     },
 
-    listFoldersByOwner(ownerUserId) {
+    listFoldersByOwner(ownerUserId, options = {}) {
       return getFilesRepo().listFoldersByOwner(ownerUserId, {
-        includeDeleted: false,
+        includeDeleted: options.includeDeleted ?? false,
       });
     },
 
-    listFilesByOwner(ownerUserId) {
+    listFilesByOwner(ownerUserId, options = {}) {
       return getFilesRepo().listFilesByOwner(ownerUserId, {
-        includeDeleted: false,
+        includeDeleted: options.includeDeleted ?? false,
       });
     },
 

--- a/apps/web/server/retrieval/service.test.ts
+++ b/apps/web/server/retrieval/service.test.ts
@@ -154,19 +154,22 @@ const createMemoryRepository = () => {
       return file ? cloneFile(file) : null;
     },
 
-    async listFoldersByOwner(ownerUserId) {
+    async listFoldersByOwner(ownerUserId, options = {}) {
       return state.folders
         .filter(
           (folder) =>
-            folder.ownerUserId === ownerUserId && folder.deletedAt === null,
+            folder.ownerUserId === ownerUserId &&
+            (options.includeDeleted || folder.deletedAt === null),
         )
         .map(cloneFolder);
     },
 
-    async listFilesByOwner(ownerUserId) {
+    async listFilesByOwner(ownerUserId, options = {}) {
       return state.files
         .filter(
-          (file) => file.ownerUserId === ownerUserId && file.deletedAt === null,
+          (file) =>
+            file.ownerUserId === ownerUserId &&
+            (options.includeDeleted || file.deletedAt === null),
         )
         .map(cloneFile);
     },
@@ -715,7 +718,7 @@ describe("retrieval service", () => {
     ]);
   });
 
-  it("lists recently added active files and folders by created time", async () => {
+  it("lists recently added files and folders by created time", async () => {
     const { repo, ensureFilesRootRecord, addFolder, addFile } =
       createMemoryRepository();
     const root = ensureFilesRootRecord("alice");
@@ -764,14 +767,16 @@ describe("retrieval service", () => {
     });
 
     expect(items.map((item) => [item.kind, item.name])).toEqual([
+      ["file", "trashed.bin"],
       ["file", "newer.bin"],
       ["folder", "Uploads"],
       ["file", "older.bin"],
     ]);
-    expect(items[2]?.updatedAt.toISOString()).toBe("2026-05-19T10:00:00.000Z");
+    expect(items[0]?.deletedAt?.toISOString()).toBe("2026-05-19T13:05:00.000Z");
+    expect(items[3]?.updatedAt.toISOString()).toBe("2026-05-19T10:00:00.000Z");
   });
 
-  it("records recent folder and file interactions as one row per item", async () => {
+  it("lists soft-deleted items on the recent page", async () => {
     const { repo, ensureFilesRootRecord, addFolder, addFile, state } =
       createMemoryRepository();
     const root = ensureFilesRootRecord("alice");
@@ -779,57 +784,59 @@ describe("retrieval service", () => {
       ownerUserId: "alice",
       parentId: root.id,
       name: "Projects",
+      createdAt: new Date("2026-04-02T15:00:00.000Z"),
     });
     const file = addFile({
       ownerUserId: "alice",
       folderId: folder.id,
       name: "notes.txt",
+      createdAt: new Date("2026-04-02T15:10:00.000Z"),
+      deletedAt: new Date("2026-04-02T15:15:00.000Z"),
     });
-    let currentTime = new Date("2026-04-02T15:00:00.000Z");
-    const service = createRetrievalService({
-      repo,
-      now: () => currentTime,
+    const deletedFolder = addFolder({
+      ownerUserId: "alice",
+      parentId: root.id,
+      name: "Archive",
+      createdAt: new Date("2026-04-02T15:20:00.000Z"),
+      deletedAt: new Date("2026-04-02T15:25:00.000Z"),
     });
+    const service = createRetrievalService({ repo });
 
-    await service.recordFolderAccess({
-      actorUserId: "alice",
-      actorRole: "member",
-      folderId: root.id,
-    });
-    await service.recordFolderAccess({
-      actorUserId: "alice",
-      actorRole: "member",
-      folderId: folder.id,
-    });
-    currentTime = new Date("2026-04-02T15:05:00.000Z");
-    await service.recordFolderAccess({
-      actorUserId: "alice",
-      actorRole: "member",
-      folderId: folder.id,
-    });
-    currentTime = new Date("2026-04-02T15:10:00.000Z");
-    await service.recordFileAccess({
-      actorUserId: "alice",
-      actorRole: "member",
-      fileId: file.id,
-    });
-    currentTime = new Date("2026-04-02T15:15:00.000Z");
-    file.deletedAt = new Date("2026-04-02T15:15:00.000Z");
-    await service.recordFileAccess({
-      actorUserId: "alice",
-      actorRole: "member",
-      fileId: file.id,
-    });
-
-    expect(state.recentFolders).toHaveLength(1);
-    expect(state.recentFiles).toHaveLength(1);
-
-    const recents = await service.listRecent({
+    const recents = await service.listRecentlyAdded({
       actorUserId: "alice",
       actorRole: "member",
     });
 
     expect(recents).toEqual([
+      expect.objectContaining({
+        deletedAt: new Date("2026-04-02T15:25:00.000Z"),
+        kind: "folder",
+        name: "Archive",
+      }),
+      expect.objectContaining({
+        deletedAt: new Date("2026-04-02T15:15:00.000Z"),
+        kind: "file",
+        name: "notes.txt",
+      }),
+      expect.objectContaining({
+        deletedAt: null,
+        kind: "folder",
+        name: "Projects",
+      }),
+    ]);
+
+    state.files = state.files.filter((candidate) => candidate.id !== file.id);
+
+    await expect(
+      service.listRecentlyAdded({
+        actorUserId: "alice",
+        actorRole: "member",
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        kind: "folder",
+        name: "Archive",
+      }),
       expect.objectContaining({
         kind: "folder",
         name: "Projects",

--- a/apps/web/server/retrieval/service.ts
+++ b/apps/web/server/retrieval/service.ts
@@ -192,6 +192,7 @@ const toFolderItem = ({
   }),
   href: getFolderHref(folder),
   updatedAt: folder.updatedAt,
+  deletedAt: folder.deletedAt,
   isFavorite: favoriteFolderIds.has(folder.id),
   parentId: folder.parentId,
 });
@@ -217,6 +218,7 @@ const toFileItem = ({
   }),
   href: getFileHref(file),
   updatedAt: file.updatedAt,
+  deletedAt: file.deletedAt,
   isFavorite: favoriteFileIds.has(file.id),
   folderId: file.folderId,
   mimeType: file.mimeType,
@@ -500,8 +502,8 @@ export const createRetrievalService = ({
       const activeRepo = await resolveRepo();
       const [filesRoot, folders, files, favoriteState] = await Promise.all([
         activeRepo.ensureFilesRoot(actorUserId),
-        activeRepo.listFoldersByOwner(actorUserId),
-        activeRepo.listFilesByOwner(actorUserId),
+        activeRepo.listFoldersByOwner(actorUserId, { includeDeleted: true }),
+        activeRepo.listFilesByOwner(actorUserId, { includeDeleted: true }),
         getFavoriteState(actorUserId),
       ]);
       const folderMap = buildFolderMap(folders);

--- a/apps/web/server/retrieval/types.ts
+++ b/apps/web/server/retrieval/types.ts
@@ -9,6 +9,7 @@ export type RetrievalItem =
       pathLabel: string;
       href: string;
       updatedAt: Date;
+      deletedAt: Date | null;
       isFavorite: boolean;
       matchKind?: SearchMatchKind;
       parentId: string | null;
@@ -20,6 +21,7 @@ export type RetrievalItem =
       pathLabel: string;
       href: string;
       updatedAt: Date;
+      deletedAt: Date | null;
       isFavorite: boolean;
       matchKind?: SearchMatchKind;
       folderId: string | null;
@@ -65,12 +67,22 @@ export type RecentFolderRecord = {
   lastInteractedAt: Date;
 };
 
+export type RetrievalListOptions = {
+  includeDeleted?: boolean;
+};
+
 export type RetrievalRepository = {
   ensureFilesRoot(ownerUserId: string): Promise<FolderSummary>;
   findFolderById(folderId: string): Promise<FolderSummary | null>;
   findFileById(fileId: string): Promise<FileSummary | null>;
-  listFoldersByOwner(ownerUserId: string): Promise<FolderSummary[]>;
-  listFilesByOwner(ownerUserId: string): Promise<FileSummary[]>;
+  listFoldersByOwner(
+    ownerUserId: string,
+    options?: RetrievalListOptions,
+  ): Promise<FolderSummary[]>;
+  listFilesByOwner(
+    ownerUserId: string,
+    options?: RetrievalListOptions,
+  ): Promise<FileSummary[]>;
   searchFilesByOwner(
     ownerUserId: string,
     nameQuery: string,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "prepare": "husky",
     "db:generate": "pnpm --filter @staaash/db db:generate",
     "db:push": "pnpm --filter @staaash/db exec prisma db push",
+    "app:clear-caches": "node scripts/clear-caches.mjs",
     "app:reset-local-data": "node scripts/reset-local-data.mjs"
   },
   "lint-staged": {

--- a/scripts/clear-caches.mjs
+++ b/scripts/clear-caches.mjs
@@ -1,0 +1,106 @@
+import path from "node:path";
+import { existsSync } from "node:fs";
+import { readdir, rm } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDirectory, "..");
+const dryRun = process.argv.includes("--dry-run");
+
+const explicitTargets = [
+  ".cache",
+  ".eslintcache",
+  ".parcel-cache",
+  ".tmp",
+  ".turbo",
+  ".vite",
+  "coverage",
+  "playwright-report",
+  "test-results",
+  "apps/web/.next",
+  "apps/web/.tmp",
+  "apps/web/.turbo",
+  "apps/web/coverage",
+  "apps/web/playwright-report",
+  "apps/web/test-results",
+  "apps/worker/.turbo",
+  "apps/worker/coverage",
+  "apps/worker/dist",
+  "packages/config/.turbo",
+  "packages/config/coverage",
+  "packages/config/dist",
+  "packages/db/.turbo",
+  "packages/db/coverage",
+  "packages/db/dist",
+];
+
+const skippedDirectoryNames = new Set([
+  ".data",
+  ".git",
+  ".next",
+  ".turbo",
+  "node_modules",
+]);
+
+const ensurePathWithinRepo = (targetPath) => {
+  const relativePath = path.relative(repoRoot, targetPath);
+
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    throw new Error(
+      `Refusing to delete a path outside the repository: ${targetPath}`,
+    );
+  }
+};
+
+const repoPath = (targetPath) => path.resolve(repoRoot, targetPath);
+
+const deleteTarget = async (targetPath) => {
+  ensurePathWithinRepo(targetPath);
+
+  if (!existsSync(targetPath)) {
+    return;
+  }
+
+  const displayPath = path.relative(repoRoot, targetPath);
+  console.log(`${dryRun ? "Would delete" : "Deleted"} ${displayPath}`);
+
+  if (!dryRun) {
+    await rm(targetPath, { recursive: true, force: true });
+  }
+};
+
+const findTsBuildInfoFiles = async (directoryPath) => {
+  const files = [];
+  const entries = await readdir(directoryPath, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const entryPath = path.join(directoryPath, entry.name);
+
+    if (entry.isDirectory()) {
+      if (skippedDirectoryNames.has(entry.name)) {
+        continue;
+      }
+
+      files.push(...(await findTsBuildInfoFiles(entryPath)));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.endsWith(".tsbuildinfo")) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+};
+
+for (const target of explicitTargets) {
+  await deleteTarget(repoPath(target));
+}
+
+for (const target of await findTsBuildInfoFiles(repoRoot)) {
+  await deleteTarget(target);
+}
+
+console.log(
+  dryRun ? "Cache cleanup dry run complete." : "Cache cleanup complete.",
+);


### PR DESCRIPTION
## 🚀 Summary

Standardizes workspace item context menus and selection behavior across Files, Recent, Favorites, Shared, and Trash.

Recent now keeps deleted items visible with deleted-state affordances so users can still understand where they went and recover them through Trash.

## 📊 Impacts and Changes

Users get more consistent right-click and blank-space actions across workspace file surfaces, including shared menu rendering while each page keeps its own behavior.

Recent can include soft-deleted items instead of hiding them immediately. Trash and restore flows remain the recovery path; this does not add schema, auth, or storage changes.

Maintainers get a shared dashboard context menu model, focused tests for the menu/retrieval behavior, and a `pnpm clear:caches` helper for clearing local Next/Turbo caches.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

Manual UI verification note: I started `pnpm web:dev` and ran a Playwright route smoke check against `/recent`, `/files`, `/favorites`, `/shared`, and `/trash`, but the local app returned Prisma `ECONNREFUSED` at `db.systemSettings.findUnique()` because the local DB was not reachable. Build, type/lint, and unit coverage passed.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

Schema/auth/storage/restore note: no schema, auth, or storage behavior changes. Restore behavior is unchanged; deleted Recent entries remain recoverable through Trash.

## 🧗 Follow-ups or Limitations

Manual browser verification should be completed once the local database is running.

## 🔗 Linked Issues

None.