### PR TITLE
Fix Discord video share embeds

### DIFF
--- a/apps/web/server/sharing/metadata.test.ts
+++ b/apps/web/server/sharing/metadata.test.ts
@@ -33,7 +33,12 @@ const fixedNow = new Date("2026-05-31T12:00:00.000Z");
 
 type OpenGraphForTest = {
   images?: Array<{ url: string; alt?: string; type?: string }>;
-  videos?: Array<{ url: string; type?: string }>;
+  videos?: Array<{
+    url: string;
+    type?: string;
+    width?: number;
+    height?: number;
+  }>;
   type?: string;
 };
 
@@ -170,7 +175,7 @@ describe("share metadata", () => {
         pagePath: "/s/token",
         contentPath: "/s/token/content",
         file: makeFile(),
-        hasReadyVideoDerivative: false,
+        videoEmbedMetadata: null,
       },
     });
 
@@ -202,7 +207,11 @@ describe("share metadata", () => {
           mimeType: "video/x-matroska",
           viewerKind: "video",
         }),
-        hasReadyVideoDerivative: true,
+        videoEmbedMetadata: {
+          type: "video/mp4",
+          width: 1920,
+          height: 1080,
+        },
       },
     });
 
@@ -213,11 +222,13 @@ describe("share metadata", () => {
       {
         url: "https://files.example/s/token/content",
         type: "video/mp4",
+        width: 1920,
+        height: 1080,
       },
     ]);
   });
 
-  it("emits Open Graph video for broadly playable original videos", () => {
+  it("emits Open Graph video with fallback dimensions for broadly playable original videos", () => {
     const metadata = buildShareMetadata({
       baseUrl: "https://files.example",
       instanceName: "Ares Cloud",
@@ -230,7 +241,7 @@ describe("share metadata", () => {
           mimeType: "video/mp4",
           viewerKind: "video",
         }),
-        hasReadyVideoDerivative: false,
+        videoEmbedMetadata: null,
       },
     });
 
@@ -240,6 +251,42 @@ describe("share metadata", () => {
       {
         url: "https://files.example/s/token/content",
         type: "video/mp4",
+        width: 1280,
+        height: 720,
+      },
+    ]);
+  });
+
+  it("uses ready derivative dimensions for resolved video shares", async () => {
+    mocks.resolvePublicShare.mockResolvedValue(
+      makeFileResolution({
+        file: makeFile({
+          name: "clip.mkv",
+          mimeType: "video/x-matroska",
+          viewerKind: "video",
+        }),
+      }),
+    );
+    mocks.findReadyDerivative.mockResolvedValue({
+      storageKey: "derivatives/user-1/file-1/preview-1080p.mp4",
+      mimeType: "video/mp4",
+      width: 1440,
+      height: 810,
+    });
+
+    const metadata = await getSharePageMetadata({
+      baseUrl: "https://files.example",
+      token: "token",
+    });
+
+    const openGraph = metadata.openGraph as OpenGraphForTest;
+
+    expect(openGraph.videos).toEqual([
+      {
+        url: "https://files.example/s/token/content",
+        type: "video/mp4",
+        width: 1440,
+        height: 810,
       },
     ]);
   });
@@ -257,7 +304,7 @@ describe("share metadata", () => {
           mimeType: "video/x-matroska",
           viewerKind: "video",
         }),
-        hasReadyVideoDerivative: false,
+        videoEmbedMetadata: null,
       },
     });
 

--- a/apps/web/server/sharing/metadata.ts
+++ b/apps/web/server/sharing/metadata.ts
@@ -10,6 +10,16 @@ import type { PublicShareResolution } from "./types";
 
 const DEFAULT_INSTANCE_NAME = "Staaash";
 const PLAYABLE_VIDEO_TYPES = new Set(["video/mp4", "video/webm"]);
+const DEFAULT_VIDEO_EMBED_DIMENSIONS = {
+  width: 1280,
+  height: 720,
+};
+
+type VideoEmbedMetadata = {
+  type: string;
+  width: number;
+  height: number;
+};
 
 type GenericShareMetadataTarget = {
   kind: "generic";
@@ -22,7 +32,7 @@ type FileShareMetadataTarget = {
   pagePath: string;
   contentPath: string;
   file: FileSummary;
-  hasReadyVideoDerivative: boolean;
+  videoEmbedMetadata: VideoEmbedMetadata | null;
 };
 
 type FolderShareMetadataTarget = {
@@ -53,8 +63,18 @@ type SharePageMetadataInput = {
 const normalizeMimeType = (mimeType: string) =>
   mimeType.split(";")[0]?.trim().toLowerCase() ?? "";
 
-const isBroadlyPlayableVideo = (file: FileSummary) =>
-  PLAYABLE_VIDEO_TYPES.has(normalizeMimeType(file.mimeType));
+const getOriginalVideoEmbedMetadata = (
+  file: FileSummary,
+): VideoEmbedMetadata | null => {
+  const type = normalizeMimeType(file.mimeType);
+
+  if (!PLAYABLE_VIDEO_TYPES.has(type)) return null;
+
+  return {
+    type,
+    ...DEFAULT_VIDEO_EMBED_DIMENSIONS,
+  };
+};
 
 const toAbsoluteUrl = (path: string, baseUrl: string) =>
   new URL(path, baseUrl).toString();
@@ -147,9 +167,11 @@ export const buildShareMetadata = ({
   const description = `${file.mimeType} - ${formatBytes(file.sizeBytes)} shared via ${instanceName}.`;
   const mediaUrl = toAbsoluteUrl(target.contentPath, baseUrl);
   const isImage = file.viewerKind === "image";
-  const shouldExposeVideo =
-    file.viewerKind === "video" &&
-    (target.hasReadyVideoDerivative || isBroadlyPlayableVideo(file));
+  const videoEmbedMetadata =
+    file.viewerKind === "video"
+      ? (target.videoEmbedMetadata ?? getOriginalVideoEmbedMetadata(file))
+      : null;
+  const shouldExposeVideo = videoEmbedMetadata !== null;
 
   return {
     title,
@@ -175,9 +197,9 @@ export const buildShareMetadata = ({
             videos: [
               {
                 url: mediaUrl,
-                type: target.hasReadyVideoDerivative
-                  ? "video/mp4"
-                  : normalizeMimeType(file.mimeType),
+                type: videoEmbedMetadata.type,
+                width: videoEmbedMetadata.width,
+                height: videoEmbedMetadata.height,
               },
             ],
           }
@@ -201,12 +223,22 @@ const getInstanceName = async (): Promise<string> => {
   }
 };
 
-const hasReadyVideoDerivative = async (fileId: string): Promise<boolean> => {
+const getReadyVideoEmbedMetadata = async (
+  fileId: string,
+): Promise<VideoEmbedMetadata | null> => {
   const derivative = await findReadyDerivative(fileId);
-  return Boolean(
-    derivative?.storageKey &&
-    normalizeMimeType(derivative.mimeType ?? "") === "video/mp4",
-  );
+  const mimeType = normalizeMimeType(derivative?.mimeType ?? "");
+  const width = derivative?.width ?? 0;
+  const height = derivative?.height ?? 0;
+
+  if (!derivative?.storageKey || mimeType !== "video/mp4") return null;
+  if (width <= 0 || height <= 0) return null;
+
+  return {
+    type: mimeType,
+    width,
+    height,
+  };
 };
 
 const shouldExposeShareDetails = (resolution: PublicShareResolution) =>
@@ -279,10 +311,10 @@ export const getSharePageMetadata = async ({
           pagePath: buildFileSharePath(token, file.id),
           contentPath: buildNestedFileContentPath(token, file.id),
           file,
-          hasReadyVideoDerivative:
+          videoEmbedMetadata:
             file.viewerKind === "video"
-              ? await hasReadyVideoDerivative(file.id)
-              : false,
+              ? await getReadyVideoEmbedMetadata(file.id)
+              : null,
         },
       });
     }
@@ -296,10 +328,10 @@ export const getSharePageMetadata = async ({
           pagePath: buildRootSharePath(token),
           contentPath: `${buildRootSharePath(token)}/content`,
           file: resolution.file,
-          hasReadyVideoDerivative:
+          videoEmbedMetadata:
             resolution.file.viewerKind === "video"
-              ? await hasReadyVideoDerivative(resolution.file.id)
-              : false,
+              ? await getReadyVideoEmbedMetadata(resolution.file.id)
+              : null,
         },
       });
     }

--- a/apps/worker/src/handlers/media-derivative.test.ts
+++ b/apps/worker/src/handlers/media-derivative.test.ts
@@ -1,0 +1,211 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BackgroundJobRecord } from "@staaash/db/jobs";
+
+const mocks = vi.hoisted(() => ({
+  buildDerivativeStorageKey: vi.fn(),
+  getFfmpegHealth: vi.fn(),
+  getPrisma: vi.fn(),
+  isStreamCopyCompatible: vi.fn(),
+  markDerivativeFailed: vi.fn(),
+  markDerivativeReady: vi.fn(),
+  runFfmpegStreamCopy: vi.fn(),
+  runFfmpegTranscode: vi.fn(),
+  runFfprobe: vi.fn(),
+  upsertDerivativeQueued: vi.fn(),
+}));
+
+vi.mock("@staaash/db/client", () => ({
+  getPrisma: mocks.getPrisma,
+}));
+
+vi.mock("@staaash/db/media-derivatives", () => ({
+  DERIVATIVE_KIND_PREVIEW: "preview",
+  DERIVATIVE_PROFILE_1080P: "preview-1080p",
+  DERIVATIVE_STATUS_PROCESSING: "processing",
+  DERIVATIVE_STATUS_STALE: "stale",
+  buildDerivativeStorageKey: mocks.buildDerivativeStorageKey,
+  markDerivativeFailed: mocks.markDerivativeFailed,
+  markDerivativeReady: mocks.markDerivativeReady,
+  upsertDerivativeQueued: mocks.upsertDerivativeQueued,
+}));
+
+vi.mock("../ffmpeg.js", () => ({
+  getFfmpegHealth: mocks.getFfmpegHealth,
+  isStreamCopyCompatible: mocks.isStreamCopyCompatible,
+  runFfmpegStreamCopy: mocks.runFfmpegStreamCopy,
+  runFfmpegTranscode: mocks.runFfmpegTranscode,
+  runFfprobe: mocks.runFfprobe,
+}));
+
+const { handleMediaDerivativeGenerate } = await import("./media-derivative.js");
+
+const fixedNow = new Date("2026-05-31T12:00:00.000Z");
+
+const createJob = (): BackgroundJobRecord => ({
+  id: "job-1",
+  kind: "media.derivative.generate",
+  status: "running",
+  payloadJson: {
+    fileId: "file-1",
+    kind: "preview",
+    profile: "preview-1080p",
+    reason: "share-created",
+  },
+  dedupeKey: "media.derivative.generate:file-1:preview:preview-1080p",
+  runAt: fixedNow,
+  lockedAt: null,
+  lockedBy: null,
+  attemptCount: 1,
+  maxAttempts: 5,
+  lastError: null,
+  createdAt: fixedNow,
+  updatedAt: fixedNow,
+});
+
+describe("media derivative handler", () => {
+  let tempRoot: string | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getFfmpegHealth.mockReturnValue({
+      available: true,
+      ffmpegVersion: "7.1",
+      ffprobeVersion: "7.1",
+      lastProbeError: null,
+    });
+    mocks.buildDerivativeStorageKey.mockReturnValue(
+      "derivatives/owner-1/file-1/preview-1080p.mp4",
+    );
+    mocks.isStreamCopyCompatible.mockReturnValue(false);
+    mocks.upsertDerivativeQueued.mockResolvedValue({
+      id: "derivative-1",
+      status: "queued",
+    });
+    mocks.markDerivativeReady.mockResolvedValue({
+      id: "derivative-1",
+      status: "ready",
+    });
+  });
+
+  afterEach(async () => {
+    if (tempRoot) {
+      await rm(tempRoot, { recursive: true, force: true });
+      tempRoot = null;
+    }
+  });
+
+  it("stores dimensions from the generated output instead of the source", async () => {
+    tempRoot = await mkdtemp(
+      path.join(os.tmpdir(), "staaash-media-derivative-"),
+    );
+    const filesRoot = path.join(tempRoot, "files");
+    const tmpRoot = path.join(tempRoot, "tmp");
+    const sourcePath = path.join(filesRoot, "library", "owner-1", "clip.mov");
+    await mkdir(path.dirname(sourcePath), { recursive: true });
+    await writeFile(sourcePath, "source", "utf8");
+
+    const client = {
+      systemSettings: {
+        findUnique: vi.fn(async () => ({
+          mediaPreviewEnabled: true,
+          mediaPreviewThresholdBytes: 1n,
+          mediaPreviewMaxHeight: 720,
+          mediaPreviewCrf: 22,
+        })),
+      },
+      file: {
+        findUnique: vi.fn(async () => ({
+          id: "file-1",
+          ownerUserId: "owner-1",
+          mimeType: "video/quicktime",
+          sizeBytes: 10_000n,
+          storageKey: "library/owner-1/clip.mov",
+          deletedAt: null,
+        })),
+      },
+      mediaDerivative: {
+        update: vi.fn(async () => ({
+          id: "derivative-1",
+          status: "processing",
+        })),
+        findUnique: vi.fn(async () => ({
+          id: "derivative-1",
+          status: "processing",
+        })),
+      },
+    };
+    mocks.getPrisma.mockReturnValue(client);
+
+    mocks.runFfprobe.mockImplementation(async (inputPath: string) => {
+      if (inputPath.endsWith("preview-1080p.mp4")) {
+        return {
+          streams: [
+            {
+              codec_type: "video",
+              codec_name: "h264",
+              width: 1280,
+              height: 720,
+            },
+            { codec_type: "audio", codec_name: "aac" },
+          ],
+          format: { duration: "12.5" },
+        };
+      }
+
+      return {
+        streams: [
+          {
+            codec_type: "video",
+            codec_name: "hevc",
+            width: 3840,
+            height: 2160,
+          },
+        ],
+        format: { duration: "12.5" },
+      };
+    });
+
+    mocks.runFfmpegTranscode.mockImplementation(
+      async (_inputPath: string, outputPath: string) => {
+        await mkdir(path.dirname(outputPath), { recursive: true });
+        await writeFile(outputPath, "output", "utf8");
+      },
+    );
+
+    await expect(
+      handleMediaDerivativeGenerate(createJob(), {
+        filesRoot,
+        tmpRoot,
+        heartbeatPath: path.join(tmpRoot, "worker-heartbeat.json"),
+        pendingDeleteRoot: path.join(tmpRoot, "pending-delete"),
+        uploadStagingTtlMs: 1,
+      }),
+    ).resolves.toBe(false);
+
+    expect(mocks.runFfprobe).toHaveBeenCalledWith(sourcePath);
+    expect(mocks.runFfprobe).toHaveBeenCalledWith(
+      path.join(
+        filesRoot,
+        "derivatives",
+        "owner-1",
+        "file-1",
+        "preview-1080p.mp4",
+      ),
+    );
+    expect(mocks.markDerivativeReady).toHaveBeenCalledWith(
+      "derivative-1",
+      expect.objectContaining({
+        mimeType: "video/mp4",
+        width: 1280,
+        height: 720,
+        durationSeconds: 12.5,
+        videoCodec: "h264",
+        audioCodec: "aac",
+      }),
+    );
+  });
+});

--- a/apps/worker/src/handlers/media-derivative.ts
+++ b/apps/worker/src/handlers/media-derivative.ts
@@ -252,10 +252,11 @@ export const handleMediaDerivativeGenerate = async (
   }
 
   const outputStats = await stat(outputPath);
-  const videoStream = probe.streams.find((s) => s.codec_type === "video");
-  const audioStream = probe.streams.find((s) => s.codec_type === "audio");
-  const durationSeconds = probe.format.duration
-    ? parseFloat(probe.format.duration)
+  const outputProbe = await runFfprobe(outputPath);
+  const videoStream = outputProbe.streams.find((s) => s.codec_type === "video");
+  const audioStream = outputProbe.streams.find((s) => s.codec_type === "audio");
+  const durationSeconds = outputProbe.format.duration
+    ? parseFloat(outputProbe.format.duration)
     : null;
 
   // Guard: admin may have marked stale while we were processing.


### PR DESCRIPTION
## 🚀 Summary

Fixes collapsed Discord video share cards by emitting non-zero Open Graph video dimensions.

## 📊 Impacts and Changes

Video share metadata now includes width and height for `og:video`. Ready MP4 derivatives use stored dimensions, playable original MP4/WebM shares fall back to 1280x720, and worker derivative generation now stores dimensions from the generated output file.

No schema, auth, storage, or restore behavior changes. Existing `MediaDerivative.width` and `MediaDerivative.height` fields are reused.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment. (N/A - social metadata only)

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

Discord may cache old embeds, so existing messages may need the link resent or a fresh share URL. Poster thumbnails are still deferred.

## 🔗 Linked Issues

None.
