### PR TITLE
Improve Discord video share embeds

### DIFF
--- a/apps/web/app/(workspace)/files/f/[folderId]/page.tsx
+++ b/apps/web/app/(workspace)/files/f/[folderId]/page.tsx
@@ -6,7 +6,7 @@ import { isFilesError } from "@/server/files/errors";
 import { filesService } from "@/server/files/service";
 import { recordFolderAccessBestEffort } from "@/server/retrieval/recent-tracking";
 import { retrievalService } from "@/server/retrieval/service";
-import { getBaseUrl } from "@/server/request";
+import { getShareBaseUrl } from "@/server/request";
 import { sharingService } from "@/server/sharing/service";
 
 import { FilesExplorer } from "../../files-explorer";
@@ -29,7 +29,7 @@ export default async function FilesFolderPage({
     searchParams,
     headers(),
   ]);
-  const baseUrl = getBaseUrl(h);
+  const baseUrl = getShareBaseUrl(h);
   const session = await requireSignedInPageSession(
     `/?next=${encodeURIComponent(`/files/f/${folderId}`)}`,
   );

--- a/apps/web/app/(workspace)/files/page.tsx
+++ b/apps/web/app/(workspace)/files/page.tsx
@@ -3,7 +3,7 @@ import { headers } from "next/headers";
 import { requireSignedInPageSession } from "@/server/auth/guards";
 import { filesService } from "@/server/files/service";
 import { retrievalService } from "@/server/retrieval/service";
-import { getBaseUrl } from "@/server/request";
+import { getShareBaseUrl } from "@/server/request";
 import { sharingService } from "@/server/sharing/service";
 
 import { FilesExplorer } from "./files-explorer";
@@ -20,7 +20,7 @@ export default async function FilesPage({ searchParams }: FilesPageProps) {
     requireSignedInPageSession("/?next=/files"),
     headers(),
   ]);
-  const baseUrl = getBaseUrl(h);
+  const baseUrl = getShareBaseUrl(h);
   const listing = await filesService.getFilesListing({
     actorUserId: session.user.id,
     actorRole: session.user.role,

--- a/apps/web/app/(workspace)/home/page.tsx
+++ b/apps/web/app/(workspace)/home/page.tsx
@@ -10,7 +10,7 @@ import { WorkspacePresetPageContextMenu } from "@/app/dashboard-context-menu";
 import { ItemTypeIcon, itemVisualIconMap } from "@/app/item-type-icon";
 import { retrievalService } from "@/server/retrieval/service";
 import type { RetrievalItem } from "@/server/retrieval/types";
-import { getBaseUrl } from "@/server/request";
+import { getShareBaseUrl } from "@/server/request";
 import { sharingService } from "@/server/sharing/service";
 import type { ShareLinkSummary } from "@/server/sharing/types";
 import type { UserRole } from "@/server/types";
@@ -374,7 +374,7 @@ export default async function HomePage() {
     actorUserId: session.user.id,
     actorRole: session.user.role,
   };
-  const baseUrl = getBaseUrl(h);
+  const baseUrl = getShareBaseUrl(h);
   const [favoriteItems, recentItems, folders, shares] = await Promise.all([
     retrievalService.listFavorites(actor),
     retrievalService.listRecent(actor),

--- a/apps/web/app/(workspace)/shared/page.tsx
+++ b/apps/web/app/(workspace)/shared/page.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/app/auth-ui";
 import { WorkspacePresetPageContextMenu } from "@/app/dashboard-context-menu";
 import { requireSignedInPageSession } from "@/server/auth/guards";
-import { getBaseUrl } from "@/server/request";
+import { getShareBaseUrl } from "@/server/request";
 import { sharingService } from "@/server/sharing/service";
 import { SharedTable, type SharedTableItem } from "./shared-table";
 
@@ -66,7 +66,7 @@ export default async function SharedPage({ searchParams }: SharedPageProps) {
     requireSignedInPageSession("/?next=/shared"),
     headers(),
   ]);
-  const baseUrl = getBaseUrl(h);
+  const baseUrl = getShareBaseUrl(h);
   const error = getSingleSearchParam(resolvedSearchParams, "error");
   const success = getSingleSearchParam(resolvedSearchParams, "success");
   const shares = await sharingService.listOwnedShares({

--- a/apps/web/app/api/shares/route.ts
+++ b/apps/web/app/api/shares/route.ts
@@ -11,7 +11,7 @@ import {
   wantsJson,
 } from "@/server/auth/http";
 import { getRequestSession } from "@/server/auth/guards";
-import { getBaseUrl } from "@/server/request";
+import { getShareBaseUrl } from "@/server/request";
 import { createShareSchema } from "@/server/sharing/schema";
 import { sharingService } from "@/server/sharing/service";
 
@@ -38,7 +38,7 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const baseUrl = getBaseUrl(request.headers);
+    const baseUrl = getShareBaseUrl(request.headers);
     const result =
       body.mode === "reissue"
         ? await sharingService.reissueShare({

--- a/apps/web/app/s/[token]/f/[folderId]/page.tsx
+++ b/apps/web/app/s/[token]/f/[folderId]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { cookies, headers } from "next/headers";
 
 import { ShareErrorView, ShareView } from "@/app/s/share-view";
-import { getBaseUrl } from "@/server/request";
+import { getShareBaseUrl } from "@/server/request";
 import { SHARE_ACCESS_COOKIE_NAME } from "@/server/sharing/access-cookie";
 import { ShareError, isShareError } from "@/server/sharing/errors";
 import { getSharePageMetadata } from "@/server/sharing/metadata";
@@ -30,7 +30,7 @@ export async function generateMetadata({
   return getSharePageMetadata({
     token,
     folderId,
-    baseUrl: getBaseUrl(h),
+    baseUrl: getShareBaseUrl(h),
     shareAccessCookieValue:
       cookieStore.get(SHARE_ACCESS_COOKIE_NAME)?.value ?? null,
   });

--- a/apps/web/app/s/[token]/files/[fileId]/page.tsx
+++ b/apps/web/app/s/[token]/files/[fileId]/page.tsx
@@ -7,7 +7,7 @@ import {
   ShareFilePage,
   ShareLockedView,
 } from "@/app/s/share-view";
-import { getBaseUrl } from "@/server/request";
+import { getShareBaseUrl } from "@/server/request";
 import { SHARE_ACCESS_COOKIE_NAME } from "@/server/sharing/access-cookie";
 import { ShareError, isShareError } from "@/server/sharing/errors";
 import { getSharePageMetadata } from "@/server/sharing/metadata";
@@ -35,7 +35,7 @@ export async function generateMetadata({
   return getSharePageMetadata({
     token,
     fileId,
-    baseUrl: getBaseUrl(h),
+    baseUrl: getShareBaseUrl(h),
     shareAccessCookieValue:
       cookieStore.get(SHARE_ACCESS_COOKIE_NAME)?.value ?? null,
   });

--- a/apps/web/app/s/[token]/files/[fileId]/poster/route.ts
+++ b/apps/web/app/s/[token]/files/[fileId]/poster/route.ts
@@ -1,0 +1,35 @@
+import { cookies } from "next/headers";
+
+import {
+  createPosterErrorResponse,
+  createSharePosterResponse,
+} from "@/app/s/poster-response";
+import { SHARE_ACCESS_COOKIE_NAME } from "@/server/sharing/access-cookie";
+import {
+  createMediaErrorResponse,
+  MediaContentError,
+} from "@/server/media/content-response";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ token: string; fileId: string }> },
+) {
+  const { token, fileId } = await params;
+  const cookieStore = await cookies();
+
+  try {
+    return await createSharePosterResponse({
+      request,
+      token,
+      fileId,
+      shareAccessCookieValue:
+        cookieStore.get(SHARE_ACCESS_COOKIE_NAME)?.value ?? null,
+    });
+  } catch (error) {
+    if (error instanceof MediaContentError) {
+      return createMediaErrorResponse(error);
+    }
+
+    return createPosterErrorResponse();
+  }
+}

--- a/apps/web/app/s/[token]/page.tsx
+++ b/apps/web/app/s/[token]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { cookies, headers } from "next/headers";
 
 import { ShareErrorView, ShareView } from "@/app/s/share-view";
-import { getBaseUrl } from "@/server/request";
+import { getShareBaseUrl } from "@/server/request";
 import { SHARE_ACCESS_COOKIE_NAME } from "@/server/sharing/access-cookie";
 import { ShareError, isShareError } from "@/server/sharing/errors";
 import { getSharePageMetadata } from "@/server/sharing/metadata";
@@ -28,7 +28,7 @@ export async function generateMetadata({
 
   return getSharePageMetadata({
     token,
-    baseUrl: getBaseUrl(h),
+    baseUrl: getShareBaseUrl(h),
     shareAccessCookieValue:
       cookieStore.get(SHARE_ACCESS_COOKIE_NAME)?.value ?? null,
   });

--- a/apps/web/app/s/[token]/poster/route.ts
+++ b/apps/web/app/s/[token]/poster/route.ts
@@ -1,0 +1,34 @@
+import { cookies } from "next/headers";
+
+import {
+  createPosterErrorResponse,
+  createSharePosterResponse,
+} from "@/app/s/poster-response";
+import { SHARE_ACCESS_COOKIE_NAME } from "@/server/sharing/access-cookie";
+import {
+  createMediaErrorResponse,
+  MediaContentError,
+} from "@/server/media/content-response";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  const { token } = await params;
+  const cookieStore = await cookies();
+
+  try {
+    return await createSharePosterResponse({
+      request,
+      token,
+      shareAccessCookieValue:
+        cookieStore.get(SHARE_ACCESS_COOKIE_NAME)?.value ?? null,
+    });
+  } catch (error) {
+    if (error instanceof MediaContentError) {
+      return createMediaErrorResponse(error);
+    }
+
+    return createPosterErrorResponse();
+  }
+}

--- a/apps/web/app/s/poster-response.ts
+++ b/apps/web/app/s/poster-response.ts
@@ -1,0 +1,71 @@
+import { findReadyPosterDerivative } from "@staaash/db/media-derivatives";
+
+import {
+  createMediaErrorResponse,
+  MediaContentError,
+} from "@/server/media/content-response";
+import { createReadyDerivativeContentResponse } from "@/server/media/derivative-content-response";
+import type { FileSummary } from "@/server/files/types";
+import { sharingService } from "@/server/sharing/service";
+
+const posterNotFound = () =>
+  new MediaContentError(404, "Poster content is unavailable.");
+
+const assertPublicPosterShare = (share: {
+  hasPassword: boolean;
+  status: string;
+}) => {
+  if (share.hasPassword || share.status !== "active") {
+    throw posterNotFound();
+  }
+};
+
+const createPosterFileName = (fileName: string) => `${fileName}.jpg`;
+
+export const createPosterErrorResponse = () =>
+  createMediaErrorResponse(posterNotFound());
+
+export const createSharePosterResponse = async ({
+  request,
+  token,
+  fileId,
+  shareAccessCookieValue,
+}: {
+  request: Request;
+  token: string;
+  fileId?: string;
+  shareAccessCookieValue?: string | null;
+}) => {
+  const resolution = await sharingService.resolvePublicShare({
+    token,
+    shareAccessCookieValue,
+  });
+  assertPublicPosterShare(resolution.share);
+
+  let file: Pick<FileSummary, "id" | "name" | "viewerKind">;
+
+  if (fileId) {
+    if (resolution.kind !== "folder") throw posterNotFound();
+    file = (
+      await sharingService.getSharedNestedFileContent({
+        token,
+        fileId,
+        shareAccessCookieValue,
+      })
+    ).file;
+  } else {
+    if (resolution.kind !== "file") throw posterNotFound();
+    file = resolution.file;
+  }
+
+  if (file.viewerKind !== "video") throw posterNotFound();
+
+  const derivative = await findReadyPosterDerivative(file.id);
+  if (!derivative) throw posterNotFound();
+
+  return createReadyDerivativeContentResponse({
+    request,
+    derivative,
+    fileName: createPosterFileName(file.name),
+  });
+};

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -17,6 +17,32 @@ const parseSecureCookies = (val: string | undefined, ctx: z.RefinementCtx) => {
   return z.NEVER;
 };
 
+const parsePublicUrl = (val: string | undefined, ctx: z.RefinementCtx) => {
+  const trimmed = val?.trim();
+  if (!trimmed) return undefined;
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "STAAASH_PUBLIC_URL must be a valid http:// or https:// URL.",
+    });
+    return z.NEVER;
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "STAAASH_PUBLIC_URL must use http:// or https://.",
+    });
+    return z.NEVER;
+  }
+
+  return url.toString().replace(/\/$/, "");
+};
+
 const envSchema = z.object({
   NODE_ENV: z
     .enum(["development", "test", "production"])
@@ -28,6 +54,7 @@ const envSchema = z.object({
     .default("postgresql://postgres:staaash@localhost:5432/staaash"),
   UPLOAD_LOCATION: z.string().trim().min(1).default("./.data/files"),
   SECURE_COOKIES: z.string().optional().transform(parseSecureCookies),
+  STAAASH_PUBLIC_URL: z.string().optional().transform(parsePublicUrl),
 });
 
 export const parseWebEnv = (rawEnv: NodeJS.ProcessEnv) => {

--- a/apps/web/server/env.test.ts
+++ b/apps/web/server/env.test.ts
@@ -37,4 +37,29 @@ describe("web env parsing", () => {
       ).toThrow(/SECURE_COOKIES must be true or false/);
     },
   );
+
+  it.each([
+    ["https://drive.example.com", "https://drive.example.com"],
+    [" https://drive.example.com/ ", "https://drive.example.com"],
+    ["http://46.1.113.7:2113", "http://46.1.113.7:2113"],
+  ])("parses STAAASH_PUBLIC_URL=%s", (value, expected) => {
+    const env = parseWebEnv({
+      ...baseEnv,
+      STAAASH_PUBLIC_URL: value,
+    });
+
+    expect(env.STAAASH_PUBLIC_URL).toBe(expected);
+  });
+
+  it.each(["ftp://drive.example.com", "not-a-url"])(
+    "rejects invalid STAAASH_PUBLIC_URL=%s",
+    (value) => {
+      expect(() =>
+        parseWebEnv({
+          ...baseEnv,
+          STAAASH_PUBLIC_URL: value,
+        }),
+      ).toThrow(/STAAASH_PUBLIC_URL/);
+    },
+  );
 });

--- a/apps/web/server/media/derivative-content-response.ts
+++ b/apps/web/server/media/derivative-content-response.ts
@@ -92,14 +92,14 @@ const serveDerivativeBytes = async (
   sizeBytes: number,
   mimeType: string,
   fileName: string,
-): Promise<Response> => {
+): Promise<Response | null> => {
   const storagePath = getStoragePath(storageKey);
   let fileHandle;
 
   try {
     fileHandle = await open(storagePath, "r");
   } catch {
-    return null as unknown as Response;
+    return null;
   }
 
   try {
@@ -124,7 +124,7 @@ const serveDerivativeBytes = async (
     };
 
     if (!rangeHeader) {
-      return new Response(createStream() as unknown as ReadableStream, {
+      return new Response(createStream() as unknown as BodyInit, {
         status: 200,
         headers: { ...baseHeaders, "content-length": String(sizeBytes) },
       });
@@ -145,17 +145,14 @@ const serveDerivativeBytes = async (
     const { start, end } = range;
     const contentLength = end - start + 1;
 
-    return new Response(
-      createStream({ start, end }) as unknown as ReadableStream,
-      {
-        status: 206,
-        headers: {
-          ...baseHeaders,
-          "content-length": String(contentLength),
-          "content-range": `bytes ${start}-${end}/${sizeBytes}`,
-        },
+    return new Response(createStream({ start, end }) as unknown as BodyInit, {
+      status: 206,
+      headers: {
+        ...baseHeaders,
+        "content-length": String(contentLength),
+        "content-range": `bytes ${start}-${end}/${sizeBytes}`,
       },
-    );
+    });
   } catch (error) {
     try {
       await fileHandle.close();
@@ -164,6 +161,34 @@ const serveDerivativeBytes = async (
     }
     throw error;
   }
+};
+
+export const createReadyDerivativeContentResponse = async ({
+  request,
+  derivative,
+  fileName,
+}: {
+  request: Request;
+  derivative: Pick<DerivativeRow, "storageKey" | "sizeBytes" | "mimeType">;
+  fileName: string;
+}): Promise<Response> => {
+  if (!derivative.storageKey || derivative.sizeBytes === null) {
+    throw new MediaContentError(404, "Derivative content is unavailable.");
+  }
+
+  const response = await serveDerivativeBytes(
+    request,
+    derivative.storageKey,
+    Number(derivative.sizeBytes),
+    derivative.mimeType ?? "application/octet-stream",
+    fileName,
+  );
+
+  if (!response) {
+    throw new MediaContentError(404, "Derivative content is unavailable.");
+  }
+
+  return response;
 };
 
 export const createInlineContentResponse = async ({

--- a/apps/web/server/request.test.ts
+++ b/apps/web/server/request.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const originalPublicUrl = process.env.STAAASH_PUBLIC_URL;
+
+const headers = {
+  get(name: string) {
+    if (name === "x-forwarded-proto") return "http";
+    if (name === "host") return "46.1.113.7:2113";
+    return null;
+  },
+};
+
+describe("request base URLs", () => {
+  afterEach(() => {
+    if (originalPublicUrl === undefined) {
+      delete process.env.STAAASH_PUBLIC_URL;
+    } else {
+      process.env.STAAASH_PUBLIC_URL = originalPublicUrl;
+    }
+    vi.resetModules();
+  });
+
+  it("falls back to request headers for share URLs", async () => {
+    delete process.env.STAAASH_PUBLIC_URL;
+    vi.resetModules();
+    const { getShareBaseUrl } = await import("./request");
+
+    expect(getShareBaseUrl(headers)).toBe("http://46.1.113.7:2113");
+  });
+
+  it("uses the canonical public URL for share URLs when configured", async () => {
+    process.env.STAAASH_PUBLIC_URL = "https://drive.example.com/";
+    vi.resetModules();
+    const { getShareBaseUrl } = await import("./request");
+
+    expect(getShareBaseUrl(headers)).toBe("https://drive.example.com");
+  });
+});

--- a/apps/web/server/request.ts
+++ b/apps/web/server/request.ts
@@ -1,3 +1,5 @@
+import { env } from "@/lib/env";
+
 export function getBaseUrl(headers: {
   get(name: string): string | null;
 }): string {
@@ -5,4 +7,10 @@ export function getBaseUrl(headers: {
   const host =
     headers.get("x-forwarded-host") ?? headers.get("host") ?? "localhost";
   return `${proto}://${host}`;
+}
+
+export function getShareBaseUrl(headers: {
+  get(name: string): string | null;
+}): string {
+  return env.STAAASH_PUBLIC_URL ?? getBaseUrl(headers);
 }

--- a/apps/web/server/sharing/metadata.test.ts
+++ b/apps/web/server/sharing/metadata.test.ts
@@ -5,6 +5,7 @@ import type { PublicShareResolution, ShareLinkSummary } from "./types";
 
 const mocks = vi.hoisted(() => ({
   findReadyDerivative: vi.fn(),
+  findReadyPosterDerivative: vi.fn(),
   getSetupState: vi.fn(),
   getSharedNestedFileContent: vi.fn(),
   resolvePublicShare: vi.fn(),
@@ -12,6 +13,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@staaash/db/media-derivatives", () => ({
   findReadyDerivative: mocks.findReadyDerivative,
+  findReadyPosterDerivative: mocks.findReadyPosterDerivative,
 }));
 
 vi.mock("@/server/auth/service", () => ({
@@ -31,8 +33,16 @@ import { buildShareMetadata, getSharePageMetadata } from "./metadata";
 
 const fixedNow = new Date("2026-05-31T12:00:00.000Z");
 
+type OpenGraphImageForTest = {
+  url: string;
+  alt?: string;
+  type?: string;
+  width?: number;
+  height?: number;
+};
+
 type OpenGraphForTest = {
-  images?: Array<{ url: string; alt?: string; type?: string }>;
+  images?: OpenGraphImageForTest[];
   videos?: Array<{
     url: string;
     type?: string;
@@ -164,6 +174,7 @@ describe("share metadata", () => {
     vi.clearAllMocks();
     mocks.getSetupState.mockResolvedValue({ instanceName: "Ares Cloud" });
     mocks.findReadyDerivative.mockResolvedValue(null);
+    mocks.findReadyPosterDerivative.mockResolvedValue(null);
   });
 
   it("emits absolute Open Graph and Twitter image URLs for image shares", () => {
@@ -289,6 +300,46 @@ describe("share metadata", () => {
         height: 810,
       },
     ]);
+  });
+
+  it("emits poster image metadata for resolved video shares", async () => {
+    mocks.resolvePublicShare.mockResolvedValue(
+      makeFileResolution({
+        file: makeFile({
+          name: "clip.mp4",
+          mimeType: "video/mp4",
+          viewerKind: "video",
+        }),
+      }),
+    );
+    mocks.findReadyPosterDerivative.mockResolvedValue({
+      storageKey: "derivatives/user-1/file-1/social-poster.jpg",
+      mimeType: "image/jpeg",
+      width: 1280,
+      height: 720,
+    });
+
+    const metadata = await getSharePageMetadata({
+      baseUrl: "https://files.example",
+      token: "token",
+    });
+
+    const openGraph = metadata.openGraph as OpenGraphForTest;
+    const twitter = metadata.twitter as TwitterForTest;
+
+    expect(openGraph.images).toEqual([
+      {
+        url: "https://files.example/s/token/poster",
+        alt: "clip.mp4",
+        type: "image/jpeg",
+        width: 1280,
+        height: 720,
+      },
+    ]);
+    expect(twitter).toMatchObject({
+      card: "summary_large_image",
+      images: ["https://files.example/s/token/poster"],
+    });
   });
 
   it("does not emit Open Graph video for non-playable video without derivative", () => {

--- a/apps/web/server/sharing/metadata.ts
+++ b/apps/web/server/sharing/metadata.ts
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
 
-import { findReadyDerivative } from "@staaash/db/media-derivatives";
+import {
+  findReadyDerivative,
+  findReadyPosterDerivative,
+} from "@staaash/db/media-derivatives";
 
 import { authService } from "@/server/auth/service";
 import type { FileSummary } from "@/server/files/types";
@@ -21,6 +24,12 @@ type VideoEmbedMetadata = {
   height: number;
 };
 
+type ImageEmbedMetadata = {
+  type?: string;
+  width?: number;
+  height?: number;
+};
+
 type GenericShareMetadataTarget = {
   kind: "generic";
   pagePath: string;
@@ -31,8 +40,10 @@ type FileShareMetadataTarget = {
   kind: "file";
   pagePath: string;
   contentPath: string;
+  posterPath?: string | null;
   file: FileSummary;
   videoEmbedMetadata: VideoEmbedMetadata | null;
+  posterImageMetadata?: ImageEmbedMetadata | null;
 };
 
 type FolderShareMetadataTarget = {
@@ -166,12 +177,24 @@ export const buildShareMetadata = ({
   const title = `${file.name} - ${instanceName}`;
   const description = `${file.mimeType} - ${formatBytes(file.sizeBytes)} shared via ${instanceName}.`;
   const mediaUrl = toAbsoluteUrl(target.contentPath, baseUrl);
+  const posterUrl = target.posterPath
+    ? toAbsoluteUrl(target.posterPath, baseUrl)
+    : null;
   const isImage = file.viewerKind === "image";
   const videoEmbedMetadata =
     file.viewerKind === "video"
       ? (target.videoEmbedMetadata ?? getOriginalVideoEmbedMetadata(file))
       : null;
   const shouldExposeVideo = videoEmbedMetadata !== null;
+  const imageMetadata = isImage
+    ? { url: mediaUrl, alt: file.name }
+    : target.posterImageMetadata && posterUrl
+      ? {
+          url: posterUrl,
+          alt: file.name,
+          ...target.posterImageMetadata,
+        }
+      : null;
 
   return {
     title,
@@ -182,14 +205,9 @@ export const buildShareMetadata = ({
       siteName: instanceName,
       type: shouldExposeVideo ? "video.other" : "website",
       url: pageUrl,
-      ...(isImage
+      ...(imageMetadata
         ? {
-            images: [
-              {
-                url: mediaUrl,
-                alt: file.name,
-              },
-            ],
+            images: [imageMetadata],
           }
         : {}),
       ...(shouldExposeVideo
@@ -206,10 +224,10 @@ export const buildShareMetadata = ({
         : {}),
     },
     twitter: {
-      card: isImage ? "summary_large_image" : "summary",
+      card: imageMetadata ? "summary_large_image" : "summary",
       title,
       description,
-      ...(isImage ? { images: [mediaUrl] } : {}),
+      ...(imageMetadata ? { images: [imageMetadata.url] } : {}),
     },
   };
 };
@@ -241,6 +259,24 @@ const getReadyVideoEmbedMetadata = async (
   };
 };
 
+const getReadyPosterImageMetadata = async (
+  fileId: string,
+): Promise<ImageEmbedMetadata | null> => {
+  const derivative = await findReadyPosterDerivative(fileId);
+  const mimeType = normalizeMimeType(derivative?.mimeType ?? "");
+  const width = derivative?.width ?? 0;
+  const height = derivative?.height ?? 0;
+
+  if (!derivative?.storageKey || mimeType !== "image/jpeg") return null;
+  if (width <= 0 || height <= 0) return null;
+
+  return {
+    type: mimeType,
+    width,
+    height,
+  };
+};
+
 const shouldExposeShareDetails = (resolution: PublicShareResolution) =>
   resolution.share.status === "active" && !resolution.share.hasPassword;
 
@@ -254,6 +290,12 @@ const buildFileSharePath = (token: string, fileId: string) =>
 
 const buildNestedFileContentPath = (token: string, fileId: string) =>
   `/s/${encodeURIComponent(token)}/files/${encodeURIComponent(fileId)}/content`;
+
+const buildRootSharePosterPath = (token: string) =>
+  `${buildRootSharePath(token)}/poster`;
+
+const buildNestedFilePosterPath = (token: string, fileId: string) =>
+  `/s/${encodeURIComponent(token)}/files/${encodeURIComponent(fileId)}/poster`;
 
 export const getSharePageMetadata = async ({
   baseUrl,
@@ -310,10 +352,18 @@ export const getSharePageMetadata = async ({
           kind: "file",
           pagePath: buildFileSharePath(token, file.id),
           contentPath: buildNestedFileContentPath(token, file.id),
+          posterPath:
+            file.viewerKind === "video"
+              ? buildNestedFilePosterPath(token, file.id)
+              : null,
           file,
           videoEmbedMetadata:
             file.viewerKind === "video"
               ? await getReadyVideoEmbedMetadata(file.id)
+              : null,
+          posterImageMetadata:
+            file.viewerKind === "video"
+              ? await getReadyPosterImageMetadata(file.id)
               : null,
         },
       });
@@ -327,10 +377,18 @@ export const getSharePageMetadata = async ({
           kind: "file",
           pagePath: buildRootSharePath(token),
           contentPath: `${buildRootSharePath(token)}/content`,
+          posterPath:
+            resolution.file.viewerKind === "video"
+              ? buildRootSharePosterPath(token)
+              : null,
           file: resolution.file,
           videoEmbedMetadata:
             resolution.file.viewerKind === "video"
               ? await getReadyVideoEmbedMetadata(resolution.file.id)
+              : null,
+          posterImageMetadata:
+            resolution.file.viewerKind === "video"
+              ? await getReadyPosterImageMetadata(resolution.file.id)
               : null,
         },
       });

--- a/apps/web/server/sharing/poster-route.test.ts
+++ b/apps/web/server/sharing/poster-route.test.ts
@@ -1,0 +1,172 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  cookieGet: vi.fn(),
+  findReadyPosterDerivative: vi.fn(),
+  getSharedNestedFileContent: vi.fn(),
+  getStoragePath: vi.fn(),
+  resolvePublicShare: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({
+    get: mocks.cookieGet,
+  })),
+}));
+
+vi.mock("@staaash/db/media-derivatives", () => ({
+  findReadyPosterDerivative: mocks.findReadyPosterDerivative,
+}));
+
+vi.mock("@/server/storage", () => ({
+  getStoragePath: mocks.getStoragePath,
+}));
+
+vi.mock("@/server/sharing/service", () => ({
+  sharingService: {
+    getSharedNestedFileContent: mocks.getSharedNestedFileContent,
+    resolvePublicShare: mocks.resolvePublicShare,
+  },
+}));
+
+const fixedNow = new Date("2026-05-31T12:00:00.000Z");
+
+const makeFile = () => ({
+  id: "file-1",
+  ownerUserId: "user-1",
+  ownerUsername: "alice",
+  folderId: "folder-1",
+  name: "clip.mp4",
+  mimeType: "video/mp4",
+  sizeBytes: 1024,
+  viewerKind: "video",
+  deletedAt: null,
+  createdAt: fixedNow,
+  updatedAt: fixedNow,
+});
+
+const makeResolution = (overrides: object = {}) => ({
+  kind: "file",
+  share: {
+    id: "share-1",
+    hasPassword: false,
+    status: "active",
+  },
+  access: {
+    requiresPassword: false,
+    isUnlocked: true,
+  },
+  file: makeFile(),
+  ...overrides,
+});
+
+describe("public share poster route", () => {
+  let tempDir = "";
+  let posterPath = "";
+
+  beforeAll(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "staaash-poster-route-"));
+    posterPath = path.join(tempDir, "poster.jpg");
+    await writeFile(posterPath, "poster-bytes", "utf8");
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.cookieGet.mockReturnValue(null);
+    mocks.getStoragePath.mockReturnValue(posterPath);
+    mocks.resolvePublicShare.mockResolvedValue(makeResolution());
+    mocks.findReadyPosterDerivative.mockResolvedValue({
+      storageKey: "derivatives/user-1/file-1/social-poster.jpg",
+      mimeType: "image/jpeg",
+      sizeBytes: 12n,
+    });
+  });
+
+  afterAll(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns a ready poster for active public video shares", async () => {
+    const { GET } = await import("@/app/s/[token]/poster/route");
+
+    const response = await GET(new Request("http://localhost/s/token/poster"), {
+      params: Promise.resolve({ token: "token" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/jpeg");
+    expect(response.headers.get("content-length")).toBe("12");
+    expect(await response.text()).toBe("poster-bytes");
+  });
+
+  it("returns a ready poster for nested files in folder shares", async () => {
+    const { GET } = await import("@/app/s/[token]/files/[fileId]/poster/route");
+    mocks.resolvePublicShare.mockResolvedValue(
+      makeResolution({
+        kind: "folder",
+        listing: {
+          rootFolder: { id: "folder-1", ownerUserId: "user-1" },
+        },
+      }),
+    );
+    mocks.getSharedNestedFileContent.mockResolvedValue({ file: makeFile() });
+
+    const response = await GET(
+      new Request("http://localhost/s/token/files/file-1/poster"),
+      {
+        params: Promise.resolve({ token: "token", fileId: "file-1" }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/jpeg");
+    expect(mocks.getSharedNestedFileContent).toHaveBeenCalledWith({
+      token: "token",
+      fileId: "file-1",
+      shareAccessCookieValue: null,
+    });
+  });
+
+  it("returns 404 when the poster is not ready", async () => {
+    const { GET } = await import("@/app/s/[token]/poster/route");
+    mocks.findReadyPosterDerivative.mockResolvedValue(null);
+
+    const response = await GET(new Request("http://localhost/s/token/poster"), {
+      params: Promise.resolve({ token: "token" }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 404 for passworded shares", async () => {
+    const { GET } = await import("@/app/s/[token]/poster/route");
+    mocks.resolvePublicShare.mockResolvedValue(
+      makeResolution({
+        share: {
+          id: "share-1",
+          hasPassword: true,
+          status: "active",
+        },
+      }),
+    );
+
+    const response = await GET(new Request("http://localhost/s/token/poster"), {
+      params: Promise.resolve({ token: "token" }),
+    });
+
+    expect(response.status).toBe(404);
+    expect(mocks.findReadyPosterDerivative).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/server/sharing/service.test.ts
+++ b/apps/web/server/sharing/service.test.ts
@@ -1,4 +1,32 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const derivativeMocks = vi.hoisted(() => ({
+  findReadyDerivative: vi.fn(),
+  scheduleDerivativeGenerate: vi.fn(),
+  touchDerivativeShared: vi.fn(),
+}));
+const settingsMocks = vi.hoisted(() => ({
+  getSystemSettings: vi.fn(),
+}));
+
+vi.mock("@staaash/db/media-derivatives", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@staaash/db/media-derivatives")>();
+  return {
+    ...actual,
+    findReadyDerivative: derivativeMocks.findReadyDerivative,
+    scheduleDerivativeGenerate: derivativeMocks.scheduleDerivativeGenerate,
+    touchDerivativeShared: derivativeMocks.touchDerivativeShared,
+  };
+});
+
+vi.mock("@/server/settings", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/server/settings")>();
+  return {
+    ...actual,
+    getSystemSettings: settingsMocks.getSystemSettings,
+  };
+});
 
 import { buildShareAccessCookie } from "@/server/sharing/access-cookie";
 import { ShareError } from "@/server/sharing/errors";
@@ -94,6 +122,25 @@ const childFile: StoredFile = {
   sizeBytes: 220,
   contentChecksum: "def",
   viewerKind: null,
+  deletedAt: null,
+  createdAt: fixedNow,
+  updatedAt: fixedNow,
+};
+
+const smallVideoFile: StoredFile = {
+  id: "file-small-video",
+  ownerUserId: "user-1",
+  ownerUsername: "alice",
+  folderId: "folder-shared",
+  name: "clip.mp4",
+  storageKey: "files/alice/Projects/clip.mp4",
+  storageStatus: "available",
+  storageCheckedAt: null,
+  storageMissingAt: null,
+  mimeType: "video/mp4",
+  sizeBytes: 13 * 1024 * 1024,
+  contentChecksum: "video",
+  viewerKind: "video",
   deletedAt: null,
   createdAt: fixedNow,
   updatedAt: fixedNow,
@@ -238,7 +285,34 @@ const fakeFilesRepo = {
   },
 } as unknown as FilesRepository;
 
+const waitForAssertion = async (assertion: () => void) => {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+
+  throw lastError;
+};
+
 describe("sharing service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    settingsMocks.getSystemSettings.mockResolvedValue({
+      mediaPreviewEnabled: true,
+      mediaPreviewThresholdBytes: 367001600n,
+    });
+    derivativeMocks.findReadyDerivative.mockResolvedValue(null);
+    derivativeMocks.scheduleDerivativeGenerate.mockResolvedValue({ id: "job" });
+    derivativeMocks.touchDerivativeShared.mockResolvedValue(undefined);
+  });
+
   it("creates and reissues singleton links for the same target", async () => {
     const sharingRepo = createFakeSharingRepository();
     const service = createSharingService({
@@ -388,5 +462,51 @@ describe("sharing service", () => {
     ).rejects.toMatchObject({
       code: "SHARE_ACCESS_DENIED",
     });
+  });
+
+  it("schedules a social poster for small shared videos below preview threshold", async () => {
+    const sharingRepo = createFakeSharingRepository();
+    const videoFilesRepo = {
+      ...fakeFilesRepo,
+      async findFileById(fileId: string) {
+        if (fileId === smallVideoFile.id) return smallVideoFile;
+        return fakeFilesRepo.findFileById(fileId);
+      },
+    } as unknown as FilesRepository;
+    const service = createSharingService({
+      repo: sharingRepo.repo,
+      filesRepo: videoFilesRepo,
+      now: () => fixedNow,
+    });
+
+    await service.createOrReissueShare({
+      actorUserId: "user-1",
+      actorRole: "member",
+      targetType: "file",
+      fileId: smallVideoFile.id,
+      expiresAt: addDays(7),
+    });
+
+    await waitForAssertion(() => {
+      expect(derivativeMocks.scheduleDerivativeGenerate).toHaveBeenCalledWith({
+        fileId: smallVideoFile.id,
+        kind: "poster",
+        profile: "social-jpeg",
+        reason: "share-created",
+        now: fixedNow,
+      });
+    });
+    expect(derivativeMocks.scheduleDerivativeGenerate).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileId: smallVideoFile.id,
+        kind: "preview",
+      }),
+    );
+    expect(derivativeMocks.touchDerivativeShared).toHaveBeenCalledWith(
+      smallVideoFile.id,
+      "poster",
+      "social-jpeg",
+      fixedNow,
+    );
   });
 });

--- a/apps/web/server/sharing/service.ts
+++ b/apps/web/server/sharing/service.ts
@@ -2,9 +2,13 @@ import { createHash, randomBytes } from "node:crypto";
 
 import type { ShareTargetType } from "@staaash/db/client";
 import {
+  DERIVATIVE_KIND_POSTER,
   scheduleDerivativeGenerate,
   touchDerivativeShared,
   findReadyDerivative,
+  DERIVATIVE_PROFILE_SOCIAL_JPEG,
+  DERIVATIVE_KIND_PREVIEW,
+  DERIVATIVE_PROFILE_1080P,
 } from "@staaash/db/media-derivatives";
 
 import { canAccessPrivateNamespace } from "@/server/access";
@@ -252,6 +256,35 @@ const isEligibleForPreview = (
   file.viewerKind === "video" &&
   BigInt(file.sizeBytes) >= settings.mediaPreviewThresholdBytes;
 
+const isEligibleForPoster = (
+  file: StoredFile,
+  settings: MediaPreviewSettings,
+): boolean => settings.mediaPreviewEnabled && file.viewerKind === "video";
+
+const ensureSharedDerivative = async ({
+  fileId,
+  kind,
+  profile,
+  now,
+}: {
+  fileId: string;
+  kind: "preview" | "poster";
+  profile: "preview-1080p" | "social-jpeg";
+  now: Date;
+}) => {
+  const existing = await findReadyDerivative(fileId, kind, profile);
+  if (!existing) {
+    await scheduleDerivativeGenerate({
+      fileId,
+      kind,
+      profile,
+      reason: "share-created",
+      now,
+    });
+  }
+  await touchDerivativeShared(fileId, kind, profile, now);
+};
+
 const schedulePreviewsForShare = async ({
   targetType,
   file,
@@ -270,16 +303,21 @@ const schedulePreviewsForShare = async ({
   now: Date;
 }): Promise<void> => {
   if (targetType === "file") {
-    if (!file || !isEligibleForPreview(file, settings)) return;
-    const existing = await findReadyDerivative(file.id);
-    if (!existing) {
-      await scheduleDerivativeGenerate({
+    if (!file || !isEligibleForPoster(file, settings)) return;
+    await ensureSharedDerivative({
+      fileId: file.id,
+      kind: DERIVATIVE_KIND_POSTER,
+      profile: DERIVATIVE_PROFILE_SOCIAL_JPEG,
+      now,
+    });
+    if (isEligibleForPreview(file, settings)) {
+      await ensureSharedDerivative({
         fileId: file.id,
-        reason: "share-created",
+        kind: DERIVATIVE_KIND_PREVIEW,
+        profile: DERIVATIVE_PROFILE_1080P,
         now,
       });
     }
-    await touchDerivativeShared(file.id, "preview", "preview-1080p", now);
     return;
   }
 
@@ -289,7 +327,7 @@ const schedulePreviewsForShare = async ({
     (f) =>
       !f.deletedAt &&
       f.folderId &&
-      isEligibleForPreview(f, settings) &&
+      isEligibleForPoster(f, settings) &&
       isFolderWithinRoot({
         folderId: f.folderId,
         rootFolderId: folderId,
@@ -299,15 +337,20 @@ const schedulePreviewsForShare = async ({
 
   await Promise.all(
     eligibleFiles.map(async (f) => {
-      const existing = await findReadyDerivative(f.id);
-      if (!existing) {
-        await scheduleDerivativeGenerate({
+      await ensureSharedDerivative({
+        fileId: f.id,
+        kind: DERIVATIVE_KIND_POSTER,
+        profile: DERIVATIVE_PROFILE_SOCIAL_JPEG,
+        now,
+      });
+      if (isEligibleForPreview(f, settings)) {
+        await ensureSharedDerivative({
           fileId: f.id,
-          reason: "share-created",
+          kind: DERIVATIVE_KIND_PREVIEW,
+          profile: DERIVATIVE_PROFILE_1080P,
           now,
         });
       }
-      await touchDerivativeShared(f.id, "preview", "preview-1080p", now);
     }),
   );
 };

--- a/apps/worker/src/ffmpeg.test.ts
+++ b/apps/worker/src/ffmpeg.test.ts
@@ -1,0 +1,54 @@
+import { EventEmitter } from "node:events";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const createProcess = (code: number) => {
+  const proc = new EventEmitter() as EventEmitter & { kill: () => void };
+  proc.kill = vi.fn();
+  const originalOn = proc.on.bind(proc);
+  proc.on = ((
+    eventName: string | symbol,
+    listener: (...args: unknown[]) => void,
+  ) => {
+    const result = originalOn(eventName, listener);
+    if (eventName === "close") {
+      setImmediate(() => listener(code));
+    }
+    return result;
+  }) as typeof proc.on;
+  return proc;
+};
+
+describe("ffmpeg helpers", () => {
+  afterEach(() => {
+    vi.doUnmock("node:child_process");
+    vi.resetModules();
+  });
+
+  it("retries poster capture at the start when the 1s frame fails", async () => {
+    const spawnMock = vi
+      .fn()
+      .mockReturnValueOnce(createProcess(1))
+      .mockReturnValueOnce(createProcess(0));
+
+    vi.doMock("node:child_process", () => ({
+      execFile: vi.fn(),
+      spawn: spawnMock,
+    }));
+    vi.resetModules();
+
+    const { runFfmpegPoster } = await import("./ffmpeg.js");
+
+    await expect(runFfmpegPoster("input.mp4", "poster.jpg")).resolves.toBe(
+      undefined,
+    );
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    expect(spawnMock.mock.calls[0]?.[1]).toEqual(
+      expect.arrayContaining(["-ss", "1"]),
+    );
+    expect(spawnMock.mock.calls[1]?.[1]).toEqual(
+      expect.arrayContaining(["-ss", "0"]),
+    );
+  });
+});

--- a/apps/worker/src/ffmpeg.ts
+++ b/apps/worker/src/ffmpeg.ts
@@ -187,3 +187,42 @@ export const runFfmpegTranscode = (
     ],
     signal,
   );
+
+const runFfmpegPosterFrame = (
+  inputPath: string,
+  outputPath: string,
+  seekSeconds: number,
+  signal?: AbortSignal,
+): Promise<void> =>
+  runFfmpegProcess(
+    [
+      "-y",
+      "-ss",
+      String(seekSeconds),
+      "-i",
+      inputPath,
+      "-frames:v",
+      "1",
+      "-vf",
+      "scale=min(1280\\,iw):-2",
+      "-q:v",
+      "2",
+      "-f",
+      "image2",
+      outputPath,
+    ],
+    signal,
+  );
+
+export const runFfmpegPoster = async (
+  inputPath: string,
+  outputPath: string,
+  signal?: AbortSignal,
+): Promise<void> => {
+  try {
+    await runFfmpegPosterFrame(inputPath, outputPath, 1, signal);
+  } catch (error) {
+    if (signal?.aborted) throw error;
+    await runFfmpegPosterFrame(inputPath, outputPath, 0, signal);
+  }
+};

--- a/apps/worker/src/handlers/media-derivative.test.ts
+++ b/apps/worker/src/handlers/media-derivative.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   isStreamCopyCompatible: vi.fn(),
   markDerivativeFailed: vi.fn(),
   markDerivativeReady: vi.fn(),
+  runFfmpegPoster: vi.fn(),
   runFfmpegStreamCopy: vi.fn(),
   runFfmpegTranscode: vi.fn(),
   runFfprobe: vi.fn(),
@@ -24,7 +25,9 @@ vi.mock("@staaash/db/client", () => ({
 
 vi.mock("@staaash/db/media-derivatives", () => ({
   DERIVATIVE_KIND_PREVIEW: "preview",
+  DERIVATIVE_KIND_POSTER: "poster",
   DERIVATIVE_PROFILE_1080P: "preview-1080p",
+  DERIVATIVE_PROFILE_SOCIAL_JPEG: "social-jpeg",
   DERIVATIVE_STATUS_PROCESSING: "processing",
   DERIVATIVE_STATUS_STALE: "stale",
   buildDerivativeStorageKey: mocks.buildDerivativeStorageKey,
@@ -36,6 +39,7 @@ vi.mock("@staaash/db/media-derivatives", () => ({
 vi.mock("../ffmpeg.js", () => ({
   getFfmpegHealth: mocks.getFfmpegHealth,
   isStreamCopyCompatible: mocks.isStreamCopyCompatible,
+  runFfmpegPoster: mocks.runFfmpegPoster,
   runFfmpegStreamCopy: mocks.runFfmpegStreamCopy,
   runFfmpegTranscode: mocks.runFfmpegTranscode,
   runFfprobe: mocks.runFfprobe,
@@ -205,6 +209,127 @@ describe("media derivative handler", () => {
         durationSeconds: 12.5,
         videoCodec: "h264",
         audioCodec: "aac",
+      }),
+    );
+  });
+
+  it("generates shared poster derivatives below the video preview threshold", async () => {
+    tempRoot = await mkdtemp(path.join(os.tmpdir(), "staaash-media-poster-"));
+    const filesRoot = path.join(tempRoot, "files");
+    const tmpRoot = path.join(tempRoot, "tmp");
+    const sourcePath = path.join(filesRoot, "library", "owner-1", "clip.mp4");
+    await mkdir(path.dirname(sourcePath), { recursive: true });
+    await writeFile(sourcePath, "source", "utf8");
+
+    mocks.buildDerivativeStorageKey.mockReturnValue(
+      "derivatives/owner-1/file-1/social-poster.jpg",
+    );
+    mocks.upsertDerivativeQueued.mockResolvedValue({
+      id: "poster-derivative-1",
+      status: "queued",
+    });
+
+    const client = {
+      systemSettings: {
+        findUnique: vi.fn(async () => ({
+          mediaPreviewEnabled: true,
+          mediaPreviewThresholdBytes: 367_001_600n,
+          mediaPreviewMaxHeight: 720,
+          mediaPreviewCrf: 22,
+        })),
+      },
+      file: {
+        findUnique: vi.fn(async () => ({
+          id: "file-1",
+          ownerUserId: "owner-1",
+          mimeType: "video/mp4",
+          sizeBytes: 10_000n,
+          storageKey: "library/owner-1/clip.mp4",
+          deletedAt: null,
+        })),
+      },
+      mediaDerivative: {
+        update: vi.fn(async () => ({
+          id: "poster-derivative-1",
+          status: "processing",
+        })),
+        findUnique: vi.fn(async () => ({
+          id: "poster-derivative-1",
+          status: "processing",
+        })),
+      },
+    };
+    mocks.getPrisma.mockReturnValue(client);
+
+    mocks.runFfprobe.mockImplementation(async (inputPath: string) => {
+      if (inputPath.endsWith("social-poster.jpg")) {
+        return {
+          streams: [
+            {
+              codec_type: "video",
+              codec_name: "mjpeg",
+              width: 1280,
+              height: 720,
+            },
+          ],
+          format: {},
+        };
+      }
+
+      return {
+        streams: [
+          {
+            codec_type: "video",
+            codec_name: "h264",
+            width: 1920,
+            height: 1080,
+          },
+        ],
+        format: { duration: "10" },
+      };
+    });
+
+    mocks.runFfmpegPoster.mockImplementation(
+      async (_inputPath: string, outputPath: string) => {
+        await mkdir(path.dirname(outputPath), { recursive: true });
+        await writeFile(outputPath, "poster", "utf8");
+      },
+    );
+
+    const posterJob = createJob();
+    posterJob.payloadJson = {
+      fileId: "file-1",
+      kind: "poster",
+      profile: "social-jpeg",
+      reason: "share-created",
+    };
+
+    await expect(
+      handleMediaDerivativeGenerate(posterJob, {
+        filesRoot,
+        tmpRoot,
+        heartbeatPath: path.join(tmpRoot, "worker-heartbeat.json"),
+        pendingDeleteRoot: path.join(tmpRoot, "pending-delete"),
+        uploadStagingTtlMs: 1,
+      }),
+    ).resolves.toBe(false);
+
+    expect(mocks.runFfmpegPoster).toHaveBeenCalledWith(
+      sourcePath,
+      path.join(tmpRoot, "derivatives", "poster-derivative-1.jpg.tmp"),
+      expect.any(AbortSignal),
+    );
+    expect(mocks.runFfmpegTranscode).not.toHaveBeenCalled();
+    expect(mocks.markDerivativeReady).toHaveBeenCalledWith(
+      "poster-derivative-1",
+      expect.objectContaining({
+        storageKey: "derivatives/owner-1/file-1/social-poster.jpg",
+        mimeType: "image/jpeg",
+        width: 1280,
+        height: 720,
+        durationSeconds: null,
+        videoCodec: null,
+        audioCodec: null,
       }),
     );
   });

--- a/apps/worker/src/handlers/media-derivative.ts
+++ b/apps/worker/src/handlers/media-derivative.ts
@@ -4,8 +4,10 @@ import { mkdir, rename, rm, stat } from "node:fs/promises";
 import { getPrisma } from "@staaash/db/client";
 import type { BackgroundJobRecord } from "@staaash/db/jobs";
 import {
+  DERIVATIVE_KIND_POSTER,
   DERIVATIVE_KIND_PREVIEW,
   DERIVATIVE_PROFILE_1080P,
+  DERIVATIVE_PROFILE_SOCIAL_JPEG,
   DERIVATIVE_STATUS_PROCESSING,
   DERIVATIVE_STATUS_STALE,
   buildDerivativeStorageKey,
@@ -20,6 +22,7 @@ import { safeResolveStoragePath } from "../storage-maintenance.js";
 import {
   getFfmpegHealth,
   isStreamCopyCompatible,
+  runFfmpegPoster,
   runFfmpegStreamCopy,
   runFfmpegTranscode,
   runFfprobe,
@@ -137,21 +140,23 @@ export const handleMediaDerivativeGenerate = async (
     return false;
   }
 
+  const kind =
+    payload.kind === DERIVATIVE_KIND_POSTER
+      ? DERIVATIVE_KIND_POSTER
+      : DERIVATIVE_KIND_PREVIEW;
+  const profile =
+    kind === DERIVATIVE_KIND_POSTER
+      ? DERIVATIVE_PROFILE_SOCIAL_JPEG
+      : DERIVATIVE_PROFILE_1080P;
+  const isPoster = kind === DERIVATIVE_KIND_POSTER;
+
   if (
+    !isPoster &&
     payload.reason !== "manual-regenerate" &&
     file.sizeBytes < settings.mediaPreviewThresholdBytes
   ) {
     return false;
   }
-
-  const kind =
-    payload.kind === DERIVATIVE_KIND_PREVIEW
-      ? DERIVATIVE_KIND_PREVIEW
-      : DERIVATIVE_KIND_PREVIEW;
-  const profile =
-    payload.profile === DERIVATIVE_PROFILE_1080P
-      ? DERIVATIVE_PROFILE_1080P
-      : DERIVATIVE_PROFILE_1080P;
 
   const derivative = await upsertDerivativeQueued(file.id, kind, profile);
 
@@ -171,7 +176,10 @@ export const handleMediaDerivativeGenerate = async (
   );
   const outputPath = safeResolveStoragePath(storagePaths.filesRoot, storageKey);
   const tmpDir = path.resolve(storagePaths.tmpRoot, "derivatives");
-  const tmpPath = path.resolve(tmpDir, `${derivative.id}.mp4.tmp`);
+  const tmpPath = path.resolve(
+    tmpDir,
+    `${derivative.id}.${isPoster ? "jpg" : "mp4"}.tmp`,
+  );
 
   await mkdir(tmpDir, { recursive: true });
 
@@ -217,8 +225,13 @@ export const handleMediaDerivativeGenerate = async (
   }, 3000);
 
   try {
-    await context?.updateProgress({ stage: "encoding", fileId: file.id });
-    if (isStreamCopyCompatible(probe)) {
+    await context?.updateProgress({
+      stage: isPoster ? "capturing-poster" : "encoding",
+      fileId: file.id,
+    });
+    if (isPoster) {
+      await runFfmpegPoster(inputPath, tmpPath, controller.signal);
+    } else if (isStreamCopyCompatible(probe)) {
       await runFfmpegStreamCopy(inputPath, tmpPath, controller.signal);
     } else {
       await runFfmpegTranscode(
@@ -253,11 +266,16 @@ export const handleMediaDerivativeGenerate = async (
 
   const outputStats = await stat(outputPath);
   const outputProbe = await runFfprobe(outputPath);
-  const videoStream = outputProbe.streams.find((s) => s.codec_type === "video");
-  const audioStream = outputProbe.streams.find((s) => s.codec_type === "audio");
-  const durationSeconds = outputProbe.format.duration
-    ? parseFloat(outputProbe.format.duration)
-    : null;
+  const visualStream = outputProbe.streams.find(
+    (s) => s.codec_type === "video",
+  );
+  const audioStream = isPoster
+    ? null
+    : outputProbe.streams.find((s) => s.codec_type === "audio");
+  const durationSeconds =
+    !isPoster && outputProbe.format.duration
+      ? parseFloat(outputProbe.format.duration)
+      : null;
 
   // Guard: admin may have marked stale while we were processing.
   const current = await (
@@ -273,12 +291,12 @@ export const handleMediaDerivativeGenerate = async (
 
   await markDerivativeReady(derivative.id, {
     storageKey,
-    mimeType: "video/mp4",
+    mimeType: isPoster ? "image/jpeg" : "video/mp4",
     sizeBytes: BigInt(outputStats.size),
-    width: videoStream?.width ?? null,
-    height: videoStream?.height ?? null,
+    width: visualStream?.width ?? null,
+    height: visualStream?.height ?? null,
     durationSeconds: Number.isFinite(durationSeconds) ? durationSeconds : null,
-    videoCodec: videoStream?.codec_name ?? null,
+    videoCodec: isPoster ? null : (visualStream?.codec_name ?? null),
     audioCodec: audioStream?.codec_name ?? null,
     generatedAt: new Date(),
   });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       DATABASE_URL: postgresql://${DB_USERNAME:-postgres}:${DB_PASSWORD}@db:5432/${DB_DATABASE_NAME:-staaash}
       UPLOAD_LOCATION: /data/files
       SECURE_COOKIES: "${SECURE_COOKIES:-}"
+      STAAASH_PUBLIC_URL: "${STAAASH_PUBLIC_URL:-}"
     volumes:
       # Do not edit the next line. To change where files are stored, edit UPLOAD_LOCATION in the .env file
       - ${UPLOAD_LOCATION:-./library}:/data/files

--- a/docs/operations/public-sharing.md
+++ b/docs/operations/public-sharing.md
@@ -1,0 +1,40 @@
+# Public Sharing URLs
+
+Staaash can share links from either a direct HTTP address or a public HTTPS
+address.
+
+## Direct HTTP
+
+This works with the default Docker setup:
+
+```env
+STAAASH_PUBLIC_URL=
+```
+
+Share links use the address from the incoming request, such as
+`http://STATIC_IP:2113`. This is fine for normal browser sharing, but Discord may
+not play video embeds from plain HTTP URLs.
+
+## Public HTTPS
+
+For Discord video playback, put Staaash behind a real HTTPS hostname and set:
+
+```env
+STAAASH_PUBLIC_URL=https://drive.example.com
+SECURE_COOKIES=true
+```
+
+The reverse proxy or tunnel should forward traffic to Staaash on port `2113` and
+send:
+
+```text
+X-Forwarded-Proto: https
+X-Forwarded-Host: drive.example.com
+```
+
+With `STAAASH_PUBLIC_URL` set, generated share links and Open Graph metadata use
+that HTTPS address. Existing HTTP access still works if your network exposes it,
+but Discord embeds should use the HTTPS share URL.
+
+Discord caches embed metadata, so repost the link or create a fresh share after
+changing this setting.

--- a/example.env
+++ b/example.env
@@ -21,3 +21,7 @@ DB_PASSWORD=change-me
 # Optional override. By default, Staaash uses secure cookies on HTTPS and
 # non-secure cookies on plain HTTP. Allowed values when set: true or false.
 # SECURE_COOKIES=true
+
+# Optional canonical public URL for generated share links and embeds.
+# Use an HTTPS URL here when you want playable Discord video embeds.
+# STAAASH_PUBLIC_URL=https://drive.example.com

--- a/packages/db/src/media-derivatives.ts
+++ b/packages/db/src/media-derivatives.ts
@@ -6,7 +6,9 @@ import {
 } from "./jobs";
 
 export const DERIVATIVE_KIND_PREVIEW = "preview" as const;
+export const DERIVATIVE_KIND_POSTER = "poster" as const;
 export const DERIVATIVE_PROFILE_1080P = "preview-1080p" as const;
+export const DERIVATIVE_PROFILE_SOCIAL_JPEG = "social-jpeg" as const;
 
 export const DERIVATIVE_STATUS_QUEUED = "queued" as const;
 export const DERIVATIVE_STATUS_PROCESSING = "processing" as const;
@@ -14,8 +16,12 @@ export const DERIVATIVE_STATUS_READY = "ready" as const;
 export const DERIVATIVE_STATUS_FAILED = "failed" as const;
 export const DERIVATIVE_STATUS_STALE = "stale" as const;
 
-export type DerivativeKind = typeof DERIVATIVE_KIND_PREVIEW;
-export type DerivativeProfile = typeof DERIVATIVE_PROFILE_1080P;
+export type DerivativeKind =
+  | typeof DERIVATIVE_KIND_PREVIEW
+  | typeof DERIVATIVE_KIND_POSTER;
+export type DerivativeProfile =
+  | typeof DERIVATIVE_PROFILE_1080P
+  | typeof DERIVATIVE_PROFILE_SOCIAL_JPEG;
 export type DerivativeStatus =
   | typeof DERIVATIVE_STATUS_QUEUED
   | typeof DERIVATIVE_STATUS_PROCESSING
@@ -77,7 +83,13 @@ export const buildDerivativeStorageKey = (
   ownerUserId: string,
   fileId: string,
   profile: DerivativeProfile,
-): string => `derivatives/${ownerUserId}/${fileId}/${profile}.mp4`;
+): string => {
+  const fileName =
+    profile === DERIVATIVE_PROFILE_SOCIAL_JPEG
+      ? "social-poster.jpg"
+      : `${profile}.mp4`;
+  return `derivatives/${ownerUserId}/${fileId}/${fileName}`;
+};
 
 export const buildDerivativeDedupeKey = (
   fileId: string,
@@ -129,6 +141,17 @@ export const findReadyDerivative = async (
     where: { fileId, kind, profile, status: DERIVATIVE_STATUS_READY },
   });
 };
+
+export const findReadyPosterDerivative = async (
+  fileId: string,
+  client?: DerivativeClient,
+): Promise<MediaDerivativeRecord | null> =>
+  findReadyDerivative(
+    fileId,
+    DERIVATIVE_KIND_POSTER,
+    DERIVATIVE_PROFILE_SOCIAL_JPEG,
+    client,
+  );
 
 export const findDerivative = async (
   fileId: string,


### PR DESCRIPTION
## 🚀 Summary

Adds Discord-friendly video share metadata without requiring HTTPS for normal self-hosted sharing. Staaash now supports an optional `STAAASH_PUBLIC_URL` canonical base URL for share links and Open Graph media URLs, adds JPEG poster derivatives for shared videos, and exposes public poster routes for active non-password shares.

## 📊 Impacts and Changes

- Users can keep sharing direct HTTP static-IP links as normal browser links.
- Operators can set `STAAASH_PUBLIC_URL=https://drive.example.com` so Discord sees HTTPS share, poster, and video URLs.
- Shared videos now queue a `poster` / `social-jpeg` derivative even when the video is below the normal preview-size threshold.
- New poster files are stored under `derivatives/{ownerUserId}/{fileId}/social-poster.jpg` using the existing `MediaDerivative` table, so there is no DB migration.
- New public poster routes serve JPEG posters for active non-password shares only:
  - `/s/[token]/poster`
  - `/s/[token]/files/[fileId]/poster`
- Docker/example env and operations docs now explain HTTP sharing vs HTTPS-required Discord playback.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [ ] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

Additional checks run:

- [x] `pnpm typecheck` passed
- [x] `pnpm format:check` passed
- [x] `git diff --check` passed

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

Storage/auth notes: this reuses `MediaDerivative` with new kind/profile values, adds a new derivative storage key shape for JPEG posters, and keeps poster access limited to active non-password public shares.

## 🧗 Follow-ups or Limitations

Discord playback still requires a reachable HTTPS public URL. Plain HTTP static-IP shares remain supported, but Discord may show only the title/poster card and refuse inline playback.

## 🔗 Linked Issues

None.
