### PR TITLE
Fix HTTP auth cookies for LAN installs

### DIFF
--- a/apps/web/app/api/auth/invites/redeem/route.ts
+++ b/apps/web/app/api/auth/invites/redeem/route.ts
@@ -47,7 +47,11 @@ export async function POST(request: NextRequest) {
         );
 
     response.cookies.set(
-      buildSessionCookie(result.sessionToken, result.session.expiresAt),
+      buildSessionCookie(
+        result.sessionToken,
+        result.session.expiresAt,
+        request,
+      ),
     );
 
     return response;

--- a/apps/web/app/api/auth/password-resets/redeem/route.ts
+++ b/apps/web/app/api/auth/password-resets/redeem/route.ts
@@ -44,7 +44,11 @@ export async function POST(request: NextRequest) {
         );
 
     response.cookies.set(
-      buildSessionCookie(result.sessionToken, result.session.expiresAt),
+      buildSessionCookie(
+        result.sessionToken,
+        result.session.expiresAt,
+        request,
+      ),
     );
 
     return response;

--- a/apps/web/app/api/auth/rehydrate/route.ts
+++ b/apps/web/app/api/auth/rehydrate/route.ts
@@ -20,7 +20,9 @@ export async function GET(request: NextRequest) {
   const response = NextResponse.redirect(
     new URL("/files", getBaseUrl(request.headers)),
   );
-  response.cookies.set(buildOnboardedCookie());
-  response.cookies.set(buildThemeCookie(session.user.preferences.theme));
+  response.cookies.set(buildOnboardedCookie(request));
+  response.cookies.set(
+    buildThemeCookie(session.user.preferences.theme, request),
+  );
   return response;
 }

--- a/apps/web/app/api/auth/session/route.ts
+++ b/apps/web/app/api/auth/session/route.ts
@@ -31,6 +31,6 @@ export async function DELETE(request: NextRequest) {
     getSessionTokenFromCookieStore(request.cookies),
   );
   const response = NextResponse.json({ ok: true });
-  response.cookies.set(buildClearedSessionCookie());
+  response.cookies.set(buildClearedSessionCookie(request));
   return response;
 }

--- a/apps/web/app/api/auth/setup/route.ts
+++ b/apps/web/app/api/auth/setup/route.ts
@@ -44,9 +44,13 @@ export async function POST(request: NextRequest) {
       : NextResponse.redirect(new URL("/files", request.url), 303);
 
     response.cookies.set(
-      buildSessionCookie(result.sessionToken, result.session.expiresAt),
+      buildSessionCookie(
+        result.sessionToken,
+        result.session.expiresAt,
+        request,
+      ),
     );
-    response.cookies.set(buildClearedOnboardedCookie());
+    response.cookies.set(buildClearedOnboardedCookie(request));
 
     return response;
   } catch (error) {

--- a/apps/web/app/api/auth/sign-in/route.ts
+++ b/apps/web/app/api/auth/sign-in/route.ts
@@ -43,13 +43,17 @@ export async function POST(request: NextRequest) {
       : NextResponse.redirect(new URL(next, getBaseUrl(request.headers)), 303);
 
     response.cookies.set(
-      buildSessionCookie(result.sessionToken, result.session.expiresAt),
+      buildSessionCookie(
+        result.sessionToken,
+        result.session.expiresAt,
+        request,
+      ),
     );
 
     const prefs = result.session.user.preferences;
     if (prefs?.onboardingCompletedAt) {
-      response.cookies.set(buildOnboardedCookie());
-      response.cookies.set(buildThemeCookie(prefs.theme));
+      response.cookies.set(buildOnboardedCookie(request));
+      response.cookies.set(buildThemeCookie(prefs.theme, request));
     }
 
     return response;

--- a/apps/web/app/api/auth/sign-out/route.ts
+++ b/apps/web/app/api/auth/sign-out/route.ts
@@ -36,8 +36,8 @@ export async function POST(request: NextRequest) {
       ? NextResponse.json({ ok: true })
       : NextResponse.redirect(new URL(next, getBaseUrl(request.headers)), 303);
 
-    response.cookies.set(buildClearedSessionCookie());
-    response.cookies.set(buildClearedOnboardedCookie());
+    response.cookies.set(buildClearedSessionCookie(request));
+    response.cookies.set(buildClearedOnboardedCookie(request));
 
     return response;
   } catch (error) {

--- a/apps/web/app/api/user/preferences/route.ts
+++ b/apps/web/app/api/user/preferences/route.ts
@@ -63,8 +63,8 @@ export async function POST(request: NextRequest) {
     });
 
     const response = NextResponse.json({ ok: true });
-    response.cookies.set(buildOnboardedCookie());
-    response.cookies.set(buildThemeCookie(theme));
+    response.cookies.set(buildOnboardedCookie(request));
+    response.cookies.set(buildThemeCookie(theme, request));
     return response;
   } catch (error) {
     return jsonErrorResponse(error);

--- a/apps/web/server/auth/cookie-routes.test.ts
+++ b/apps/web/server/auth/cookie-routes.test.ts
@@ -1,14 +1,29 @@
 import { NextRequest } from "next/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { bootstrap, signIn } = vi.hoisted(() => ({
+const {
+  bootstrap,
+  getSession,
+  redeemInvite,
+  revokeSession,
+  savePreferences,
+  signIn,
+} = vi.hoisted(() => ({
   bootstrap: vi.fn(),
+  getSession: vi.fn(),
+  redeemInvite: vi.fn(),
+  revokeSession: vi.fn(),
+  savePreferences: vi.fn(),
   signIn: vi.fn(),
 }));
 
 vi.mock("@/server/auth/service", () => ({
   authService: {
     bootstrap,
+    getSession,
+    redeemInvite,
+    revokeSession,
+    savePreferences,
     signIn,
   },
 }));
@@ -23,31 +38,43 @@ const completedPreferences = {
 };
 
 const makeAuthResult = (sessionToken: string, preferences: unknown = null) => {
-  const user = {
-    id: "user-1",
-    email: "owner@example.com",
-    username: "owner",
-    displayName: "Owner",
-    avatarUrl: null,
-    role: "owner",
-    storageLimitBytes: null,
-    preferences,
-    createdAt: new Date("2026-05-10T12:00:00.000Z"),
-    updatedAt: new Date("2026-05-10T12:00:00.000Z"),
-  };
+  const user = makeAuthUser(preferences);
 
   return {
     sessionToken,
     user,
-    session: {
-      id: "session-1",
-      expiresAt,
-      createdAt: new Date("2026-05-10T12:00:00.000Z"),
-      updatedAt: new Date("2026-05-10T12:00:00.000Z"),
-      user,
-    },
+    session: makeSession(user),
   };
 };
+
+const makeAuthUser = (preferences: unknown = null) => ({
+  id: "user-1",
+  email: "owner@example.com",
+  username: "owner",
+  displayName: "Owner",
+  avatarUrl: null,
+  role: "owner",
+  storageLimitBytes: null,
+  preferences,
+  createdAt: new Date("2026-05-10T12:00:00.000Z"),
+  updatedAt: new Date("2026-05-10T12:00:00.000Z"),
+});
+
+const makeSession = (user = makeAuthUser(completedPreferences)) => ({
+  id: "session-1",
+  expiresAt,
+  createdAt: new Date("2026-05-10T12:00:00.000Z"),
+  updatedAt: new Date("2026-05-10T12:00:00.000Z"),
+  user,
+});
+
+const completedSession = (theme = "dark") =>
+  makeSession(
+    makeAuthUser({
+      ...completedPreferences,
+      theme,
+    }),
+  );
 
 const jsonRequest = (
   url: string,
@@ -65,6 +92,56 @@ const jsonRequest = (
     body: JSON.stringify(body),
   });
 
+const httpJsonRequest = (path: string, body: Record<string, string>) =>
+  jsonRequest(`http://46.1.113.7:2113${path}`, body);
+
+const forwardedHttpsJsonRequest = (
+  path: string,
+  body: Record<string, string>,
+) =>
+  jsonRequest(`http://staaash:2113${path}`, body, {
+    host: "staaash.example.com",
+    "x-forwarded-proto": "https",
+  });
+
+const request = (
+  url: string,
+  init?: ConstructorParameters<typeof NextRequest>[1],
+) =>
+  new NextRequest(url, {
+    ...init,
+    headers: {
+      host: new URL(url).host,
+      ...init?.headers,
+    },
+  });
+
+const httpRequest = (
+  path: string,
+  init?: ConstructorParameters<typeof NextRequest>[1],
+) => request(`http://46.1.113.7:2113${path}`, init);
+
+const forwardedHttpsRequest = (
+  path: string,
+  init?: ConstructorParameters<typeof NextRequest>[1],
+) =>
+  request(`http://staaash:2113${path}`, {
+    ...init,
+    headers: {
+      host: "staaash.example.com",
+      "x-forwarded-proto": "https",
+      ...init?.headers,
+    },
+  });
+
+const expectCookieSecure = (setCookie: string, expected: boolean) => {
+  if (expected) {
+    expect(setCookie).toContain("Secure");
+  } else {
+    expect(setCookie).not.toContain("Secure");
+  }
+};
+
 describe("auth cookie routes", () => {
   afterEach(() => {
     vi.clearAllMocks();
@@ -76,7 +153,7 @@ describe("auth cookie routes", () => {
     const { POST } = await import("@/app/api/auth/setup/route");
 
     const response = await POST(
-      jsonRequest("http://46.1.113.7:2113/api/auth/setup", {
+      httpJsonRequest("/api/auth/setup", {
         instanceName: "Home Drive",
         email: "owner@example.com",
         username: "owner",
@@ -87,7 +164,7 @@ describe("auth cookie routes", () => {
     expect(response.status).toBe(201);
     const setCookie = response.headers.get("set-cookie") ?? "";
     expect(setCookie).toContain("staaash_session=setup-token");
-    expect(setCookie).not.toContain("Secure");
+    expectCookieSecure(setCookie, false);
   });
 
   it("sets secure setup cookies behind forwarded HTTPS", async () => {
@@ -95,25 +172,18 @@ describe("auth cookie routes", () => {
     const { POST } = await import("@/app/api/auth/setup/route");
 
     const response = await POST(
-      jsonRequest(
-        "http://staaash:2113/api/auth/setup",
-        {
-          instanceName: "Home Drive",
-          email: "owner@example.com",
-          username: "owner",
-          password: "super-secure-password",
-        },
-        {
-          host: "staaash.example.com",
-          "x-forwarded-proto": "https",
-        },
-      ),
+      forwardedHttpsJsonRequest("/api/auth/setup", {
+        instanceName: "Home Drive",
+        email: "owner@example.com",
+        username: "owner",
+        password: "super-secure-password",
+      }),
     );
 
     expect(response.status).toBe(201);
     const setCookie = response.headers.get("set-cookie") ?? "";
     expect(setCookie).toContain("staaash_session=setup-token");
-    expect(setCookie).toContain("Secure");
+    expectCookieSecure(setCookie, true);
   });
 
   it("sets non-secure sign-in cookies over plain HTTP", async () => {
@@ -123,7 +193,7 @@ describe("auth cookie routes", () => {
     const { POST } = await import("@/app/api/auth/sign-in/route");
 
     const response = await POST(
-      jsonRequest("http://46.1.113.7:2113/api/auth/sign-in", {
+      httpJsonRequest("/api/auth/sign-in", {
         identifier: "owner",
         password: "super-secure-password",
       }),
@@ -134,7 +204,7 @@ describe("auth cookie routes", () => {
     expect(setCookie).toContain("staaash_session=sign-in-token");
     expect(setCookie).toContain("staaash_onboarded=1");
     expect(setCookie).toContain("staaash_theme=dark");
-    expect(setCookie).not.toContain("Secure");
+    expectCookieSecure(setCookie, false);
   });
 
   it("sets secure sign-in cookies behind forwarded HTTPS", async () => {
@@ -144,17 +214,10 @@ describe("auth cookie routes", () => {
     const { POST } = await import("@/app/api/auth/sign-in/route");
 
     const response = await POST(
-      jsonRequest(
-        "http://staaash:2113/api/auth/sign-in",
-        {
-          identifier: "owner",
-          password: "super-secure-password",
-        },
-        {
-          host: "staaash.example.com",
-          "x-forwarded-proto": "https",
-        },
-      ),
+      forwardedHttpsJsonRequest("/api/auth/sign-in", {
+        identifier: "owner",
+        password: "super-secure-password",
+      }),
     );
 
     expect(response.status).toBe(200);
@@ -162,6 +225,146 @@ describe("auth cookie routes", () => {
     expect(setCookie).toContain("staaash_session=sign-in-token");
     expect(setCookie).toContain("staaash_onboarded=1");
     expect(setCookie).toContain("staaash_theme=dark");
-    expect(setCookie).toContain("Secure");
+    expectCookieSecure(setCookie, true);
+  });
+
+  it("sets non-secure rehydrate cookies over plain HTTP", async () => {
+    getSession.mockResolvedValueOnce(completedSession());
+    const { GET } = await import("@/app/api/auth/rehydrate/route");
+
+    const response = await GET(
+      httpRequest("/api/auth/rehydrate", {
+        headers: {
+          cookie: "staaash_session=session-token",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(307);
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("staaash_onboarded=1");
+    expect(setCookie).toContain("staaash_theme=dark");
+    expectCookieSecure(setCookie, false);
+  });
+
+  it("sets secure rehydrate cookies behind forwarded HTTPS", async () => {
+    getSession.mockResolvedValueOnce(completedSession());
+    const { GET } = await import("@/app/api/auth/rehydrate/route");
+
+    const response = await GET(
+      forwardedHttpsRequest("/api/auth/rehydrate", {
+        headers: {
+          cookie: "staaash_session=session-token",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(307);
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("staaash_onboarded=1");
+    expect(setCookie).toContain("staaash_theme=dark");
+    expectCookieSecure(setCookie, true);
+  });
+
+  it("sets non-secure preference cookies over plain HTTP", async () => {
+    getSession.mockResolvedValueOnce(completedSession("system"));
+    savePreferences.mockResolvedValueOnce(completedPreferences);
+    const { POST } = await import("@/app/api/user/preferences/route");
+
+    const response = await POST(
+      httpJsonRequest("/api/user/preferences", {
+        theme: "light",
+        timeZone: "UTC",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(savePreferences).toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({
+        theme: "light",
+        timeZone: "UTC",
+      }),
+    );
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("staaash_onboarded=1");
+    expect(setCookie).toContain("staaash_theme=light");
+    expectCookieSecure(setCookie, false);
+  });
+
+  it("sets secure preference cookies behind forwarded HTTPS", async () => {
+    getSession.mockResolvedValueOnce(completedSession("system"));
+    savePreferences.mockResolvedValueOnce(completedPreferences);
+    const { POST } = await import("@/app/api/user/preferences/route");
+
+    const response = await POST(
+      forwardedHttpsJsonRequest("/api/user/preferences", {
+        theme: "light",
+        timeZone: "UTC",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("staaash_onboarded=1");
+    expect(setCookie).toContain("staaash_theme=light");
+    expectCookieSecure(setCookie, true);
+  });
+
+  it("sets secure cleared session cookies behind forwarded HTTPS", async () => {
+    revokeSession.mockResolvedValueOnce(undefined);
+    const { DELETE } = await import("@/app/api/auth/session/route");
+
+    const response = await DELETE(
+      forwardedHttpsRequest("/api/auth/session", {
+        method: "DELETE",
+        headers: {
+          cookie: "staaash_session=session-token",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(revokeSession).toHaveBeenCalledWith("session-token");
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("staaash_session=");
+    expect(setCookie).toContain("Max-Age=0");
+    expectCookieSecure(setCookie, true);
+  });
+
+  it("sets non-secure invite redemption cookies over plain HTTP", async () => {
+    redeemInvite.mockResolvedValueOnce(makeAuthResult("invite-token"));
+    const { POST } = await import("@/app/api/auth/invites/redeem/route");
+
+    const response = await POST(
+      httpJsonRequest("/api/auth/invites/redeem", {
+        token: "invite-token",
+        username: "member",
+        password: "super-secure-password",
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("staaash_session=invite-token");
+    expectCookieSecure(setCookie, false);
+  });
+
+  it("sets secure invite redemption cookies behind forwarded HTTPS", async () => {
+    redeemInvite.mockResolvedValueOnce(makeAuthResult("invite-token"));
+    const { POST } = await import("@/app/api/auth/invites/redeem/route");
+
+    const response = await POST(
+      forwardedHttpsJsonRequest("/api/auth/invites/redeem", {
+        token: "invite-token",
+        username: "member",
+        password: "super-secure-password",
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("staaash_session=invite-token");
+    expectCookieSecure(setCookie, true);
   });
 });

--- a/apps/web/server/auth/cookie-routes.test.ts
+++ b/apps/web/server/auth/cookie-routes.test.ts
@@ -1,0 +1,167 @@
+import { NextRequest } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { bootstrap, signIn } = vi.hoisted(() => ({
+  bootstrap: vi.fn(),
+  signIn: vi.fn(),
+}));
+
+vi.mock("@/server/auth/service", () => ({
+  authService: {
+    bootstrap,
+    signIn,
+  },
+}));
+
+const expiresAt = new Date("2026-05-11T12:00:00.000Z");
+const completedPreferences = {
+  theme: "dark",
+  timeZone: "UTC",
+  showUpdateNotifications: true,
+  enableVersionChecks: true,
+  onboardingCompletedAt: new Date("2026-05-10T12:00:00.000Z"),
+};
+
+const makeAuthResult = (sessionToken: string, preferences: unknown = null) => {
+  const user = {
+    id: "user-1",
+    email: "owner@example.com",
+    username: "owner",
+    displayName: "Owner",
+    avatarUrl: null,
+    role: "owner",
+    storageLimitBytes: null,
+    preferences,
+    createdAt: new Date("2026-05-10T12:00:00.000Z"),
+    updatedAt: new Date("2026-05-10T12:00:00.000Z"),
+  };
+
+  return {
+    sessionToken,
+    user,
+    session: {
+      id: "session-1",
+      expiresAt,
+      createdAt: new Date("2026-05-10T12:00:00.000Z"),
+      updatedAt: new Date("2026-05-10T12:00:00.000Z"),
+      user,
+    },
+  };
+};
+
+const jsonRequest = (
+  url: string,
+  body: Record<string, string>,
+  headers?: HeadersInit,
+) =>
+  new NextRequest(url, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+      host: new URL(url).host,
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+
+describe("auth cookie routes", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("sets non-secure setup cookies over plain HTTP", async () => {
+    bootstrap.mockResolvedValueOnce(makeAuthResult("setup-token"));
+    const { POST } = await import("@/app/api/auth/setup/route");
+
+    const response = await POST(
+      jsonRequest("http://46.1.113.7:2113/api/auth/setup", {
+        instanceName: "Home Drive",
+        email: "owner@example.com",
+        username: "owner",
+        password: "super-secure-password",
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("staaash_session=setup-token");
+    expect(setCookie).not.toContain("Secure");
+  });
+
+  it("sets secure setup cookies behind forwarded HTTPS", async () => {
+    bootstrap.mockResolvedValueOnce(makeAuthResult("setup-token"));
+    const { POST } = await import("@/app/api/auth/setup/route");
+
+    const response = await POST(
+      jsonRequest(
+        "http://staaash:2113/api/auth/setup",
+        {
+          instanceName: "Home Drive",
+          email: "owner@example.com",
+          username: "owner",
+          password: "super-secure-password",
+        },
+        {
+          host: "staaash.example.com",
+          "x-forwarded-proto": "https",
+        },
+      ),
+    );
+
+    expect(response.status).toBe(201);
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("staaash_session=setup-token");
+    expect(setCookie).toContain("Secure");
+  });
+
+  it("sets non-secure sign-in cookies over plain HTTP", async () => {
+    signIn.mockResolvedValueOnce(
+      makeAuthResult("sign-in-token", completedPreferences),
+    );
+    const { POST } = await import("@/app/api/auth/sign-in/route");
+
+    const response = await POST(
+      jsonRequest("http://46.1.113.7:2113/api/auth/sign-in", {
+        identifier: "owner",
+        password: "super-secure-password",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("staaash_session=sign-in-token");
+    expect(setCookie).toContain("staaash_onboarded=1");
+    expect(setCookie).toContain("staaash_theme=dark");
+    expect(setCookie).not.toContain("Secure");
+  });
+
+  it("sets secure sign-in cookies behind forwarded HTTPS", async () => {
+    signIn.mockResolvedValueOnce(
+      makeAuthResult("sign-in-token", completedPreferences),
+    );
+    const { POST } = await import("@/app/api/auth/sign-in/route");
+
+    const response = await POST(
+      jsonRequest(
+        "http://staaash:2113/api/auth/sign-in",
+        {
+          identifier: "owner",
+          password: "super-secure-password",
+        },
+        {
+          host: "staaash.example.com",
+          "x-forwarded-proto": "https",
+        },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("staaash_session=sign-in-token");
+    expect(setCookie).toContain("staaash_onboarded=1");
+    expect(setCookie).toContain("staaash_theme=dark");
+    expect(setCookie).toContain("Secure");
+  });
+});

--- a/apps/web/server/auth/session.test.ts
+++ b/apps/web/server/auth/session.test.ts
@@ -24,6 +24,11 @@ const loadSessionModule = async ({
   return import("@/server/auth/session");
 };
 
+const requestContext = (url: string, headers?: HeadersInit) => ({
+  url,
+  headers: new Headers(headers),
+});
+
 describe("auth session cookies", () => {
   afterEach(() => {
     vi.doUnmock("@/lib/env");
@@ -66,13 +71,55 @@ describe("auth session cookies", () => {
     });
   });
 
-  it("defaults secure cookies on in production", async () => {
+  it("lets SECURE_COOKIES=false override HTTPS requests", async () => {
+    const { buildSessionCookie } = await loadSessionModule({
+      secureCookies: false,
+    });
+    const expiresAt = new Date("2026-05-11T12:00:00.000Z");
+
+    expect(
+      buildSessionCookie(
+        "session-token",
+        expiresAt,
+        requestContext("http://staaash:2113/api/auth/sign-in", {
+          "x-forwarded-proto": "https",
+        }),
+      ),
+    ).toMatchObject({
+      secure: false,
+    });
+  });
+
+  it("uses non-secure cookies for plain HTTP requests without an override", async () => {
+    const { buildSessionCookie } = await loadSessionModule({
+      nodeEnv: "production",
+    });
+    const expiresAt = new Date("2026-05-11T12:00:00.000Z");
+
+    expect(
+      buildSessionCookie(
+        "session-token",
+        expiresAt,
+        requestContext("http://46.1.113.7:2113/api/auth/sign-in"),
+      ),
+    ).toMatchObject({
+      secure: false,
+    });
+  });
+
+  it("uses secure cookies for forwarded HTTPS requests without an override", async () => {
     const { buildOnboardedCookie, ONBOARDED_COOKIE_NAME } =
       await loadSessionModule({
         nodeEnv: "production",
       });
 
-    expect(buildOnboardedCookie()).toEqual({
+    expect(
+      buildOnboardedCookie(
+        requestContext("http://staaash:2113/api/auth/rehydrate", {
+          "x-forwarded-proto": "https",
+        }),
+      ),
+    ).toEqual({
       name: ONBOARDED_COOKIE_NAME,
       value: "1",
       httpOnly: true,
@@ -80,6 +127,16 @@ describe("auth session cookies", () => {
       secure: true,
       path: "/",
       maxAge: 60 * 60 * 24 * 365 * 10,
+    });
+  });
+
+  it("falls back to secure cookies in production when no request is passed", async () => {
+    const { buildOnboardedCookie } = await loadSessionModule({
+      nodeEnv: "production",
+    });
+
+    expect(buildOnboardedCookie()).toMatchObject({
+      secure: true,
     });
   });
 
@@ -96,6 +153,7 @@ describe("auth session cookies", () => {
     expect(buildClearedOnboardedCookie()).toEqual({
       name: ONBOARDED_COOKIE_NAME,
       value: "",
+      secure: false,
       expires: new Date(0),
       maxAge: 0,
       path: "/",

--- a/apps/web/server/auth/session.ts
+++ b/apps/web/server/auth/session.ts
@@ -7,56 +7,114 @@ export const SESSION_COOKIE_NAME = "staaash_session";
 export const ONBOARDED_COOKIE_NAME = "staaash_onboarded";
 export const THEME_COOKIE_NAME = "staaash_theme";
 
-const isSecure =
-  env.SECURE_COOKIES !== undefined
-    ? env.SECURE_COOKIES
-    : env.NODE_ENV === "production";
+type CookieRequestContext = {
+  headers?: {
+    get(name: string): string | null;
+  };
+  nextUrl?: {
+    protocol?: string;
+  };
+  url?: string;
+};
 
-const baseCookie = {
+const normalizeProtocol = (protocol: string) =>
+  protocol.replace(/:$/, "").trim().toLowerCase();
+
+const getForwardedProtocol = (context?: CookieRequestContext) => {
+  const proto = context?.headers
+    ?.get("x-forwarded-proto")
+    ?.split(",")[0]
+    ?.trim();
+
+  return proto ? normalizeProtocol(proto) : null;
+};
+
+const getRequestProtocol = (context?: CookieRequestContext) => {
+  const forwardedProtocol = getForwardedProtocol(context);
+  if (forwardedProtocol) return forwardedProtocol;
+
+  const nextUrlProtocol = context?.nextUrl?.protocol;
+  if (nextUrlProtocol) return normalizeProtocol(nextUrlProtocol);
+
+  if (context?.url) {
+    try {
+      return normalizeProtocol(new URL(context.url).protocol);
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+};
+
+export const resolveSecureCookie = (context?: CookieRequestContext) => {
+  if (env.SECURE_COOKIES !== undefined) {
+    return env.SECURE_COOKIES;
+  }
+
+  const protocol = getRequestProtocol(context);
+  if (protocol) {
+    return protocol === "https";
+  }
+
+  return env.NODE_ENV === "production";
+};
+
+const baseCookie = (context?: CookieRequestContext) => ({
   name: SESSION_COOKIE_NAME,
   httpOnly: true,
   sameSite: "lax" as const,
-  secure: isSecure,
+  secure: resolveSecureCookie(context),
   path: "/",
-};
+});
 
-export const buildSessionCookie = (value: string, expiresAt: Date) => ({
-  ...baseCookie,
+export const buildSessionCookie = (
+  value: string,
+  expiresAt: Date,
+  context?: CookieRequestContext,
+) => ({
+  ...baseCookie(context),
   value,
   expires: expiresAt,
 });
 
-export const buildClearedSessionCookie = () => ({
-  ...baseCookie,
+export const buildClearedSessionCookie = (context?: CookieRequestContext) => ({
+  ...baseCookie(context),
   value: "",
   expires: new Date(0),
   maxAge: 0,
 });
 
-export const buildOnboardedCookie = () => ({
+export const buildOnboardedCookie = (context?: CookieRequestContext) => ({
   name: ONBOARDED_COOKIE_NAME,
   value: "1",
   httpOnly: true,
   sameSite: "lax" as const,
-  secure: isSecure,
+  secure: resolveSecureCookie(context),
   path: "/",
   maxAge: 60 * 60 * 24 * 365 * 10,
 });
 
-export const buildClearedOnboardedCookie = () => ({
+export const buildClearedOnboardedCookie = (
+  context?: CookieRequestContext,
+) => ({
   name: ONBOARDED_COOKIE_NAME,
   value: "",
+  secure: resolveSecureCookie(context),
   expires: new Date(0),
   maxAge: 0,
   path: "/",
 });
 
-export const buildThemeCookie = (theme: string) => ({
+export const buildThemeCookie = (
+  theme: string,
+  context?: CookieRequestContext,
+) => ({
   name: THEME_COOKIE_NAME,
   value: theme,
   httpOnly: false,
   sameSite: "lax" as const,
-  secure: isSecure,
+  secure: resolveSecureCookie(context),
   path: "/",
   maxAge: 60 * 60 * 24 * 365 * 10,
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       STAAASH_VERSION: ${STAAASH_VERSION:-latest}
       DATABASE_URL: postgresql://${DB_USERNAME:-postgres}:${DB_PASSWORD}@db:5432/${DB_DATABASE_NAME:-staaash}
       UPLOAD_LOCATION: /data/files
-      SECURE_COOKIES: "${SECURE_COOKIES:-true}"
+      SECURE_COOKIES: "${SECURE_COOKIES:-}"
     volumes:
       # Do not edit the next line. To change where files are stored, edit UPLOAD_LOCATION in the .env file
       - ${UPLOAD_LOCATION:-./library}:/data/files

--- a/example.env
+++ b/example.env
@@ -18,7 +18,6 @@ DB_DATABASE_NAME=staaash
 DB_PASSWORD=change-me
 
 # ── Security ──────────────────────────────────────────────────────────────────
-# Set to false if you are running without HTTPS (e.g. plain HTTP on a local network).
-# Secure cookies require HTTPS — leaving this true over HTTP will break login.
-# Allowed values when set: true or false.
-# SECURE_COOKIES=false
+# Optional override. By default, Staaash uses secure cookies on HTTPS and
+# non-secure cookies on plain HTTP. Allowed values when set: true or false.
+# SECURE_COOKIES=true


### PR DESCRIPTION
## 🚀 Summary

Fixes login on plain HTTP Staaash instances, including LAN/IP installs such as `http://46.1.113.7:2113`. Auth cookies now follow the request protocol when `SECURE_COOKIES` is not explicitly set.

Root cause: Docker production mode defaulted auth cookies to `Secure`, so browsers dropped session cookies over plain HTTP. The app then returned to `/` and showed sign-in again.

## 📊 Impacts and Changes

Users can register, finish onboarding, and sign in on plain HTTP installs without setting `SECURE_COOKIES=false` manually.

HTTPS and reverse-proxy installs stay secure when `x-forwarded-proto=https` is present. `SECURE_COOKIES=true` and `SECURE_COOKIES=false` still force the old explicit behavior.

Auth behavior changed: setup, sign-in, rehydrate, invite redemption, password reset redemption, sign-out, session delete, and preferences now pass request context into cookie creation.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

Additional checks run:

- [x] `pnpm --filter web test -- server/auth/session.test.ts server/auth/cookie-routes.test.ts server/auth/sign-out-route.test.ts`
- [x] `pnpm --filter web typecheck`
- [x] `pnpm format:check`
- [x] `git diff --check`

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

None.

## 🔗 Linked Issues

None.
