### PR TITLE
Require onboarding before protected routes

### DIFF
--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -4,7 +4,17 @@ import { NextRequest, NextResponse } from "next/server";
 const SESSION_COOKIE = "staaash_session";
 const ONBOARDED_COOKIE = "staaash_onboarded";
 
-const WORKSPACE_PREFIX = ["/files", "/settings", "/admin", "/invite", "/share"];
+const WORKSPACE_PREFIX = [
+  "/admin",
+  "/favorites",
+  "/files",
+  "/home",
+  "/recent",
+  "/search",
+  "/settings",
+  "/shared",
+  "/trash",
+];
 
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;

--- a/apps/web/server/auth/guards.test.ts
+++ b/apps/web/server/auth/guards.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+
+const getCurrentSession = vi.fn();
+const getSession = vi.fn();
+const redirect = vi.fn((path: string) => {
+  throw new Error(`redirect:${path}`);
+});
+
+vi.mock("@/server/auth/session", () => ({
+  getCurrentSession,
+  getSessionTokenFromCookieStore: (cookieStore: {
+    get(name: string): { value: string } | undefined;
+  }) => cookieStore.get("staaash_session")?.value ?? null,
+}));
+
+vi.mock("@/server/auth/service", () => ({
+  authService: {
+    getSession,
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect,
+}));
+
+const completedSession = {
+  user: {
+    preferences: {
+      onboardingCompletedAt: new Date("2026-05-30T00:00:00.000Z"),
+    },
+  },
+};
+
+const pendingSession = {
+  user: {
+    preferences: null,
+  },
+};
+
+const cookieRequest = (value: string) => ({
+  cookies: {
+    get: (name: string) => (name === "staaash_session" ? { value } : undefined),
+  },
+});
+
+describe("auth guards", () => {
+  it("redirects signed-out page callers to the requested sign-in path", async () => {
+    getCurrentSession.mockResolvedValueOnce(null);
+    const { requireSignedInPageSession } = await import("@/server/auth/guards");
+
+    await expect(requireSignedInPageSession("/?next=/files")).rejects.toThrow(
+      "redirect:/?next=/files",
+    );
+    expect(redirect).toHaveBeenCalledWith("/?next=/files");
+  });
+
+  it("redirects signed-in page callers without completed onboarding to root", async () => {
+    getCurrentSession.mockResolvedValueOnce(pendingSession);
+    const { requireSignedInPageSession } = await import("@/server/auth/guards");
+
+    await expect(requireSignedInPageSession("/?next=/files")).rejects.toThrow(
+      "redirect:/",
+    );
+    expect(redirect).toHaveBeenCalledWith("/");
+  });
+
+  it("returns signed-in page sessions after onboarding is complete", async () => {
+    getCurrentSession.mockResolvedValueOnce(completedSession);
+    const { requireSignedInPageSession } = await import("@/server/auth/guards");
+
+    await expect(requireSignedInPageSession("/?next=/files")).resolves.toBe(
+      completedSession,
+    );
+  });
+
+  it("hides protected API sessions without completed onboarding", async () => {
+    getSession.mockResolvedValueOnce(pendingSession);
+    const { getRequestSession } = await import("@/server/auth/guards");
+
+    await expect(
+      getRequestSession(cookieRequest("session-token")),
+    ).resolves.toBe(null);
+    expect(getSession).toHaveBeenCalledWith("session-token");
+  });
+
+  it("returns protected API sessions after onboarding is complete", async () => {
+    getSession.mockResolvedValueOnce(completedSession);
+    const { getRequestSession } = await import("@/server/auth/guards");
+
+    await expect(
+      getRequestSession(cookieRequest("session-token")),
+    ).resolves.toBe(completedSession);
+  });
+});

--- a/apps/web/server/auth/guards.ts
+++ b/apps/web/server/auth/guards.ts
@@ -6,12 +6,20 @@ import {
   getSessionTokenFromCookieStore,
 } from "@/server/auth/session";
 import { authService } from "@/server/auth/service";
+import type { AuthSession } from "@/server/auth/types";
+
+export const hasCompletedOnboarding = (session: AuthSession | null) =>
+  Boolean(session?.user.preferences?.onboardingCompletedAt);
 
 export const requireSignedInPageSession = async (redirectTo = "/") => {
   const session = await getCurrentSession();
 
   if (!session) {
     redirect(redirectTo);
+  }
+
+  if (!hasCompletedOnboarding(session)) {
+    redirect("/");
   }
 
   return session;
@@ -29,4 +37,10 @@ export const requireOwnerPageSession = async () => {
 
 export const getRequestSession = async (request: {
   cookies: { get(name: string): { value: string } | undefined };
-}) => authService.getSession(getSessionTokenFromCookieStore(request.cookies));
+}) => {
+  const session = await authService.getSession(
+    getSessionTokenFromCookieStore(request.cookies),
+  );
+
+  return hasCompletedOnboarding(session) ? session : null;
+};

--- a/apps/web/server/proxy.test.ts
+++ b/apps/web/server/proxy.test.ts
@@ -1,0 +1,51 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it } from "vitest";
+
+import { proxy } from "@/proxy";
+
+const requestForPath = (path: string, cookie: string) =>
+  new NextRequest(`http://localhost:3000${path}`, {
+    headers: {
+      cookie,
+      host: "localhost:3000",
+    },
+  });
+
+describe("proxy onboarding cookie guard", () => {
+  it.each([
+    "/admin",
+    "/favorites",
+    "/files",
+    "/home",
+    "/recent",
+    "/search",
+    "/settings",
+    "/shared",
+    "/trash",
+  ])(
+    "redirects %s when session exists but onboarded cookie is missing",
+    (path) => {
+      const response = proxy(requestForPath(path, "staaash_session=token"));
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get("location")).toBe("http://localhost:3000/");
+    },
+  );
+
+  it("lets the DB-backed page and API guards handle stale onboarded cookies", () => {
+    const response = proxy(
+      requestForPath("/files", "staaash_session=token; staaash_onboarded=1"),
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("does not gate public invite or share paths", () => {
+    expect(
+      proxy(requestForPath("/invite/token", "staaash_session=token")).status,
+    ).toBe(200);
+    expect(
+      proxy(requestForPath("/s/token", "staaash_session=token")).status,
+    ).toBe(200);
+  });
+});


### PR DESCRIPTION
## 🚀 Summary

Require completed onboarding in the database before signed-in users can access protected Staaash routes and APIs.

This fixes the case where a stale `staaash_onboarded=1` cookie could let a fresh Docker deployment skip onboarding after login.

## 📊 Impacts and Changes

- Protected workspace pages now redirect signed-in users back to `/` until `UserPreference.onboardingCompletedAt` exists.
- Protected file, share, upload, and admin APIs now treat unfinished onboarding sessions as unauthenticated.
- Proxy cookie gating now covers all workspace route prefixes, while public invite/share routes stay public.
- Auth behavior changed; no schema, storage, or restore behavior changed.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [ ] If this PR changes UI or UX behavior, I verified it manually in the local dev environment. Not run: Docker stack in `C:\Atlas\Staaash` was not running; stale-cookie behavior is covered by unit tests.

Additional checks run:

- `pnpm web:test`
- `pnpm typecheck`
- `pnpm format:check`
- `git diff --check`

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

After deploying the fixed image, clear localhost cookies or use a clean browser profile when retesting an unfinished onboarding account.

## 🔗 Linked Issues

None.
