### PR TITLE
Add Discord-friendly share metadata

### DIFF
--- a/apps/web/app/s/[token]/f/[folderId]/page.tsx
+++ b/apps/web/app/s/[token]/f/[folderId]/page.tsx
@@ -1,8 +1,11 @@
-import { cookies } from "next/headers";
+import type { Metadata } from "next";
+import { cookies, headers } from "next/headers";
 
 import { ShareErrorView, ShareView } from "@/app/s/share-view";
+import { getBaseUrl } from "@/server/request";
 import { SHARE_ACCESS_COOKIE_NAME } from "@/server/sharing/access-cookie";
 import { ShareError, isShareError } from "@/server/sharing/errors";
+import { getSharePageMetadata } from "@/server/sharing/metadata";
 import { sharingService } from "@/server/sharing/service";
 
 export const dynamic = "force-dynamic";
@@ -14,6 +17,24 @@ type SharedFolderPageProps = {
   }>;
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
+
+export async function generateMetadata({
+  params,
+}: SharedFolderPageProps): Promise<Metadata> {
+  const [{ token, folderId }, h, cookieStore] = await Promise.all([
+    params,
+    headers(),
+    cookies(),
+  ]);
+
+  return getSharePageMetadata({
+    token,
+    folderId,
+    baseUrl: getBaseUrl(h),
+    shareAccessCookieValue:
+      cookieStore.get(SHARE_ACCESS_COOKIE_NAME)?.value ?? null,
+  });
+}
 
 export default async function SharedFolderPage({
   params,

--- a/apps/web/app/s/[token]/files/[fileId]/page.tsx
+++ b/apps/web/app/s/[token]/files/[fileId]/page.tsx
@@ -1,4 +1,5 @@
-import { cookies } from "next/headers";
+import type { Metadata } from "next";
+import { cookies, headers } from "next/headers";
 import { notFound } from "next/navigation";
 
 import {
@@ -6,8 +7,10 @@ import {
   ShareFilePage,
   ShareLockedView,
 } from "@/app/s/share-view";
+import { getBaseUrl } from "@/server/request";
 import { SHARE_ACCESS_COOKIE_NAME } from "@/server/sharing/access-cookie";
 import { ShareError, isShareError } from "@/server/sharing/errors";
+import { getSharePageMetadata } from "@/server/sharing/metadata";
 import { sharingService } from "@/server/sharing/service";
 
 export const dynamic = "force-dynamic";
@@ -19,6 +22,24 @@ type SharedNestedFilePageProps = {
   }>;
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
+
+export async function generateMetadata({
+  params,
+}: SharedNestedFilePageProps): Promise<Metadata> {
+  const [{ token, fileId }, h, cookieStore] = await Promise.all([
+    params,
+    headers(),
+    cookies(),
+  ]);
+
+  return getSharePageMetadata({
+    token,
+    fileId,
+    baseUrl: getBaseUrl(h),
+    shareAccessCookieValue:
+      cookieStore.get(SHARE_ACCESS_COOKIE_NAME)?.value ?? null,
+  });
+}
 
 export default async function SharedNestedFilePage({
   params,

--- a/apps/web/app/s/[token]/page.tsx
+++ b/apps/web/app/s/[token]/page.tsx
@@ -1,8 +1,11 @@
-import { cookies } from "next/headers";
+import type { Metadata } from "next";
+import { cookies, headers } from "next/headers";
 
 import { ShareErrorView, ShareView } from "@/app/s/share-view";
+import { getBaseUrl } from "@/server/request";
 import { SHARE_ACCESS_COOKIE_NAME } from "@/server/sharing/access-cookie";
 import { ShareError, isShareError } from "@/server/sharing/errors";
+import { getSharePageMetadata } from "@/server/sharing/metadata";
 import { sharingService } from "@/server/sharing/service";
 
 export const dynamic = "force-dynamic";
@@ -13,6 +16,23 @@ type SharedRootPageProps = {
   }>;
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
+
+export async function generateMetadata({
+  params,
+}: SharedRootPageProps): Promise<Metadata> {
+  const [{ token }, h, cookieStore] = await Promise.all([
+    params,
+    headers(),
+    cookies(),
+  ]);
+
+  return getSharePageMetadata({
+    token,
+    baseUrl: getBaseUrl(h),
+    shareAccessCookieValue:
+      cookieStore.get(SHARE_ACCESS_COOKIE_NAME)?.value ?? null,
+  });
+}
 
 export default async function SharedRootPage({
   params,

--- a/apps/web/server/sharing/metadata.test.ts
+++ b/apps/web/server/sharing/metadata.test.ts
@@ -1,0 +1,344 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { FileSummary, FolderSummary } from "@/server/files/types";
+import type { PublicShareResolution, ShareLinkSummary } from "./types";
+
+const mocks = vi.hoisted(() => ({
+  findReadyDerivative: vi.fn(),
+  getSetupState: vi.fn(),
+  getSharedNestedFileContent: vi.fn(),
+  resolvePublicShare: vi.fn(),
+}));
+
+vi.mock("@staaash/db/media-derivatives", () => ({
+  findReadyDerivative: mocks.findReadyDerivative,
+}));
+
+vi.mock("@/server/auth/service", () => ({
+  authService: {
+    getSetupState: mocks.getSetupState,
+  },
+}));
+
+vi.mock("@/server/sharing/service", () => ({
+  sharingService: {
+    getSharedNestedFileContent: mocks.getSharedNestedFileContent,
+    resolvePublicShare: mocks.resolvePublicShare,
+  },
+}));
+
+import { buildShareMetadata, getSharePageMetadata } from "./metadata";
+
+const fixedNow = new Date("2026-05-31T12:00:00.000Z");
+
+type OpenGraphForTest = {
+  images?: Array<{ url: string; alt?: string; type?: string }>;
+  videos?: Array<{ url: string; type?: string }>;
+  type?: string;
+};
+
+type TwitterForTest = {
+  card?: string;
+  images?: string[];
+};
+
+const makeFile = (overrides: Partial<FileSummary> = {}): FileSummary => ({
+  id: "file-1",
+  ownerUserId: "user-1",
+  ownerUsername: "alice",
+  folderId: "folder-1",
+  name: "photo.png",
+  mimeType: "image/png",
+  sizeBytes: 2_097_152,
+  viewerKind: "image",
+  deletedAt: null,
+  createdAt: fixedNow,
+  updatedAt: fixedNow,
+  ...overrides,
+});
+
+const makeFolder = (overrides: Partial<FolderSummary> = {}): FolderSummary => ({
+  id: "folder-1",
+  ownerUserId: "user-1",
+  ownerUsername: "alice",
+  parentId: null,
+  name: "Photos",
+  isFilesRoot: false,
+  deletedAt: null,
+  createdAt: fixedNow,
+  updatedAt: fixedNow,
+  ...overrides,
+});
+
+const makeShare = (
+  overrides: Partial<ShareLinkSummary> = {},
+): ShareLinkSummary => ({
+  id: "share-1",
+  createdByUserId: "user-1",
+  targetType: "file",
+  fileId: "file-1",
+  folderId: null,
+  shareUrl: "https://files.example/s/token",
+  hasPassword: false,
+  downloadDisabled: false,
+  expiresAt: new Date("2026-06-30T12:00:00.000Z"),
+  revokedAt: null,
+  createdAt: fixedNow,
+  updatedAt: fixedNow,
+  status: "active",
+  target: {
+    targetType: "file",
+    id: "file-1",
+    ownerUserId: "user-1",
+    ownerUsername: "alice",
+    name: "photo.png",
+    folderId: "folder-1",
+    mimeType: "image/png",
+    sizeBytes: 2_097_152,
+    pathLabel: "Files / photo.png",
+    deletedAt: null,
+  },
+  ...overrides,
+});
+
+const makeFileResolution = (
+  overrides: Partial<PublicShareResolution & { file: FileSummary }> = {},
+): PublicShareResolution => {
+  const file = overrides.file ?? makeFile();
+  return {
+    kind: "file",
+    share: overrides.share ?? makeShare(),
+    access: overrides.access ?? {
+      requiresPassword: false,
+      isUnlocked: true,
+    },
+    file,
+  };
+};
+
+const makeFolderResolution = (
+  overrides: Partial<PublicShareResolution> = {},
+): PublicShareResolution => {
+  const folder = makeFolder();
+  return {
+    kind: "folder",
+    share:
+      overrides.share ??
+      makeShare({
+        targetType: "folder",
+        fileId: null,
+        folderId: folder.id,
+        target: {
+          targetType: "folder",
+          id: folder.id,
+          ownerUserId: "user-1",
+          ownerUsername: "alice",
+          name: folder.name,
+          parentId: null,
+          isFilesRoot: false,
+          pathLabel: "Files / Photos",
+          deletedAt: null,
+        },
+      }),
+    access: overrides.access ?? {
+      requiresPassword: false,
+      isUnlocked: true,
+    },
+    listing: {
+      rootFolder: folder,
+      currentFolder: folder,
+      breadcrumbs: [],
+      childFolders: [],
+      files: [],
+    },
+  };
+};
+
+describe("share metadata", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSetupState.mockResolvedValue({ instanceName: "Ares Cloud" });
+    mocks.findReadyDerivative.mockResolvedValue(null);
+  });
+
+  it("emits absolute Open Graph and Twitter image URLs for image shares", () => {
+    const metadata = buildShareMetadata({
+      baseUrl: "https://files.example",
+      instanceName: "Ares Cloud",
+      target: {
+        kind: "file",
+        pagePath: "/s/token",
+        contentPath: "/s/token/content",
+        file: makeFile(),
+        hasReadyVideoDerivative: false,
+      },
+    });
+
+    const openGraph = metadata.openGraph as OpenGraphForTest;
+    const twitter = metadata.twitter as TwitterForTest;
+
+    expect(openGraph.images).toEqual([
+      {
+        url: "https://files.example/s/token/content",
+        alt: "photo.png",
+      },
+    ]);
+    expect(twitter).toMatchObject({
+      card: "summary_large_image",
+      images: ["https://files.example/s/token/content"],
+    });
+  });
+
+  it("emits Open Graph video when a ready MP4 derivative exists", () => {
+    const metadata = buildShareMetadata({
+      baseUrl: "https://files.example",
+      instanceName: "Ares Cloud",
+      target: {
+        kind: "file",
+        pagePath: "/s/token",
+        contentPath: "/s/token/content",
+        file: makeFile({
+          name: "clip.mkv",
+          mimeType: "video/x-matroska",
+          viewerKind: "video",
+        }),
+        hasReadyVideoDerivative: true,
+      },
+    });
+
+    const openGraph = metadata.openGraph as OpenGraphForTest;
+
+    expect(openGraph.type).toBe("video.other");
+    expect(openGraph.videos).toEqual([
+      {
+        url: "https://files.example/s/token/content",
+        type: "video/mp4",
+      },
+    ]);
+  });
+
+  it("emits Open Graph video for broadly playable original videos", () => {
+    const metadata = buildShareMetadata({
+      baseUrl: "https://files.example",
+      instanceName: "Ares Cloud",
+      target: {
+        kind: "file",
+        pagePath: "/s/token",
+        contentPath: "/s/token/content",
+        file: makeFile({
+          name: "clip.mp4",
+          mimeType: "video/mp4",
+          viewerKind: "video",
+        }),
+        hasReadyVideoDerivative: false,
+      },
+    });
+
+    const openGraph = metadata.openGraph as OpenGraphForTest;
+
+    expect(openGraph.videos).toEqual([
+      {
+        url: "https://files.example/s/token/content",
+        type: "video/mp4",
+      },
+    ]);
+  });
+
+  it("does not emit Open Graph video for non-playable video without derivative", () => {
+    const metadata = buildShareMetadata({
+      baseUrl: "https://files.example",
+      instanceName: "Ares Cloud",
+      target: {
+        kind: "file",
+        pagePath: "/s/token",
+        contentPath: "/s/token/content",
+        file: makeFile({
+          name: "clip.mkv",
+          mimeType: "video/x-matroska",
+          viewerKind: "video",
+        }),
+        hasReadyVideoDerivative: false,
+      },
+    });
+
+    const openGraph = metadata.openGraph as OpenGraphForTest;
+
+    expect(openGraph.type).toBe("website");
+    expect(openGraph.videos).toBeUndefined();
+  });
+
+  it("hides passworded share details from metadata", async () => {
+    mocks.resolvePublicShare.mockResolvedValue(
+      makeFileResolution({
+        share: makeShare({ hasPassword: true }),
+        access: {
+          requiresPassword: true,
+          isUnlocked: false,
+        },
+      }),
+    );
+
+    const metadata = await getSharePageMetadata({
+      baseUrl: "https://files.example",
+      token: "secret-token",
+    });
+
+    expect(metadata.title).toBe("Ares Cloud share");
+    expect(JSON.stringify(metadata)).not.toContain("photo.png");
+    expect(metadata.robots).toEqual({ index: false, follow: false });
+  });
+
+  it("returns generic noindex metadata for invalid shares", async () => {
+    mocks.resolvePublicShare.mockRejectedValue(new Error("missing"));
+
+    const metadata = await getSharePageMetadata({
+      baseUrl: "https://files.example",
+      token: "missing-token",
+    });
+
+    expect(metadata.title).toBe("Ares Cloud share");
+    expect(metadata.robots).toEqual({ index: false, follow: false });
+  });
+
+  it("emits folder card metadata without child media previews", () => {
+    const metadata = buildShareMetadata({
+      baseUrl: "https://files.example",
+      instanceName: "Ares Cloud",
+      target: {
+        kind: "folder",
+        pagePath: "/s/token",
+        folderName: "Photos",
+      },
+    });
+
+    const openGraph = metadata.openGraph as OpenGraphForTest;
+
+    expect(metadata.title).toBe("Photos - Ares Cloud");
+    expect(openGraph.images).toBeUndefined();
+    expect(openGraph.videos).toBeUndefined();
+  });
+
+  it("emits nested shared file metadata from folder shares", async () => {
+    mocks.resolvePublicShare.mockResolvedValue(makeFolderResolution());
+    mocks.getSharedNestedFileContent.mockResolvedValue({
+      file: makeFile({
+        id: "nested-file",
+        name: "nested-photo.jpg",
+        mimeType: "image/jpeg",
+      }),
+    });
+
+    const metadata = await getSharePageMetadata({
+      baseUrl: "https://files.example",
+      token: "folder-token",
+      fileId: "nested-file",
+    });
+
+    const openGraph = metadata.openGraph as OpenGraphForTest;
+
+    expect(metadata.title).toBe("nested-photo.jpg - Ares Cloud");
+    expect(openGraph.images?.[0]?.url).toBe(
+      "https://files.example/s/folder-token/files/nested-file/content",
+    );
+  });
+});

--- a/apps/web/server/sharing/metadata.ts
+++ b/apps/web/server/sharing/metadata.ts
@@ -1,0 +1,321 @@
+import type { Metadata } from "next";
+
+import { findReadyDerivative } from "@staaash/db/media-derivatives";
+
+import { authService } from "@/server/auth/service";
+import type { FileSummary } from "@/server/files/types";
+
+import { sharingService } from "./service";
+import type { PublicShareResolution } from "./types";
+
+const DEFAULT_INSTANCE_NAME = "Staaash";
+const PLAYABLE_VIDEO_TYPES = new Set(["video/mp4", "video/webm"]);
+
+type GenericShareMetadataTarget = {
+  kind: "generic";
+  pagePath: string;
+  noindex: boolean;
+};
+
+type FileShareMetadataTarget = {
+  kind: "file";
+  pagePath: string;
+  contentPath: string;
+  file: FileSummary;
+  hasReadyVideoDerivative: boolean;
+};
+
+type FolderShareMetadataTarget = {
+  kind: "folder";
+  pagePath: string;
+  folderName: string;
+};
+
+export type ShareMetadataTarget =
+  | GenericShareMetadataTarget
+  | FileShareMetadataTarget
+  | FolderShareMetadataTarget;
+
+export type ShareMetadataInput = {
+  baseUrl: string;
+  instanceName?: string | null;
+  target: ShareMetadataTarget;
+};
+
+type SharePageMetadataInput = {
+  baseUrl: string;
+  fileId?: string;
+  folderId?: string;
+  shareAccessCookieValue?: string | null;
+  token: string;
+};
+
+const normalizeMimeType = (mimeType: string) =>
+  mimeType.split(";")[0]?.trim().toLowerCase() ?? "";
+
+const isBroadlyPlayableVideo = (file: FileSummary) =>
+  PLAYABLE_VIDEO_TYPES.has(normalizeMimeType(file.mimeType));
+
+const toAbsoluteUrl = (path: string, baseUrl: string) =>
+  new URL(path, baseUrl).toString();
+
+const formatBytes = (value: number) =>
+  new Intl.NumberFormat("en-GB", {
+    maximumFractionDigits: 1,
+    notation: "standard",
+  }).format(value / (1024 * 1024)) + " MB";
+
+const buildGenericDescription = (instanceName: string) =>
+  `A file or folder shared via ${instanceName}.`;
+
+const buildGenericShareMetadata = ({
+  baseUrl,
+  instanceName,
+  pagePath,
+  noindex,
+}: {
+  baseUrl: string;
+  instanceName: string;
+  pagePath: string;
+  noindex: boolean;
+}): Metadata => {
+  const title = `${instanceName} share`;
+  const description = buildGenericDescription(instanceName);
+  const pageUrl = toAbsoluteUrl(pagePath, baseUrl);
+
+  return {
+    title,
+    description,
+    ...(noindex ? { robots: { index: false, follow: false } } : {}),
+    openGraph: {
+      title,
+      description,
+      siteName: instanceName,
+      type: "website",
+      url: pageUrl,
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
+    },
+  };
+};
+
+export const buildShareMetadata = ({
+  baseUrl,
+  instanceName: rawInstanceName,
+  target,
+}: ShareMetadataInput): Metadata => {
+  const instanceName = rawInstanceName?.trim() || DEFAULT_INSTANCE_NAME;
+
+  if (target.kind === "generic") {
+    return buildGenericShareMetadata({
+      baseUrl,
+      instanceName,
+      pagePath: target.pagePath,
+      noindex: target.noindex,
+    });
+  }
+
+  const pageUrl = toAbsoluteUrl(target.pagePath, baseUrl);
+
+  if (target.kind === "folder") {
+    const title = `${target.folderName} - ${instanceName}`;
+    const description = `Folder shared via ${instanceName}.`;
+
+    return {
+      title,
+      description,
+      openGraph: {
+        title,
+        description,
+        siteName: instanceName,
+        type: "website",
+        url: pageUrl,
+      },
+      twitter: {
+        card: "summary",
+        title,
+        description,
+      },
+    };
+  }
+
+  const file = target.file;
+  const title = `${file.name} - ${instanceName}`;
+  const description = `${file.mimeType} - ${formatBytes(file.sizeBytes)} shared via ${instanceName}.`;
+  const mediaUrl = toAbsoluteUrl(target.contentPath, baseUrl);
+  const isImage = file.viewerKind === "image";
+  const shouldExposeVideo =
+    file.viewerKind === "video" &&
+    (target.hasReadyVideoDerivative || isBroadlyPlayableVideo(file));
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      siteName: instanceName,
+      type: shouldExposeVideo ? "video.other" : "website",
+      url: pageUrl,
+      ...(isImage
+        ? {
+            images: [
+              {
+                url: mediaUrl,
+                alt: file.name,
+              },
+            ],
+          }
+        : {}),
+      ...(shouldExposeVideo
+        ? {
+            videos: [
+              {
+                url: mediaUrl,
+                type: target.hasReadyVideoDerivative
+                  ? "video/mp4"
+                  : normalizeMimeType(file.mimeType),
+              },
+            ],
+          }
+        : {}),
+    },
+    twitter: {
+      card: isImage ? "summary_large_image" : "summary",
+      title,
+      description,
+      ...(isImage ? { images: [mediaUrl] } : {}),
+    },
+  };
+};
+
+const getInstanceName = async (): Promise<string> => {
+  try {
+    const setupState = await authService.getSetupState();
+    return setupState.instanceName?.trim() || DEFAULT_INSTANCE_NAME;
+  } catch {
+    return DEFAULT_INSTANCE_NAME;
+  }
+};
+
+const hasReadyVideoDerivative = async (fileId: string): Promise<boolean> => {
+  const derivative = await findReadyDerivative(fileId);
+  return Boolean(
+    derivative?.storageKey &&
+    normalizeMimeType(derivative.mimeType ?? "") === "video/mp4",
+  );
+};
+
+const shouldExposeShareDetails = (resolution: PublicShareResolution) =>
+  resolution.share.status === "active" && !resolution.share.hasPassword;
+
+const buildRootSharePath = (token: string) => `/s/${encodeURIComponent(token)}`;
+
+const buildFolderSharePath = (token: string, folderId: string) =>
+  `/s/${encodeURIComponent(token)}/f/${encodeURIComponent(folderId)}`;
+
+const buildFileSharePath = (token: string, fileId: string) =>
+  `/s/${encodeURIComponent(token)}/files/${encodeURIComponent(fileId)}`;
+
+const buildNestedFileContentPath = (token: string, fileId: string) =>
+  `/s/${encodeURIComponent(token)}/files/${encodeURIComponent(fileId)}/content`;
+
+export const getSharePageMetadata = async ({
+  baseUrl,
+  fileId,
+  folderId,
+  shareAccessCookieValue,
+  token,
+}: SharePageMetadataInput): Promise<Metadata> => {
+  const instanceName = await getInstanceName();
+  const fallbackPath = fileId
+    ? buildFileSharePath(token, fileId)
+    : folderId
+      ? buildFolderSharePath(token, folderId)
+      : buildRootSharePath(token);
+
+  const fallbackMetadata = () =>
+    buildShareMetadata({
+      baseUrl,
+      instanceName,
+      target: {
+        kind: "generic",
+        pagePath: fallbackPath,
+        noindex: true,
+      },
+    });
+
+  try {
+    const resolution = await sharingService.resolvePublicShare({
+      token,
+      requestedFolderId: folderId,
+      shareAccessCookieValue,
+      baseUrl,
+    });
+
+    if (!shouldExposeShareDetails(resolution)) {
+      return fallbackMetadata();
+    }
+
+    if (fileId) {
+      if (resolution.kind !== "folder") {
+        return fallbackMetadata();
+      }
+
+      const { file } = await sharingService.getSharedNestedFileContent({
+        token,
+        fileId,
+        shareAccessCookieValue,
+      });
+
+      return buildShareMetadata({
+        baseUrl,
+        instanceName,
+        target: {
+          kind: "file",
+          pagePath: buildFileSharePath(token, file.id),
+          contentPath: buildNestedFileContentPath(token, file.id),
+          file,
+          hasReadyVideoDerivative:
+            file.viewerKind === "video"
+              ? await hasReadyVideoDerivative(file.id)
+              : false,
+        },
+      });
+    }
+
+    if (resolution.kind === "file") {
+      return buildShareMetadata({
+        baseUrl,
+        instanceName,
+        target: {
+          kind: "file",
+          pagePath: buildRootSharePath(token),
+          contentPath: `${buildRootSharePath(token)}/content`,
+          file: resolution.file,
+          hasReadyVideoDerivative:
+            resolution.file.viewerKind === "video"
+              ? await hasReadyVideoDerivative(resolution.file.id)
+              : false,
+        },
+      });
+    }
+
+    return buildShareMetadata({
+      baseUrl,
+      instanceName,
+      target: {
+        kind: "folder",
+        pagePath: folderId
+          ? buildFolderSharePath(token, resolution.listing.currentFolder.id)
+          : buildRootSharePath(token),
+        folderName: resolution.listing.currentFolder.name,
+      },
+    });
+  } catch {
+    return fallbackMetadata();
+  }
+};


### PR DESCRIPTION
## 🚀 Summary

Adds standards-based Open Graph and Twitter metadata for public share pages so Discord and similar apps can unfurl Staaash image, video, and folder links with useful cards.

## 📊 Impacts and Changes

- Public, non-password image shares expose their inline content URL as social image metadata.
- Public video shares expose video metadata when a ready MP4 derivative exists or the original is already broadly playable (`video/mp4` or `video/webm`).
- Folder shares get title and description metadata without child media previews.
- Passworded, invalid, expired, revoked, or unavailable shares use generic noindex metadata so file or folder names and media URLs are not leaked.

No schema, auth, storage, or restore behavior changes.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [ ] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

Discord decides final embed rendering and may cache public media. Manual Discord Embed Debugger testing still needs a public HTTPS deployment after this lands.

## 🔗 Linked Issues

None.
