### PR TITLE
Harden keyboard and accessibility flows

### DIFF
--- a/apps/web/app/(workspace)/favorites/favorites-view.tsx
+++ b/apps/web/app/(workspace)/favorites/favorites-view.tsx
@@ -279,6 +279,38 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
     setLastSelectedKey(key);
   };
 
+  const selectItemFromKeyboard = (
+    key: string,
+    event: KeyboardEvent<HTMLElement>,
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (event.ctrlKey || event.metaKey) {
+      setSelectedKeys((current) => {
+        const next = new Set(current);
+        if (next.has(key)) next.delete(key);
+        else next.add(key);
+        return next;
+      });
+      setLastSelectedKey(key);
+      return;
+    }
+
+    if (event.shiftKey && lastSelectedKey) {
+      const start = visibleKeys.indexOf(lastSelectedKey);
+      const end = visibleKeys.indexOf(key);
+      if (start >= 0 && end >= 0) {
+        const [from, to] = [Math.min(start, end), Math.max(start, end)];
+        setSelectedKeys(new Set(visibleKeys.slice(from, to + 1)));
+        return;
+      }
+    }
+
+    setSelectedKeys(new Set([key]));
+    setLastSelectedKey(key);
+  };
+
   const openItem = (item: FavoriteClientItem) => {
     if (item.href.startsWith("/files/")) {
       router.push(item.href);
@@ -469,48 +501,6 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
     }
   };
 
-  useEffect(() => {
-    const onKey = (event: globalThis.KeyboardEvent) => {
-      const target = event.target as HTMLElement | null;
-      if (
-        target?.tagName === "INPUT" ||
-        target?.tagName === "TEXTAREA" ||
-        target?.tagName === "SELECT" ||
-        target?.isContentEditable
-      ) {
-        return;
-      }
-
-      if (event.key === "Escape") {
-        clearSelection();
-        return;
-      }
-
-      if (
-        (event.key === "Delete" || event.key === "Backspace") &&
-        selectedItems.length > 0
-      ) {
-        event.preventDefault();
-        void removeFavorites(selectedItems);
-        return;
-      }
-
-      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "a") {
-        event.preventDefault();
-        selectAllVisible();
-        return;
-      }
-
-      if (event.key === "Enter" && selectedItems.length === 1) {
-        event.preventDefault();
-        openItem(selectedItems[0]);
-      }
-    };
-
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [selectedItems, visibleKeys, allVisibleSelected]);
-
   const handleFavoritesSurfaceClick = (event: MouseEvent<HTMLDivElement>) => {
     if (didRubberBand.current) return;
     const target = event.target as HTMLElement;
@@ -556,6 +546,21 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
     },
     [],
   );
+
+  const handleFavoriteItemKeyDown = (
+    item: FavoriteClientItem,
+    event: KeyboardEvent<HTMLElement>,
+  ) => {
+    if (event.target !== event.currentTarget) return;
+    if (event.key === "Enter") {
+      event.preventDefault();
+      openItem(item);
+      return;
+    }
+    if (event.key === " ") {
+      selectItemFromKeyboard(getItemKey(item), event);
+    }
+  };
 
   useEffect(() => {
     const onMove = (event: globalThis.MouseEvent) => {
@@ -1000,7 +1005,13 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
                 >
                   <article
                     data-favorite-item={key}
+                    tabIndex={0}
+                    role="button"
+                    aria-pressed={selected}
                     className={`favorites-row${selected ? " is-selected" : ""}`}
+                    onKeyDown={(event) =>
+                      handleFavoriteItemKeyDown(item, event)
+                    }
                     onDoubleClick={(event) => {
                       event.stopPropagation();
                       openItem(item);
@@ -1048,7 +1059,13 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
                 >
                   <article
                     data-favorite-item={key}
+                    tabIndex={0}
+                    role="button"
+                    aria-pressed={selected}
                     className={`favorites-grid-card${selected ? " is-selected" : ""}`}
+                    onKeyDown={(event) =>
+                      handleFavoriteItemKeyDown(item, event)
+                    }
                     onDoubleClick={(event) => {
                       event.stopPropagation();
                       openItem(item);

--- a/apps/web/app/(workspace)/files/files-row.tsx
+++ b/apps/web/app/(workspace)/files/files-row.tsx
@@ -294,7 +294,7 @@ export function FilesRow(props: FilesRowProps) {
         tabIndex={isSelected ? 0 : -1}
       >
         {/* Icon */}
-        <div className="explorer-row-icon">
+        <div className="explorer-row-icon" role="gridcell">
           <ItemTypeIcon
             icon={props.kind === "folder" ? IconComponent : undefined}
             size={16}
@@ -303,7 +303,7 @@ export function FilesRow(props: FilesRowProps) {
         </div>
 
         {/* Name */}
-        <div className="explorer-row-name-cell">
+        <div className="explorer-row-name-cell" role="gridcell">
           {isRenaming ? (
             <input
               ref={renameInputRef}
@@ -343,10 +343,16 @@ export function FilesRow(props: FilesRowProps) {
         </div>
 
         {/* Size */}
-        <span className="explorer-row-meta">{size}</span>
+        <span className="explorer-row-meta" role="gridcell">
+          {size}
+        </span>
 
         {/* Date */}
-        <span className="explorer-row-meta" suppressHydrationWarning>
+        <span
+          className="explorer-row-meta"
+          role="gridcell"
+          suppressHydrationWarning
+        >
           {date}
         </span>
       </div>

--- a/apps/web/app/(workspace)/files/files-view.tsx
+++ b/apps/web/app/(workspace)/files/files-view.tsx
@@ -18,6 +18,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { FlashMessage } from "@/app/auth-ui";
 import { DashboardPageContextMenu } from "@/app/dashboard-context-menu";
 import { startValidatedDownload } from "@/lib/transfers/download";
@@ -203,6 +204,15 @@ export function FilesView({
   const didRubberBand = useRef(false);
   const listRef = useRef<HTMLDivElement>(null);
   const rowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  const focusRowById = useCallback((id: string) => {
+    const row =
+      rowRefs.current.get(id) ??
+      Array.from(
+        listRef.current?.querySelectorAll<HTMLElement>("[data-file-row]") ?? [],
+      ).find((element) => element.dataset.fileRow === id);
+
+    row?.focus({ preventScroll: true });
+  }, []);
 
   // ---- Paste animation ----
   const [justMovedIds, setJustMovedIds] = useState<Set<string>>(new Set());
@@ -313,6 +323,7 @@ export function FilesView({
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement;
+      if (!listRef.current?.contains(target)) return;
       if (
         target.tagName === "INPUT" ||
         target.tagName === "TEXTAREA" ||
@@ -419,6 +430,20 @@ export function FilesView({
         if (ids[next]) {
           setSelectedIds(new Set([ids[next]]));
           setLastSelectedId(ids[next]);
+          requestAnimationFrame(() => focusRowById(ids[next]));
+        }
+        return;
+      }
+
+      // Space — select the focused row or first row when the list itself is focused
+      if (e.key === " ") {
+        const focusedRow = target.closest<HTMLElement>("[data-file-row]");
+        const id = focusedRow?.dataset.fileRow ?? allItems[0]?.id;
+        if (id) {
+          e.preventDefault();
+          setSelectedIds(new Set([id]));
+          setLastSelectedId(id);
+          requestAnimationFrame(() => focusRowById(id));
         }
         return;
       }
@@ -435,6 +460,12 @@ export function FilesView({
     return () => document.removeEventListener("keydown", onKey);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allItems, selectedIds, cutItems, lastSelectedId, showShortcutLegend]);
+
+  useEffect(() => {
+    if (selectedIds.size !== 1) return;
+    const id = Array.from(selectedIds)[0];
+    focusRowById(id);
+  }, [focusRowById, selectedIds]);
 
   // ---------------------------------------------------------------------------
   // Item actions
@@ -998,6 +1029,11 @@ export function FilesView({
                     );
                   })}
                 </nav>
+                <p className="sr-only" aria-live="polite">
+                  {selectedIds.size === 0
+                    ? "No items selected"
+                    : `${selectedIds.size} item${selectedIds.size === 1 ? "" : "s"} selected`}
+                </p>
                 {(selectedIds.size > 0 || cutItems.length > 0) && (
                   <div className="explorer-badges">
                     {selectedIds.size > 0 && (
@@ -1083,6 +1119,9 @@ export function FilesView({
           <div
             ref={listRef}
             className="explorer-list"
+            role="grid"
+            aria-label={`${listing.currentFolder.name} files`}
+            tabIndex={0}
             onClick={(e) => {
               // A rubber-band drag just ended — skip this ghost click entirely
               if (didRubberBand.current) return;
@@ -1508,7 +1547,7 @@ function GhostUploadRow({
         </div>
         <span className="uploading-row-name">{name}</span>
         <span className="uploading-row-status ghost-upload-row-status">
-          Incomplete · click to
+          Incomplete ·
           <button
             type="button"
             className="uploading-row-retry"
@@ -1544,23 +1583,34 @@ function GhostUploadRow({
 // ---------------------------------------------------------------------------
 
 function ShortcutLegend({ onClose }: { onClose: () => void }) {
+  const openerRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const opener = document.activeElement;
+    openerRef.current = opener instanceof HTMLElement ? opener : null;
+  }, []);
+
+  const closeAndRestoreFocus = () => {
+    onClose();
+    requestAnimationFrame(() => openerRef.current?.focus());
+  };
+
   return (
-    <div
-      className="shortcut-legend-overlay"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) closeAndRestoreFocus();
       }}
-      role="dialog"
-      aria-modal="true"
-      aria-label="Keyboard shortcuts"
     >
-      <div className="shortcut-legend">
+      <DialogContent className="shortcut-legend" showCloseButton={false}>
         <div className="shortcut-legend-title">
-          Keyboard shortcuts
+          <DialogTitle className="shortcut-legend-title-text">
+            Keyboard shortcuts
+          </DialogTitle>
           <button
             className="shortcut-legend-close"
             type="button"
-            onClick={onClose}
+            onClick={closeAndRestoreFocus}
             aria-label="Close"
           >
             ✕
@@ -1674,7 +1724,7 @@ function ShortcutLegend({ onClose }: { onClose: () => void }) {
             </span>
           </div>
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/app/(workspace)/files/share-dialog.tsx
+++ b/apps/web/app/(workspace)/files/share-dialog.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { createPortal } from "react-dom";
+import { useEffect, useRef, useState } from "react";
 import { Check, Copy, Link2Off, Lock, LockOpen, Download } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import type { ShareLinkSummary } from "@/server/sharing";
 
 // ---------------------------------------------------------------------------
@@ -96,10 +96,21 @@ export function ShareDialog({
   const [copied, setCopied] = useState(false);
   const [passwordValue, setPasswordValue] = useState("");
   const [showPasswordField, setShowPasswordField] = useState(false);
+  const openerRef = useRef<HTMLElement | null>(null);
 
   // Custom expiry state — kept in sync with dialogShare.expiresAt
   const [customDate, setCustomDate] = useState("");
   const [customTime, setCustomTime] = useState("");
+
+  useEffect(() => {
+    const opener = document.activeElement;
+    openerRef.current = opener instanceof HTMLElement ? opener : null;
+  }, []);
+
+  const closeAndRestoreFocus = () => {
+    onClose();
+    requestAnimationFrame(() => openerRef.current?.focus());
+  };
 
   // Sync custom date/time when share changes
   useEffect(() => {
@@ -108,15 +119,6 @@ export function ShareDialog({
       setCustomTime(toLocalTimeString(dialogShare.expiresAt));
     }
   }, [dialogShare?.id, dialogShare?.expiresAt.getTime()]);
-
-  // Close on Escape
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
-  }, [onClose]);
 
   // ---------------------------------------------------------------------------
   // API helper
@@ -276,26 +278,21 @@ export function ShareDialog({
   const isActive = dialogShare?.status === "active";
   const isInactive = dialogShare !== null && dialogShare.status !== "active";
 
-  return createPortal(
-    <div
-      className="share-dialog-overlay"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) closeAndRestoreFocus();
       }}
     >
-      <div
-        className="share-dialog"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Share"
-      >
+      <DialogContent className="share-dialog" showCloseButton={false}>
         {/* Header */}
         <div className="share-dialog-header">
-          <span className="share-dialog-title">Share</span>
+          <DialogTitle className="share-dialog-title">Share</DialogTitle>
           <button
             className="shortcut-legend-close"
             type="button"
-            onClick={onClose}
+            onClick={closeAndRestoreFocus}
             aria-label="Close"
           >
             ✕
@@ -520,8 +517,7 @@ export function ShareDialog({
             </div>
           )}
         </div>
-      </div>
-    </div>,
-    document.body,
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/app/(workspace)/layout.tsx
+++ b/apps/web/app/(workspace)/layout.tsx
@@ -55,6 +55,9 @@ export default async function WorkspaceLayout({
 
   return (
     <>
+      <a className="skip-link" href="#main-content">
+        Skip to content
+      </a>
       <div className="workspace-shell">
         <aside className="workspace-sidebar">
           <div className="workspace-brand-area">
@@ -93,6 +96,9 @@ export default async function WorkspaceLayout({
         <div className="workspace-main">
           <header className="workspace-topbar">
             <form action="/search" className="workspace-search" method="get">
+              <label className="sr-only" htmlFor="workspace-search">
+                Search files and folders
+              </label>
               <Search
                 className="workspace-search-icon"
                 size={14}
@@ -134,7 +140,9 @@ export default async function WorkspaceLayout({
             ) : null}
           </header>
 
-          <div className="workspace-content">{children}</div>
+          <main className="workspace-content" id="main-content" tabIndex={-1}>
+            {children}
+          </main>
         </div>
       </div>
 

--- a/apps/web/app/(workspace)/recent/recent-view.tsx
+++ b/apps/web/app/(workspace)/recent/recent-view.tsx
@@ -260,6 +260,39 @@ export function RecentView({ error, items, success }: RecentViewProps) {
     setLastSelectedId(item.id);
   };
 
+  const selectItemFromKeyboard = (
+    item: RecentClientItem,
+    event: KeyboardEvent<HTMLElement>,
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (item.deletedAt) return;
+
+    if (event.ctrlKey || event.metaKey) {
+      setSelectedIds((current) => {
+        const next = new Set(current);
+        if (next.has(item.id)) next.delete(item.id);
+        else next.add(item.id);
+        return next;
+      });
+      setLastSelectedId(item.id);
+      return;
+    }
+
+    if (event.shiftKey && lastSelectedId) {
+      const start = activeVisibleIds.indexOf(lastSelectedId);
+      const end = activeVisibleIds.indexOf(item.id);
+      if (start >= 0 && end >= 0) {
+        const [from, to] = [Math.min(start, end), Math.max(start, end)];
+        setSelectedIds(new Set(activeVisibleIds.slice(from, to + 1)));
+        return;
+      }
+    }
+
+    setSelectedIds(new Set([item.id]));
+    setLastSelectedId(item.id);
+  };
+
   const openItem = (item: RecentClientItem) => {
     if (item.deletedAt) return;
 
@@ -368,6 +401,22 @@ export function RecentView({ error, items, success }: RecentViewProps) {
     if (event.key === "Enter" && selectedItems.length === 1) {
       event.preventDefault();
       openItem(selectedItems[0]);
+    }
+  };
+
+  const handleRecentItemKeyDown = (
+    item: RecentClientItem,
+    event: KeyboardEvent<HTMLElement>,
+  ) => {
+    if (event.target !== event.currentTarget) return;
+    if (event.key === "Enter") {
+      event.preventDefault();
+      event.stopPropagation();
+      openItem(item);
+      return;
+    }
+    if (event.key === " ") {
+      selectItemFromKeyboard(item, event);
     }
   };
 
@@ -838,7 +887,13 @@ export function RecentView({ error, items, success }: RecentViewProps) {
                     <article
                       data-recent-active={deleted ? undefined : "true"}
                       data-recent-item={item.id}
+                      tabIndex={deleted ? -1 : 0}
+                      role={deleted ? undefined : "button"}
+                      aria-pressed={deleted ? undefined : selected}
                       className={`recent-row${selected ? " is-selected" : ""}${deleted ? " is-deleted" : ""}`}
+                      onKeyDown={(event) =>
+                        handleRecentItemKeyDown(item, event)
+                      }
                       onClick={(event) => handleItemClick(item, event)}
                       onDoubleClick={(event) => {
                         event.stopPropagation();
@@ -934,7 +989,13 @@ export function RecentView({ error, items, success }: RecentViewProps) {
                       <article
                         data-recent-active={deleted ? undefined : "true"}
                         data-recent-item={item.id}
+                        tabIndex={deleted ? -1 : 0}
+                        role={deleted ? undefined : "button"}
+                        aria-pressed={deleted ? undefined : selected}
                         className={`recent-grid-card${selected ? " is-selected" : ""}${deleted ? " is-deleted" : ""}`}
+                        onKeyDown={(event) =>
+                          handleRecentItemKeyDown(item, event)
+                        }
                         onClick={(event) => handleItemClick(item, event)}
                         onDoubleClick={(event) => {
                           event.stopPropagation();

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -14,32 +14,39 @@ export default async function AdminLayout({
   const initials = getInitials(session.user.displayName, session.user.username);
 
   return (
-    <div className="admin-shell">
-      <aside className="admin-sidebar">
-        <h1 className="workspace-brand" style={{ padding: "4px 8px" }}>
-          Staaash Admin
-        </h1>
-        <AdminNav />
-      </aside>
+    <>
+      <a className="skip-link" href="#main-content">
+        Skip to content
+      </a>
+      <div className="admin-shell">
+        <aside className="admin-sidebar">
+          <h1 className="workspace-brand" style={{ padding: "4px 8px" }}>
+            Staaash Admin
+          </h1>
+          <AdminNav />
+        </aside>
 
-      <div className="admin-main">
-        <header className="admin-topbar">
-          <AdminTopbarActions
-            userLabel={userLabel}
-            username={session.user.username}
-            initials={initials}
-            avatarUrl={session.user.avatarUrl ?? null}
-            initialTheme={
-              (session.user.preferences?.theme as
-                | "light"
-                | "dark"
-                | "system") ?? "system"
-            }
-          />
-        </header>
+        <div className="admin-main">
+          <header className="admin-topbar">
+            <AdminTopbarActions
+              userLabel={userLabel}
+              username={session.user.username}
+              initials={initials}
+              avatarUrl={session.user.avatarUrl ?? null}
+              initialTheme={
+                (session.user.preferences?.theme as
+                  | "light"
+                  | "dark"
+                  | "system") ?? "system"
+              }
+            />
+          </header>
 
-        <div className="admin-main-content">{children}</div>
+          <main className="admin-main-content" id="main-content" tabIndex={-1}>
+            {children}
+          </main>
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -7014,16 +7014,6 @@ main.share-locked-page {
   margin: 0;
 }
 
-.onboarding-step__title:focus {
-  outline: none;
-}
-
-.onboarding-step__title:focus-visible {
-  outline: 2px solid oklch(74% 0.08 78 / 0.5);
-  outline-offset: 4px;
-  border-radius: 6px;
-}
-
 .onboarding-step__body {
   font-size: 0.9rem;
   line-height: 1.65;

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -63,6 +63,29 @@ a {
   text-decoration: none;
 }
 
+.skip-link {
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  z-index: 1000;
+  transform: translateY(-160%);
+  border-radius: 8px;
+  padding: 9px 12px;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  font-size: 0.875rem;
+  font-weight: 600;
+  box-shadow: 0 12px 32px
+    color-mix(in oklab, var(--foreground) 22%, transparent);
+  transition: transform 140ms ease-out;
+}
+
+.skip-link:focus-visible {
+  transform: translateY(0);
+  outline: 2px solid color-mix(in oklab, var(--ring) 70%, transparent);
+  outline-offset: 3px;
+}
+
 a:focus-visible,
 button:focus-visible,
 input:focus-visible,
@@ -2214,6 +2237,12 @@ h3 {
   background: color-mix(in oklab, var(--foreground) 4%, transparent);
 }
 
+.recent-row:focus-visible,
+.recent-grid-card:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--ring) 62%, transparent);
+  outline-offset: 2px;
+}
+
 .recent-row.is-selected {
   background: color-mix(in oklab, var(--primary) 8%, transparent);
 }
@@ -2757,6 +2786,12 @@ h3 {
 .favorites-row:hover,
 .favorites-row:focus-within {
   background: color-mix(in oklab, var(--foreground) 4%, transparent);
+}
+
+.favorites-row:focus-visible,
+.favorites-grid-card:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--ring) 62%, transparent);
+  outline-offset: 2px;
 }
 
 .favorites-row.is-selected {
@@ -3310,6 +3345,25 @@ h3 {
   outline: none;
   cursor: default;
   user-select: none;
+}
+
+.entry-intro-action {
+  border: 0;
+  padding: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.entry-intro-action:disabled {
+  cursor: default;
+}
+
+.entry-intro-action:focus-visible {
+  outline: 2px solid oklch(74% 0.08 78 / 0.55);
+  outline-offset: 12px;
+  border-radius: 12px;
 }
 
 .entry-intro__title {
@@ -4364,6 +4418,13 @@ h3 {
   user-select: none;
   /* Don't select text during rubber-band */
   min-height: 200px;
+  outline: none;
+}
+
+.explorer-list:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--ring) 58%, transparent);
+  outline-offset: 6px;
+  border-radius: 10px;
 }
 
 /* ---- Section label ---- */
@@ -4413,6 +4474,11 @@ h3 {
 
 .explorer-row.is-selected:hover {
   background: color-mix(in oklab, var(--primary) 10%, var(--card));
+}
+
+.explorer-row:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--ring) 62%, transparent);
+  outline-offset: 2px;
 }
 
 .explorer-row.is-cut {
@@ -4959,6 +5025,7 @@ h3 {
 }
 
 .shortcut-legend {
+  display: block;
   background: var(--card);
   border: 1px solid color-mix(in oklab, var(--foreground) 10%, transparent);
   border-radius: 18px;
@@ -4968,6 +5035,11 @@ h3 {
   box-shadow: 0 16px 40px
     color-mix(in oklab, var(--foreground) 12%, transparent);
   animation: legend-in 180ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.shortcut-legend-title-text {
+  font: inherit;
+  color: inherit;
 }
 
 @keyframes legend-in {
@@ -5078,9 +5150,11 @@ h3 {
 }
 
 .share-dialog {
+  display: block;
   background: var(--card);
   border: 1px solid color-mix(in oklab, var(--foreground) 10%, transparent);
   border-radius: 14px;
+  padding: 0;
   width: 420px;
   max-width: calc(100vw - 32px);
   box-shadow:
@@ -5167,6 +5241,14 @@ h3 {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.share-url-input:focus-visible,
+.share-date-input:focus-visible,
+.share-time-input:focus-visible,
+.share-password-input:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--ring) 62%, transparent);
+  outline-offset: 2px;
 }
 
 .share-copy-btn {
@@ -5507,11 +5589,15 @@ h3 {
   border-radius: 9px;
   border: 1px solid color-mix(in oklab, var(--destructive) 28%, transparent);
   background: color-mix(in oklab, var(--destructive) 6%, var(--card));
-  color: var(--destructive);
+  color: color-mix(in oklab, var(--destructive) 78%, black 22%);
   cursor: pointer;
   transition:
     background 100ms ease,
     border-color 100ms ease;
+}
+
+.dark .share-revoke-btn {
+  color: color-mix(in oklab, var(--destructive) 90%, white 10%);
 }
 
 .share-revoke-btn:hover:not(:disabled) {
@@ -6802,6 +6888,21 @@ main.share-locked-page {
   user-select: none;
 }
 
+.onboarding-welcome-action {
+  border: 0;
+  padding: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.onboarding-welcome-action:focus-visible {
+  outline: 2px solid oklch(74% 0.08 78 / 0.55);
+  outline-offset: 12px;
+  border-radius: 12px;
+}
+
 .onboarding-welcome__title {
   font-family: var(--font-cabinet), sans-serif;
   font-size: clamp(2.6rem, 5.5vw, 5rem);
@@ -6867,13 +6968,18 @@ main.share-locked-page {
 }
 
 .onboarding-progress {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.onboarding-progress__visual {
   display: flex;
   gap: 5px;
-  margin-bottom: 4px;
 }
 
 .onboarding-progress__segment {
   flex: 1;
+  display: block;
   height: 2px;
   border-radius: 2px;
   background: oklch(50% 0.01 78 / 0.25);
@@ -6922,6 +7028,7 @@ main.share-locked-page {
 }
 
 .onboarding-theme-tile {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -6936,6 +7043,13 @@ main.share-locked-page {
     background 140ms ease-out;
 }
 
+.onboarding-theme-input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
 .onboarding-theme-tile:hover {
   background: oklch(22% 0.01 72 / 0.65);
   border-color: oklch(50% 0.012 76 / 0.5);
@@ -6947,7 +7061,8 @@ main.share-locked-page {
   box-shadow: 0 0 0 1px oklch(74% 0.08 78 / 0.25);
 }
 
-.onboarding-theme-tile:focus-visible {
+.onboarding-theme-tile:focus-visible,
+.onboarding-theme-tile:has(.onboarding-theme-input:focus-visible) {
   outline: 2px solid oklch(74% 0.08 78 / 0.5);
   outline-offset: 2px;
 }
@@ -7055,12 +7170,20 @@ main.share-locked-page {
 }
 
 .onboarding-toggle {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 20px;
   padding: 16px 0;
   border-bottom: 1px solid oklch(40% 0.012 76 / 0.22);
+  cursor: pointer;
+}
+
+.onboarding-switch-input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
   cursor: pointer;
 }
 
@@ -7102,6 +7225,10 @@ main.share-locked-page {
   background: oklch(74% 0.08 78);
 }
 
+.onboarding-switch-input:checked ~ .onboarding-switch {
+  background: oklch(74% 0.08 78);
+}
+
 .onboarding-switch__thumb {
   position: absolute;
   top: 3px;
@@ -7117,7 +7244,14 @@ main.share-locked-page {
   transform: translateX(18px);
 }
 
-.onboarding-switch:focus-visible {
+.onboarding-switch-input:checked
+  ~ .onboarding-switch
+  .onboarding-switch__thumb {
+  transform: translateX(18px);
+}
+
+.onboarding-switch:focus-visible,
+.onboarding-switch-input:focus-visible ~ .onboarding-switch {
   outline: 2px solid oklch(74% 0.08 78 / 0.5);
   outline-offset: 3px;
 }
@@ -7220,6 +7354,11 @@ main.share-locked-page {
 .onboarding-field__input:focus {
   outline: none;
   border-color: oklch(74% 0.08 78 / 0.65);
+}
+
+.onboarding-field__input:focus-visible {
+  outline: 2px solid oklch(74% 0.08 78 / 0.5);
+  outline-offset: 2px;
 }
 
 .onboarding-field__input::placeholder {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -7014,6 +7014,16 @@ main.share-locked-page {
   margin: 0;
 }
 
+.onboarding-step__title:focus {
+  outline: none;
+}
+
+.onboarding-step__title:focus-visible {
+  outline: 2px solid oklch(74% 0.08 78 / 0.5);
+  outline-offset: 4px;
+  border-radius: 6px;
+}
+
 .onboarding-step__body {
   font-size: 0.9rem;
   line-height: 1.65;

--- a/apps/web/components/public/entry-experience.tsx
+++ b/apps/web/components/public/entry-experience.tsx
@@ -44,7 +44,6 @@ export function EntryExperience({
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
   const firstFieldRef = useRef<HTMLInputElement>(null);
-  const introActionRef = useRef<HTMLButtonElement>(null);
   const advancingRef = useRef(false);
 
   const { description, endpoint, successMessage } = config[mode];
@@ -61,12 +60,10 @@ export function EntryExperience({
     }, 360);
   };
 
-  // The intro is visually mouse-first, but keeps the button focused for
-  // keyboard users and accepts Enter/Space as hidden shortcuts.
+  // The intro is visually mouse-first, but Enter/Space remain hidden shortcuts.
   useEffect(() => {
     if (phase !== "intro" && phase !== "intro-return") return;
     advancingRef.current = false;
-    const frame = requestAnimationFrame(() => introActionRef.current?.focus());
 
     const handleClick = () => advanceToForm();
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -80,7 +77,6 @@ export function EntryExperience({
     document.addEventListener("keydown", handleKeyDown);
 
     return () => {
-      cancelAnimationFrame(frame);
       document.removeEventListener("click", handleClick);
       document.removeEventListener("keydown", handleKeyDown);
     };
@@ -158,7 +154,6 @@ export function EntryExperience({
         <h1 className="entry-intro__title">{title}</h1>
         <p className="entry-intro__description">{description}</p>
         <button
-          ref={introActionRef}
           className="entry-intro__hint entry-intro-action"
           disabled={!isActive}
           onClick={advanceToForm}

--- a/apps/web/components/public/entry-experience.tsx
+++ b/apps/web/components/public/entry-experience.tsx
@@ -44,23 +44,22 @@ export function EntryExperience({
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
   const firstFieldRef = useRef<HTMLInputElement>(null);
+  const introActionRef = useRef<HTMLButtonElement>(null);
 
   const { description, endpoint, successMessage } = config[mode];
   const title =
     mode === "signin" && instanceName ? instanceName : config[mode].title;
 
-  // Click-anywhere handler — active during intro and intro-return phases
+  const advanceToForm = () => {
+    setPhase("transitioning");
+    setTimeout(() => setPhase("form"), 360);
+  };
+
+  // Put keyboard users directly on the primary action when the intro returns.
   useEffect(() => {
     if (phase !== "intro" && phase !== "intro-return") return;
-
-    const advance = (e: MouseEvent) => {
-      if ((e.target as Element).closest(".entry-brand")) return;
-      setPhase("transitioning");
-      setTimeout(() => setPhase("form"), 360);
-    };
-
-    document.addEventListener("click", advance);
-    return () => document.removeEventListener("click", advance);
+    const frame = requestAnimationFrame(() => introActionRef.current?.focus());
+    return () => cancelAnimationFrame(frame);
   }, [phase]);
 
   // Focus first field when form appears
@@ -130,25 +129,18 @@ export function EntryExperience({
         ]
           .filter(Boolean)
           .join(" ")}
-        tabIndex={isActive ? 0 : -1}
-        aria-label={
-          mode === "setup"
-            ? "First launch — click anywhere or press Enter to begin setup"
-            : "Sign in — click anywhere or press Enter to continue"
-        }
-        onKeyDown={(e) => {
-          if (isActive && (e.key === "Enter" || e.key === " ")) {
-            e.preventDefault();
-            setPhase("transitioning");
-            setTimeout(() => setPhase("form"), 360);
-          }
-        }}
       >
         <h1 className="entry-intro__title">{title}</h1>
         <p className="entry-intro__description">{description}</p>
-        <p className="entry-intro__hint" aria-hidden="true">
-          Click anywhere to begin
-        </p>
+        <button
+          ref={introActionRef}
+          className="entry-intro__hint entry-intro-action"
+          disabled={!isActive}
+          onClick={advanceToForm}
+          type="button"
+        >
+          Press Enter to begin
+        </button>
       </section>
     );
   }

--- a/apps/web/components/public/entry-experience.tsx
+++ b/apps/web/components/public/entry-experience.tsx
@@ -45,21 +45,46 @@ export function EntryExperience({
   const [pending, setPending] = useState(false);
   const firstFieldRef = useRef<HTMLInputElement>(null);
   const introActionRef = useRef<HTMLButtonElement>(null);
+  const advancingRef = useRef(false);
 
   const { description, endpoint, successMessage } = config[mode];
   const title =
     mode === "signin" && instanceName ? instanceName : config[mode].title;
 
   const advanceToForm = () => {
+    if (advancingRef.current) return;
+    advancingRef.current = true;
     setPhase("transitioning");
-    setTimeout(() => setPhase("form"), 360);
+    setTimeout(() => {
+      setPhase("form");
+      advancingRef.current = false;
+    }, 360);
   };
 
-  // Put keyboard users directly on the primary action when the intro returns.
+  // The intro is visually mouse-first, but keeps the button focused for
+  // keyboard users and accepts Enter/Space as hidden shortcuts.
   useEffect(() => {
     if (phase !== "intro" && phase !== "intro-return") return;
+    advancingRef.current = false;
     const frame = requestAnimationFrame(() => introActionRef.current?.focus());
-    return () => cancelAnimationFrame(frame);
+
+    const handleClick = () => advanceToForm();
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      advanceToForm();
+    };
+
+    document.addEventListener("click", handleClick);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      document.removeEventListener("click", handleClick);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [phase]);
 
   // Focus first field when form appears
@@ -139,7 +164,7 @@ export function EntryExperience({
           onClick={advanceToForm}
           type="button"
         >
-          Press Enter to begin
+          Click anywhere to begin
         </button>
       </section>
     );

--- a/apps/web/components/public/entry-shell.tsx
+++ b/apps/web/components/public/entry-shell.tsx
@@ -25,12 +25,17 @@ export function EntryShell({
 }: EntryShellProps) {
   return (
     <main
+      id="main-content"
       className={cn(
         "entry-surface",
         background ? "entry-surface--gateway" : "entry-surface--focused",
         className,
       )}
+      tabIndex={-1}
     >
+      <a className="skip-link" href="#main-content">
+        Skip to content
+      </a>
       {background ? (
         <div aria-hidden="true" className="entry-surface__background">
           {background}

--- a/apps/web/components/public/onboarding-experience.tsx
+++ b/apps/web/components/public/onboarding-experience.tsx
@@ -419,6 +419,12 @@ function ThemeStep({
   onBack: () => void;
   totalSteps?: number;
 }) {
+  const handleThemeKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== "Enter") return;
+    event.preventDefault();
+    onContinue();
+  };
+
   return (
     <div className="onboarding-step">
       <div className="onboarding-step__nav">
@@ -457,6 +463,7 @@ function ThemeStep({
               value={opt.value}
               checked={theme === opt.value}
               onChange={() => onSelect(opt.value)}
+              onKeyDown={handleThemeKeyDown}
             />
             <ThemePreview variant={opt.value} />
             <span className="onboarding-theme-tile__label">{opt.label}</span>

--- a/apps/web/components/public/onboarding-experience.tsx
+++ b/apps/web/components/public/onboarding-experience.tsx
@@ -331,16 +331,45 @@ export function OnboardingExperience({
 }
 
 function WelcomeStep({ onContinue }: { onContinue: () => void }) {
+  const advancingRef = useRef(false);
+
+  const advance = () => {
+    if (advancingRef.current) return;
+    advancingRef.current = true;
+    onContinue();
+  };
+
+  useEffect(() => {
+    advancingRef.current = false;
+
+    const handleClick = () => advance();
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      advance();
+    };
+
+    document.addEventListener("click", handleClick);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("click", handleClick);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onContinue]);
+
   return (
     <section className="onboarding-welcome">
       <h1 className="onboarding-welcome__title">Before you dive in.</h1>
       <button
         className="onboarding-welcome__hint onboarding-welcome-action"
         data-step-focus
-        onClick={onContinue}
+        onClick={advance}
         type="button"
       >
-        Press Enter to continue
+        Click anywhere to continue
       </button>
     </section>
   );

--- a/apps/web/components/public/onboarding-experience.tsx
+++ b/apps/web/components/public/onboarding-experience.tsx
@@ -74,6 +74,7 @@ export function OnboardingExperience({
   const [error, setError] = useState<string | null>(null);
   const [donePhase, setDonePhase] = useState<0 | 1 | 2>(0);
   const [nameSwapping, setNameSwapping] = useState(false);
+  const stepContainerRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
 
   function advance() {
@@ -199,12 +200,22 @@ export function OnboardingExperience({
     );
   }, []);
 
+  useEffect(() => {
+    if (step === "done") return;
+    const frame = requestAnimationFrame(() => {
+      stepContainerRef.current
+        ?.querySelector<HTMLElement>("[data-step-focus]")
+        ?.focus();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [step]);
+
   if (step === "done") {
     const effectiveName = instanceName ?? "Staaash";
     const isCustomName = effectiveName !== "Staaash";
 
     return (
-      <div className="onboarding-done">
+      <div className="onboarding-done" role="status" aria-live="polite">
         <div
           className={`onboarding-done__phase onboarding-done__phase--allset${donePhase > 0 ? " is-exiting" : ""}`}
         >
@@ -242,6 +253,7 @@ export function OnboardingExperience({
 
   return (
     <div
+      ref={stepContainerRef}
       className={`onboarding${animating ? " onboarding--exiting" : " onboarding--entering"}`}
     >
       {step === "welcome" && <WelcomeStep onContinue={advance} />}
@@ -319,54 +331,43 @@ export function OnboardingExperience({
 }
 
 function WelcomeStep({ onContinue }: { onContinue: () => void }) {
-  useEffect(() => {
-    let ready = false;
-    const guard = setTimeout(() => {
-      ready = true;
-    }, 300);
-
-    const clickHandler = () => {
-      if (ready) onContinue();
-    };
-    const keyHandler = (e: KeyboardEvent) => {
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
-        onContinue();
-      }
-    };
-
-    document.addEventListener("click", clickHandler);
-    document.addEventListener("keydown", keyHandler);
-    return () => {
-      clearTimeout(guard);
-      document.removeEventListener("click", clickHandler);
-      document.removeEventListener("keydown", keyHandler);
-    };
-  }, [onContinue]);
-
   return (
-    <section
-      className="onboarding-welcome"
-      tabIndex={0}
-      aria-label="Welcome — click anywhere to begin setup"
-    >
+    <section className="onboarding-welcome">
       <h1 className="onboarding-welcome__title">Before you dive in.</h1>
-      <p className="onboarding-welcome__hint" aria-hidden="true">
-        Click anywhere to continue
-      </p>
+      <button
+        className="onboarding-welcome__hint onboarding-welcome-action"
+        data-step-focus
+        onClick={onContinue}
+        type="button"
+      >
+        Press Enter to continue
+      </button>
     </section>
   );
 }
 
 function StepProgress({ current, total }: { current: number; total: number }) {
   return (
-    <div className="onboarding-progress" aria-hidden="true">
-      {Array.from({ length: total }, (_, i) => (
-        <div
-          key={i}
-          className={`onboarding-progress__segment${i < current ? " onboarding-progress__segment--active" : ""}`}
-        />
-      ))}
+    <div
+      className="onboarding-progress"
+      aria-label={`Step ${current} of ${total}`}
+    >
+      <ol className="sr-only">
+        {Array.from({ length: total }, (_, i) => (
+          <li key={i} aria-current={i + 1 === current ? "step" : undefined}>
+            Step {i + 1}
+            {i + 1 === current ? " of onboarding, current step" : ""}
+          </li>
+        ))}
+      </ol>
+      <div className="onboarding-progress__visual" aria-hidden="true">
+        {Array.from({ length: total }, (_, i) => (
+          <span
+            key={i}
+            className={`onboarding-progress__segment${i < current ? " onboarding-progress__segment--active" : ""}`}
+          />
+        ))}
+      </div>
     </div>
   );
 }
@@ -406,7 +407,9 @@ function ThemeStep({
 
       <div className="onboarding-step__header">
         <span className="onboarding-step__index">01</span>
-        <h2 className="onboarding-step__title">Choose your theme</h2>
+        <h2 className="onboarding-step__title" tabIndex={-1} data-step-focus>
+          Choose your theme
+        </h2>
       </div>
 
       <div
@@ -415,18 +418,22 @@ function ThemeStep({
         aria-label="Theme"
       >
         {THEME_OPTIONS.map((opt) => (
-          <button
+          <label
             key={opt.value}
-            role="radio"
-            aria-checked={theme === opt.value}
             className={`onboarding-theme-tile onboarding-theme-tile--variant-${opt.value}${theme === opt.value ? " onboarding-theme-tile--selected" : ""}`}
-            onClick={() => onSelect(opt.value)}
-            type="button"
           >
+            <input
+              className="onboarding-theme-input"
+              type="radio"
+              name="onboarding-theme"
+              value={opt.value}
+              checked={theme === opt.value}
+              onChange={() => onSelect(opt.value)}
+            />
             <ThemePreview variant={opt.value} />
             <span className="onboarding-theme-tile__label">{opt.label}</span>
             <span className="onboarding-theme-tile__desc">{opt.desc}</span>
-          </button>
+          </label>
         ))}
       </div>
 
@@ -470,7 +477,9 @@ function TimeZoneStep({
 
       <div className="onboarding-step__header">
         <span className="onboarding-step__index">02</span>
-        <h2 className="onboarding-step__title">Set your time zone</h2>
+        <h2 className="onboarding-step__title" tabIndex={-1} data-step-focus>
+          Set your time zone
+        </h2>
       </div>
 
       <p className="onboarding-step__body">
@@ -618,7 +627,9 @@ function ProfileStep({
 
       <div className="onboarding-step__header">
         <span className="onboarding-step__index">{indexStr}</span>
-        <h2 className="onboarding-step__title">Your profile</h2>
+        <h2 className="onboarding-step__title" tabIndex={-1} data-step-focus>
+          Your profile
+        </h2>
       </div>
 
       <div className="onboarding-profile">
@@ -634,7 +645,7 @@ function ProfileStep({
                 <img
                   className="onboarding-avatar__img"
                   src={prefs.avatarUrl}
-                  alt="Profile preview"
+                  alt=""
                 />
               ) : initials ? (
                 <span className="onboarding-avatar__initials">{initials}</span>
@@ -656,7 +667,7 @@ function ProfileStep({
               )}
             </span>
           </button>
-          <span className="onboarding-avatar__hint">Click to upload photo</span>
+          <span className="onboarding-avatar__hint">Select photo</span>
           <input
             ref={fileInputRef}
             type="file"
@@ -736,7 +747,9 @@ function PrivacyStep({
 
       <div className="onboarding-step__header">
         <span className="onboarding-step__index">04</span>
-        <h2 className="onboarding-step__title">Privacy &amp; features</h2>
+        <h2 className="onboarding-step__title" tabIndex={-1} data-step-focus>
+          Privacy &amp; features
+        </h2>
       </div>
 
       <p className="onboarding-step__body">
@@ -745,24 +758,31 @@ function PrivacyStep({
       </p>
 
       <div className="onboarding-toggles">
-        <label className="onboarding-toggle">
+        <label className="onboarding-toggle" htmlFor="ob-version-checks">
+          <input
+            id="ob-version-checks"
+            role="switch"
+            className="onboarding-switch-input"
+            type="checkbox"
+            checked={prefs.enableVersionChecks}
+            onChange={(event) =>
+              onVersionChecksChange(event.currentTarget.checked)
+            }
+            aria-describedby="ob-version-checks-desc"
+          />
           <div className="onboarding-toggle__text">
             <span className="onboarding-toggle__label">Version checks</span>
-            <span className="onboarding-toggle__desc">
+            <span
+              className="onboarding-toggle__desc"
+              id="ob-version-checks-desc"
+            >
               Check GitHub for updates and show a badge when a new version is
               available.
             </span>
           </div>
-          <button
-            role="switch"
-            aria-checked={prefs.enableVersionChecks}
-            className={`onboarding-switch${prefs.enableVersionChecks ? " onboarding-switch--on" : ""}`}
-            onClick={() => onVersionChecksChange(!prefs.enableVersionChecks)}
-            type="button"
-            aria-label="Version checks"
-          >
+          <span className="onboarding-switch" aria-hidden="true">
             <span className="onboarding-switch__thumb" />
-          </button>
+          </span>
         </label>
       </div>
 
@@ -815,7 +835,9 @@ function MediaStep({
 
       <div className="onboarding-step__header">
         <span className="onboarding-step__index">05</span>
-        <h2 className="onboarding-step__title">Media previews</h2>
+        <h2 className="onboarding-step__title" tabIndex={-1} data-step-focus>
+          Media previews
+        </h2>
       </div>
 
       <p className="onboarding-step__body">
@@ -825,26 +847,31 @@ function MediaStep({
       </p>
 
       <div className="onboarding-toggles">
-        <label className="onboarding-toggle">
+        <label className="onboarding-toggle" htmlFor="ob-media-previews">
+          <input
+            id="ob-media-previews"
+            role="switch"
+            className="onboarding-switch-input"
+            type="checkbox"
+            checked={enabled}
+            onChange={(event) => onToggle(event.currentTarget.checked)}
+            aria-describedby="ob-media-previews-desc"
+          />
           <div className="onboarding-toggle__text">
             <span className="onboarding-toggle__label">
               Enable media previews
             </span>
-            <span className="onboarding-toggle__desc">
+            <span
+              className="onboarding-toggle__desc"
+              id="ob-media-previews-desc"
+            >
               Generates compressed video previews on demand. Requires a worker
               process and a reasonably capable CPU.
             </span>
           </div>
-          <button
-            role="switch"
-            aria-checked={enabled}
-            className={`onboarding-switch${enabled ? " onboarding-switch--on" : ""}`}
-            onClick={() => onToggle(!enabled)}
-            type="button"
-            aria-label="Enable media previews"
-          >
+          <span className="onboarding-switch" aria-hidden="true">
             <span className="onboarding-switch__thumb" />
-          </button>
+          </span>
         </label>
       </div>
 

--- a/apps/web/components/public/onboarding-experience.tsx
+++ b/apps/web/components/public/onboarding-experience.tsx
@@ -41,6 +41,16 @@ const STEP_ORDER: OnboardingStep[] = [
   "done",
 ];
 
+const STEP_ANNOUNCEMENTS: Record<OnboardingStep, string> = {
+  welcome: "Before you dive in.",
+  theme: "Choose your theme.",
+  timezone: "Set your time zone.",
+  profile: "Your profile.",
+  privacy: "Privacy and features.",
+  media: "Media previews.",
+  done: "Onboarding complete.",
+};
+
 function applyThemePreview(theme: Theme) {
   const html = document.documentElement;
   html.classList.remove("dark", "light");
@@ -74,7 +84,6 @@ export function OnboardingExperience({
   const [error, setError] = useState<string | null>(null);
   const [donePhase, setDonePhase] = useState<0 | 1 | 2>(0);
   const [nameSwapping, setNameSwapping] = useState(false);
-  const stepContainerRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
 
   function advance() {
@@ -200,16 +209,6 @@ export function OnboardingExperience({
     );
   }, []);
 
-  useEffect(() => {
-    if (step === "welcome" || step === "done") return;
-    const frame = requestAnimationFrame(() => {
-      stepContainerRef.current
-        ?.querySelector<HTMLElement>("[data-step-focus]")
-        ?.focus();
-    });
-    return () => cancelAnimationFrame(frame);
-  }, [step]);
-
   if (step === "done") {
     const effectiveName = instanceName ?? "Staaash";
     const isCustomName = effectiveName !== "Staaash";
@@ -253,9 +252,11 @@ export function OnboardingExperience({
 
   return (
     <div
-      ref={stepContainerRef}
       className={`onboarding${animating ? " onboarding--exiting" : " onboarding--entering"}`}
     >
+      <p className="sr-only" aria-live="polite" aria-atomic="true">
+        {STEP_ANNOUNCEMENTS[step]}
+      </p>
       {step === "welcome" && <WelcomeStep onContinue={advance} />}
       {step === "theme" && (
         <ThemeStep
@@ -441,9 +442,7 @@ function ThemeStep({
 
       <div className="onboarding-step__header">
         <span className="onboarding-step__index">01</span>
-        <h2 className="onboarding-step__title" tabIndex={-1} data-step-focus>
-          Choose your theme
-        </h2>
+        <h2 className="onboarding-step__title">Choose your theme</h2>
       </div>
 
       <div
@@ -512,9 +511,7 @@ function TimeZoneStep({
 
       <div className="onboarding-step__header">
         <span className="onboarding-step__index">02</span>
-        <h2 className="onboarding-step__title" tabIndex={-1} data-step-focus>
-          Set your time zone
-        </h2>
+        <h2 className="onboarding-step__title">Set your time zone</h2>
       </div>
 
       <p className="onboarding-step__body">
@@ -662,9 +659,7 @@ function ProfileStep({
 
       <div className="onboarding-step__header">
         <span className="onboarding-step__index">{indexStr}</span>
-        <h2 className="onboarding-step__title" tabIndex={-1} data-step-focus>
-          Your profile
-        </h2>
+        <h2 className="onboarding-step__title">Your profile</h2>
       </div>
 
       <div className="onboarding-profile">
@@ -782,9 +777,7 @@ function PrivacyStep({
 
       <div className="onboarding-step__header">
         <span className="onboarding-step__index">04</span>
-        <h2 className="onboarding-step__title" tabIndex={-1} data-step-focus>
-          Privacy &amp; features
-        </h2>
+        <h2 className="onboarding-step__title">Privacy &amp; features</h2>
       </div>
 
       <p className="onboarding-step__body">
@@ -870,9 +863,7 @@ function MediaStep({
 
       <div className="onboarding-step__header">
         <span className="onboarding-step__index">05</span>
-        <h2 className="onboarding-step__title" tabIndex={-1} data-step-focus>
-          Media previews
-        </h2>
+        <h2 className="onboarding-step__title">Media previews</h2>
       </div>
 
       <p className="onboarding-step__body">

--- a/apps/web/components/public/onboarding-experience.tsx
+++ b/apps/web/components/public/onboarding-experience.tsx
@@ -201,7 +201,7 @@ export function OnboardingExperience({
   }, []);
 
   useEffect(() => {
-    if (step === "done") return;
+    if (step === "welcome" || step === "done") return;
     const frame = requestAnimationFrame(() => {
       stepContainerRef.current
         ?.querySelector<HTMLElement>("[data-step-focus]")
@@ -365,7 +365,6 @@ function WelcomeStep({ onContinue }: { onContinue: () => void }) {
       <h1 className="onboarding-welcome__title">Before you dive in.</h1>
       <button
         className="onboarding-welcome__hint onboarding-welcome-action"
-        data-step-focus
         onClick={advance}
         type="button"
       >

--- a/apps/web/components/public/setup-experience.tsx
+++ b/apps/web/components/public/setup-experience.tsx
@@ -32,17 +32,41 @@ export function SetupExperience({ title, description }: SetupExperienceProps) {
   const [pending, setPending] = useState(false);
   const firstFieldRef = useRef<HTMLInputElement>(null);
   const introActionRef = useRef<HTMLButtonElement>(null);
+  const advancingRef = useRef(false);
   const router = useRouter();
 
   const advanceToForm = () => {
+    if (advancingRef.current) return;
+    advancingRef.current = true;
     setPhase("transitioning");
-    setTimeout(() => setPhase("form"), 380);
+    setTimeout(() => {
+      setPhase("form");
+      advancingRef.current = false;
+    }, 380);
   };
 
   useEffect(() => {
     if (phase !== "intro") return;
+    advancingRef.current = false;
     const frame = requestAnimationFrame(() => introActionRef.current?.focus());
-    return () => cancelAnimationFrame(frame);
+
+    const handleClick = () => advanceToForm();
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      advanceToForm();
+    };
+
+    document.addEventListener("click", handleClick);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      document.removeEventListener("click", handleClick);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [phase]);
 
   // Focus first field when form appears
@@ -103,7 +127,7 @@ export function SetupExperience({ title, description }: SetupExperienceProps) {
             onClick={advanceToForm}
             type="button"
           >
-            Press Enter to begin setup
+            Click anywhere to begin setup
           </button>
         </section>
       )}

--- a/apps/web/components/public/setup-experience.tsx
+++ b/apps/web/components/public/setup-experience.tsx
@@ -31,21 +31,18 @@ export function SetupExperience({ title, description }: SetupExperienceProps) {
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
   const firstFieldRef = useRef<HTMLInputElement>(null);
+  const introActionRef = useRef<HTMLButtonElement>(null);
   const router = useRouter();
 
-  // Click-anywhere handler — active only during intro phase
+  const advanceToForm = () => {
+    setPhase("transitioning");
+    setTimeout(() => setPhase("form"), 380);
+  };
+
   useEffect(() => {
     if (phase !== "intro") return;
-
-    const advance = () => {
-      setPhase("transitioning");
-      setTimeout(() => setPhase("form"), 380);
-    };
-
-    document.addEventListener("click", advance);
-    return () => {
-      document.removeEventListener("click", advance);
-    };
+    const frame = requestAnimationFrame(() => introActionRef.current?.focus());
+    return () => cancelAnimationFrame(frame);
   }, [phase]);
 
   // Focus first field when form appears
@@ -92,15 +89,6 @@ export function SetupExperience({ title, description }: SetupExperienceProps) {
       {phase !== "form" && (
         <section
           className={`setup-gateway${phase === "transitioning" ? " setup-gateway--exiting" : ""}`}
-          tabIndex={phase === "intro" ? 0 : -1}
-          aria-label="First launch — click anywhere or press Enter to begin setup"
-          onKeyDown={(e) => {
-            if (phase === "intro" && (e.key === "Enter" || e.key === " ")) {
-              e.preventDefault();
-              setPhase("transitioning");
-              setTimeout(() => setPhase("form"), 380);
-            }
-          }}
         >
           <h1 className="setup-gateway__title font-heading text-[clamp(4rem,9vw,8rem)] leading-[0.92] tracking-[-0.06em] text-foreground">
             {title}
@@ -108,9 +96,15 @@ export function SetupExperience({ title, description }: SetupExperienceProps) {
           <p className="setup-gateway__description text-base leading-7 text-muted-foreground md:text-lg md:leading-8">
             {description}
           </p>
-          <p className="setup-gateway__hint" aria-hidden="true">
-            Click anywhere to begin
-          </p>
+          <button
+            ref={introActionRef}
+            className="setup-gateway__hint entry-intro-action"
+            disabled={phase !== "intro"}
+            onClick={advanceToForm}
+            type="button"
+          >
+            Press Enter to begin setup
+          </button>
         </section>
       )}
 

--- a/apps/web/components/public/setup-experience.tsx
+++ b/apps/web/components/public/setup-experience.tsx
@@ -31,7 +31,6 @@ export function SetupExperience({ title, description }: SetupExperienceProps) {
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
   const firstFieldRef = useRef<HTMLInputElement>(null);
-  const introActionRef = useRef<HTMLButtonElement>(null);
   const advancingRef = useRef(false);
   const router = useRouter();
 
@@ -48,7 +47,6 @@ export function SetupExperience({ title, description }: SetupExperienceProps) {
   useEffect(() => {
     if (phase !== "intro") return;
     advancingRef.current = false;
-    const frame = requestAnimationFrame(() => introActionRef.current?.focus());
 
     const handleClick = () => advanceToForm();
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -62,7 +60,6 @@ export function SetupExperience({ title, description }: SetupExperienceProps) {
     document.addEventListener("keydown", handleKeyDown);
 
     return () => {
-      cancelAnimationFrame(frame);
       document.removeEventListener("click", handleClick);
       document.removeEventListener("keydown", handleKeyDown);
     };
@@ -121,7 +118,6 @@ export function SetupExperience({ title, description }: SetupExperienceProps) {
             {description}
           </p>
           <button
-            ref={introActionRef}
             className="setup-gateway__hint entry-intro-action"
             disabled={phase !== "intro"}
             onClick={advanceToForm}

--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -7,6 +7,8 @@ type BootstrapState = {
   ownerPassword?: string;
   memberIdentifier?: string;
   memberPassword?: string;
+  onboardingIdentifier?: string;
+  onboardingPassword?: string;
   shareUrl?: string;
 };
 
@@ -64,6 +66,17 @@ export const getMemberCredentials = () => ({
   ),
 });
 
+export const getOnboardingCredentials = () => ({
+  identifier: getRequiredValue(
+    "STAAASH_E2E_ONBOARDING_IDENTIFIER",
+    readBootstrapState()?.onboardingIdentifier,
+  ),
+  password: getRequiredValue(
+    "STAAASH_E2E_ONBOARDING_PASSWORD",
+    readBootstrapState()?.onboardingPassword,
+  ),
+});
+
 export const getShareUrl = () =>
   getRequiredValue("STAAASH_E2E_SHARE_URL", readBootstrapState()?.shareUrl);
 
@@ -80,11 +93,13 @@ export const signIn = async (
   },
 ) => {
   await page.goto(`/?next=${encodeURIComponent(next)}`);
-  await page.click("body");
+  await page
+    .getByRole("button", { name: /Press Enter to begin/i })
+    .press("Enter");
   await page.waitForSelector(".entry-form");
   await page.getByLabel("Username or email").fill(identifier);
   await page.getByLabel("Password").fill(password);
-  await page.getByRole("button", { name: "Sign in" }).click();
+  await page.getByRole("button", { name: "Sign in" }).press("Enter");
   await page.waitForURL((url) => url.pathname === next, { timeout: 20_000 });
 };
 

--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -93,9 +93,7 @@ export const signIn = async (
   },
 ) => {
   await page.goto(`/?next=${encodeURIComponent(next)}`);
-  await page
-    .getByRole("button", { name: /Click anywhere to begin/i })
-    .press("Enter");
+  await page.keyboard.press("Enter");
   await page.waitForSelector(".entry-form");
   await page.getByLabel("Username or email").fill(identifier);
   await page.getByLabel("Password").fill(password);

--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -94,7 +94,7 @@ export const signIn = async (
 ) => {
   await page.goto(`/?next=${encodeURIComponent(next)}`);
   await page
-    .getByRole("button", { name: /Press Enter to begin/i })
+    .getByRole("button", { name: /Click anywhere to begin/i })
     .press("Enter");
   await page.waitForSelector(".entry-form");
   await page.getByLabel("Username or email").fill(identifier);

--- a/apps/web/e2e/keyboard-accessibility.spec.ts
+++ b/apps/web/e2e/keyboard-accessibility.spec.ts
@@ -87,7 +87,7 @@ test("incomplete-onboarding user can finish setup with keyboard", async ({
   await expect(page.getByRole("radio", { name: /Light/i })).toBeChecked();
   await page.keyboard.press("ArrowRight");
   await expect(page.getByRole("radio", { name: /Dark/i })).toBeChecked();
-  await page.getByRole("button", { name: "Continue" }).press("Enter");
+  await page.keyboard.press("Enter");
 
   await expect(
     page.getByRole("heading", { name: "Set your time zone" }),

--- a/apps/web/e2e/keyboard-accessibility.spec.ts
+++ b/apps/web/e2e/keyboard-accessibility.spec.ts
@@ -41,7 +41,7 @@ test("sign-in intro opens and submits with keyboard", async ({ page }) => {
   await page.goto("/");
   await expectNoSeriousA11yViolations(page);
   await page
-    .getByRole("button", { name: /Press Enter to begin/i })
+    .getByRole("button", { name: /Click anywhere to begin/i })
     .press("Enter");
 
   await expect(page.getByLabel("Username or email")).toBeFocused();
@@ -61,7 +61,7 @@ test("incomplete-onboarding user can finish setup with keyboard", async ({
 
   await page.goto("/");
   await page
-    .getByRole("button", { name: /Press Enter to begin/i })
+    .getByRole("button", { name: /Click anywhere to begin/i })
     .press("Enter");
   await page.getByLabel("Username or email").fill(credentials.identifier);
   await page.getByLabel("Password").fill(credentials.password);
@@ -72,7 +72,7 @@ test("incomplete-onboarding user can finish setup with keyboard", async ({
   ).toBeVisible();
   await expectNoSeriousA11yViolations(page);
   await page
-    .getByRole("button", { name: /Press Enter to continue/i })
+    .getByRole("button", { name: /Click anywhere to continue/i })
     .press("Enter");
 
   await expect(

--- a/apps/web/e2e/keyboard-accessibility.spec.ts
+++ b/apps/web/e2e/keyboard-accessibility.spec.ts
@@ -1,0 +1,183 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type Page } from "@playwright/test";
+
+import {
+  getOnboardingCredentials,
+  getOwnerCredentials,
+  signIn,
+} from "./helpers";
+
+const axeTags = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"];
+
+const expectNoSeriousA11yViolations = async (
+  page: Page,
+  includeSelector = "main",
+) => {
+  const results = await new AxeBuilder({ page })
+    .include(includeSelector)
+    .withTags(axeTags)
+    .analyze();
+  const violations = results.violations.filter(
+    (violation) =>
+      violation.impact === "serious" || violation.impact === "critical",
+  );
+
+  expect(
+    violations,
+    violations
+      .map(
+        (violation) =>
+          `${violation.id}: ${violation.description}\n${violation.nodes
+            .map((node) => `  ${node.target.join(", ")}`)
+            .join("\n")}`,
+      )
+      .join("\n\n"),
+  ).toEqual([]);
+};
+
+test("sign-in intro opens and submits with keyboard", async ({ page }) => {
+  const credentials = getOwnerCredentials();
+
+  await page.goto("/");
+  await expectNoSeriousA11yViolations(page);
+  await page
+    .getByRole("button", { name: /Press Enter to begin/i })
+    .press("Enter");
+
+  await expect(page.getByLabel("Username or email")).toBeFocused();
+  await page.getByLabel("Username or email").fill(credentials.identifier);
+  await page.getByLabel("Password").fill(credentials.password);
+  await page.getByRole("button", { name: "Sign in" }).press("Enter");
+
+  await page.waitForURL((url) => url.pathname === "/files", {
+    timeout: 20_000,
+  });
+});
+
+test("incomplete-onboarding user can finish setup with keyboard", async ({
+  page,
+}) => {
+  const credentials = getOnboardingCredentials();
+
+  await page.goto("/");
+  await page
+    .getByRole("button", { name: /Press Enter to begin/i })
+    .press("Enter");
+  await page.getByLabel("Username or email").fill(credentials.identifier);
+  await page.getByLabel("Password").fill(credentials.password);
+  await page.getByRole("button", { name: "Sign in" }).press("Enter");
+
+  await expect(
+    page.getByRole("heading", { name: "Before you dive in." }),
+  ).toBeVisible();
+  await expectNoSeriousA11yViolations(page);
+  await page
+    .getByRole("button", { name: /Press Enter to continue/i })
+    .press("Enter");
+
+  await expect(
+    page.getByRole("heading", { name: "Choose your theme" }),
+  ).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(page.getByRole("radio", { name: /System/i })).toBeFocused();
+  await page.keyboard.press("ArrowRight");
+  await expect(page.getByRole("radio", { name: /Light/i })).toBeChecked();
+  await page.keyboard.press("ArrowRight");
+  await expect(page.getByRole("radio", { name: /Dark/i })).toBeChecked();
+  await page.getByRole("button", { name: "Continue" }).press("Enter");
+
+  await expect(
+    page.getByRole("heading", { name: "Set your time zone" }),
+  ).toBeFocused();
+  await page.getByRole("button", { name: "Continue" }).press("Enter");
+
+  await expect(
+    page.getByRole("heading", { name: "Your profile" }),
+  ).toBeFocused();
+  await page.getByLabel("Full name").fill("Keyboard E2E");
+  await page.getByRole("button", { name: "Continue" }).press("Enter");
+
+  await expect(
+    page.getByRole("heading", { name: "Privacy & features" }),
+  ).toBeFocused();
+  const versionChecks = page.getByRole("switch", { name: /Version checks/i });
+  await expect(versionChecks).toBeChecked();
+  await versionChecks.press("Space");
+  await expect(versionChecks).not.toBeChecked();
+  await page.getByRole("button", { name: "Continue" }).press("Enter");
+
+  await expect(
+    page.getByRole("heading", { name: "Media previews" }),
+  ).toBeFocused();
+  const mediaPreviews = page.getByRole("switch", {
+    name: /Enable media previews/i,
+  });
+  await mediaPreviews.press("Space");
+  await page.getByRole("button", { name: "Enter Staaash" }).press("Enter");
+
+  await page.waitForURL((url) => url.pathname === "/files", {
+    timeout: 15_000,
+  });
+});
+
+test("files rows move focus with keyboard and open selected item", async ({
+  page,
+}) => {
+  const credentials = getOwnerCredentials();
+
+  await signIn(page, credentials);
+  await expect(page.getByText("shared-preview.png")).toBeVisible();
+  await expectNoSeriousA11yViolations(page);
+
+  const list = page.locator(".explorer-list");
+  const firstRow = page.locator("[data-file-row]").first();
+
+  await list.focus();
+  await page.keyboard.press("ArrowDown");
+  await expect(firstRow).toBeFocused();
+  await expect(firstRow).toHaveAttribute("aria-selected", "true");
+  await page.keyboard.press("Enter");
+
+  await page.waitForURL(/\/files\/view\/e2e-share-file/, {
+    timeout: 10_000,
+  });
+});
+
+test("share dialog traps focus and returns focus on Escape", async ({
+  page,
+}) => {
+  const credentials = getOwnerCredentials();
+
+  await signIn(page, {
+    ...credentials,
+    next: "/shared",
+  });
+
+  const manageButton = page.getByRole("button", { name: "Manage" }).first();
+  await manageButton.press("Enter");
+
+  const dialog = page.getByRole("dialog", { name: "Share" });
+  await expect(dialog).toBeVisible();
+  await expectNoSeriousA11yViolations(page, '[data-slot="dialog-content"]');
+
+  await page.keyboard.press("Tab");
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        Boolean(document.activeElement?.closest('[role="dialog"]')),
+      ),
+    )
+    .toBe(true);
+  await page.keyboard.press("Shift+Tab");
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        Boolean(document.activeElement?.closest('[role="dialog"]')),
+      ),
+    )
+    .toBe(true);
+
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeHidden();
+  await expect(manageButton).toBeFocused();
+});

--- a/apps/web/e2e/keyboard-accessibility.spec.ts
+++ b/apps/web/e2e/keyboard-accessibility.spec.ts
@@ -40,9 +40,10 @@ test("sign-in intro opens and submits with keyboard", async ({ page }) => {
 
   await page.goto("/");
   await expectNoSeriousA11yViolations(page);
-  await page
-    .getByRole("button", { name: /Click anywhere to begin/i })
-    .press("Enter");
+  await expect(
+    page.getByRole("button", { name: /Click anywhere to begin/i }),
+  ).not.toBeFocused();
+  await page.keyboard.press("Enter");
 
   await expect(page.getByLabel("Username or email")).toBeFocused();
   await page.getByLabel("Username or email").fill(credentials.identifier);
@@ -60,9 +61,10 @@ test("incomplete-onboarding user can finish setup with keyboard", async ({
   const credentials = getOnboardingCredentials();
 
   await page.goto("/");
-  await page
-    .getByRole("button", { name: /Click anywhere to begin/i })
-    .press("Enter");
+  await expect(
+    page.getByRole("button", { name: /Click anywhere to begin/i }),
+  ).not.toBeFocused();
+  await page.keyboard.press("Enter");
   await page.getByLabel("Username or email").fill(credentials.identifier);
   await page.getByLabel("Password").fill(credentials.password);
   await page.getByRole("button", { name: "Sign in" }).press("Enter");
@@ -71,9 +73,10 @@ test("incomplete-onboarding user can finish setup with keyboard", async ({
     page.getByRole("heading", { name: "Before you dive in." }),
   ).toBeVisible();
   await expectNoSeriousA11yViolations(page);
-  await page
-    .getByRole("button", { name: /Click anywhere to continue/i })
-    .press("Enter");
+  await expect(
+    page.getByRole("button", { name: /Click anywhere to continue/i }),
+  ).not.toBeFocused();
+  await page.keyboard.press("Enter");
 
   await expect(
     page.getByRole("heading", { name: "Choose your theme" }),

--- a/apps/web/e2e/keyboard-accessibility.spec.ts
+++ b/apps/web/e2e/keyboard-accessibility.spec.ts
@@ -1,5 +1,5 @@
 import AxeBuilder from "@axe-core/playwright";
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Locator, type Page } from "@playwright/test";
 
 import {
   getOnboardingCredentials,
@@ -33,6 +33,17 @@ const expectNoSeriousA11yViolations = async (
       )
       .join("\n\n"),
   ).toEqual([]);
+};
+
+const tabUntilFocused = async (page: Page, target: Locator, maxTabs = 6) => {
+  for (let i = 0; i < maxTabs; i += 1) {
+    if (await target.evaluate((node) => node === document.activeElement)) {
+      return;
+    }
+    await page.keyboard.press("Tab");
+  }
+
+  await expect(target).toBeFocused();
 };
 
 test("sign-in intro opens and submits with keyboard", async ({ page }) => {
@@ -80,9 +91,11 @@ test("incomplete-onboarding user can finish setup with keyboard", async ({
 
   await expect(
     page.getByRole("heading", { name: "Choose your theme" }),
-  ).toBeFocused();
-  await page.keyboard.press("Tab");
-  await expect(page.getByRole("radio", { name: /System/i })).toBeFocused();
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Choose your theme" }),
+  ).not.toBeFocused();
+  await tabUntilFocused(page, page.getByRole("radio", { name: /System/i }));
   await page.keyboard.press("ArrowRight");
   await expect(page.getByRole("radio", { name: /Light/i })).toBeChecked();
   await page.keyboard.press("ArrowRight");
@@ -91,18 +104,27 @@ test("incomplete-onboarding user can finish setup with keyboard", async ({
 
   await expect(
     page.getByRole("heading", { name: "Set your time zone" }),
-  ).toBeFocused();
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Set your time zone" }),
+  ).not.toBeFocused();
   await page.getByRole("button", { name: "Continue" }).press("Enter");
 
   await expect(
     page.getByRole("heading", { name: "Your profile" }),
-  ).toBeFocused();
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Your profile" }),
+  ).not.toBeFocused();
   await page.getByLabel("Full name").fill("Keyboard E2E");
   await page.getByRole("button", { name: "Continue" }).press("Enter");
 
   await expect(
     page.getByRole("heading", { name: "Privacy & features" }),
-  ).toBeFocused();
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Privacy & features" }),
+  ).not.toBeFocused();
   const versionChecks = page.getByRole("switch", { name: /Version checks/i });
   await expect(versionChecks).toBeChecked();
   await versionChecks.press("Space");
@@ -111,7 +133,10 @@ test("incomplete-onboarding user can finish setup with keyboard", async ({
 
   await expect(
     page.getByRole("heading", { name: "Media previews" }),
-  ).toBeFocused();
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Media previews" }),
+  ).not.toBeFocused();
   const mediaPreviews = page.getByRole("switch", {
     name: /Enable media previews/i,
   });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -41,6 +41,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.3.0",
     "@types/canvas-confetti": "^1.9.0",

--- a/apps/web/scripts/e2e-bootstrap.mjs
+++ b/apps/web/scripts/e2e-bootstrap.mjs
@@ -22,8 +22,13 @@ const MEMBER_EMAIL = "member-e2e@staaash.test";
 const MEMBER_ID = "e2e-member";
 const MEMBER_USERNAME = "member";
 const MEMBER_PASSWORD = "staaash-member-pass";
+const ONBOARDING_EMAIL = "onboarding-e2e@staaash.test";
+const ONBOARDING_ID = "e2e-onboarding";
+const ONBOARDING_USERNAME = "onboarding";
+const ONBOARDING_PASSWORD = "staaash-onboarding-pass";
 const OWNER_ROOT_ID = "e2e-owner-root";
 const MEMBER_ROOT_ID = "e2e-member-root";
+const ONBOARDING_ROOT_ID = "e2e-onboarding-root";
 const SHARE_FILE_ID = "e2e-share-file";
 const SHARE_LINK_ID = "e2e-share-link";
 const SHARE_FILE_NAME = "shared-preview.png";
@@ -188,6 +193,7 @@ const seedE2EData = async ({ filesRoot, authSecret, databaseUrl }) => {
   try {
     const ownerPasswordHash = hashPassword(OWNER_PASSWORD);
     const memberPasswordHash = hashPassword(MEMBER_PASSWORD);
+    const onboardingPasswordHash = hashPassword(ONBOARDING_PASSWORD);
 
     await client.query(
       `INSERT INTO "Instance" ("id", "name", "setupCompletedAt", "createdAt", "updatedAt")
@@ -199,7 +205,8 @@ const seedE2EData = async ({ filesRoot, authSecret, databaseUrl }) => {
       `INSERT INTO "User" ("id", "email", "username", "displayName", "passwordHash", "role", "createdAt", "updatedAt")
        VALUES
        ($1, $2, $3, $4, $5, $6::"UserRole", NOW(), NOW()),
-       ($7, $8, $9, $10, $11, $12::"UserRole", NOW(), NOW())`,
+       ($7, $8, $9, $10, $11, $12::"UserRole", NOW(), NOW()),
+       ($13, $14, $15, $16, $17, $18::"UserRole", NOW(), NOW())`,
       [
         OWNER_ID,
         OWNER_EMAIL,
@@ -213,6 +220,12 @@ const seedE2EData = async ({ filesRoot, authSecret, databaseUrl }) => {
         "E2E Member",
         memberPasswordHash,
         "member",
+        ONBOARDING_ID,
+        ONBOARDING_EMAIL,
+        ONBOARDING_USERNAME,
+        "E2E Onboarding",
+        onboardingPasswordHash,
+        "owner",
       ],
     );
 
@@ -220,16 +233,35 @@ const seedE2EData = async ({ filesRoot, authSecret, databaseUrl }) => {
       `INSERT INTO "UserPreference" ("id", "userId", "timeZone", "onboardingCompletedAt", "createdAt", "updatedAt")
        VALUES
        ($1, $2, 'UTC', NOW(), NOW(), NOW()),
-       ($3, $4, 'UTC', NOW(), NOW(), NOW())`,
-      ["e2e-owner-preferences", OWNER_ID, "e2e-member-preferences", MEMBER_ID],
+       ($3, $4, 'UTC', NOW(), NOW(), NOW()),
+       ($5, $6, 'UTC', NULL, NOW(), NOW())`,
+      [
+        "e2e-owner-preferences",
+        OWNER_ID,
+        "e2e-member-preferences",
+        MEMBER_ID,
+        "e2e-onboarding-preferences",
+        ONBOARDING_ID,
+      ],
     );
 
     await client.query(
       `INSERT INTO "Folder" ("id", "ownerUserId", "parentId", "name", "isFilesRoot", "deletedAt", "createdAt", "updatedAt")
        VALUES
        ($1, $2, NULL, $3, TRUE, NULL, NOW(), NOW()),
-       ($4, $5, NULL, $6, TRUE, NULL, NOW(), NOW())`,
-      [OWNER_ROOT_ID, OWNER_ID, "Files", MEMBER_ROOT_ID, MEMBER_ID, "Files"],
+       ($4, $5, NULL, $6, TRUE, NULL, NOW(), NOW()),
+       ($7, $8, NULL, $9, TRUE, NULL, NOW(), NOW())`,
+      [
+        OWNER_ROOT_ID,
+        OWNER_ID,
+        "Files",
+        MEMBER_ROOT_ID,
+        MEMBER_ID,
+        "Files",
+        ONBOARDING_ROOT_ID,
+        ONBOARDING_ID,
+        "Files",
+      ],
     );
 
     const storageKey = `library/${OWNER_ID}/${SHARE_FILE_NAME}`;
@@ -280,6 +312,8 @@ const seedE2EData = async ({ filesRoot, authSecret, databaseUrl }) => {
           ownerPassword: OWNER_PASSWORD,
           memberIdentifier: MEMBER_USERNAME,
           memberPassword: MEMBER_PASSWORD,
+          onboardingIdentifier: ONBOARDING_USERNAME,
+          onboardingPassword: ONBOARDING_PASSWORD,
           shareUrl: `/s/${encodeURIComponent(shareToken)}`,
         },
         null,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.11.3
+        version: 4.11.3(playwright-core@1.60.0)
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
@@ -212,6 +215,11 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@axe-core/playwright@4.11.3':
+    resolution: {integrity: sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1793,6 +1801,10 @@ packages:
   aws-ssl-profiles@1.1.2:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
+
+  axe-core@4.11.4:
+    resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
+    engines: {node: '>=4'}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -3789,6 +3801,11 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@axe-core/playwright@4.11.3(playwright-core@1.60.0)':
+    dependencies:
+      axe-core: 4.11.4
+      playwright-core: 1.60.0
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -5030,6 +5047,8 @@ snapshots:
       tslib: 2.8.1
 
   aws-ssl-profiles@1.1.2: {}
+
+  axe-core@4.11.4: {}
 
   balanced-match@4.0.4: {}
 


### PR DESCRIPTION
## 🚀 Summary

Hardens keyboard and accessibility behavior across the public entry/onboarding flow and the core workspace surfaces.

This keeps the intro/welcome screens visually mouse-first with no automatic focus ring, while preserving hidden Enter/Space shortcuts for keyboard users. Onboarding controls now use proper keyboard patterns, selected theme tiles can continue with Enter, and custom focus handling no longer lands on step headings.

## 📊 Impacts and Changes

- Entry, setup, and onboarding are usable without a mouse.
- Onboarding theme choices, switches, progress, and step changes have stronger accessibility semantics.
- Files, Recent, Favorites, share dialog, and shortcut overlay paths get improved keyboard/focus behavior.
- E2E seed data now includes an incomplete-onboarding test user.
- Adds axe-backed Playwright coverage for the accessibility paths.

No production schema, auth API, storage, or restore behavior changes.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [ ] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

Additional validation:

- [x] `pnpm format:check` passed
- [x] `pnpm typecheck` passed
- [x] focused keyboard e2e passed: `pnpm --filter web e2e -- e2e/keyboard-accessibility.spec.ts --workers=1`

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

Full `pnpm web:e2e` now starts against the disposable setup, but the default parallel run still hit auth-flow timeouts in three tests. The focused keyboard accessibility spec passed serially.

## 🔗 Linked Issues

None.
