### PR TITLE
[codex] Add mobile workspace support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ yarn-error.log*
 
 # Test and tooling caches
 test-results/
+apps/web/test-results/
 playwright-report/
 .cache/
 .eslintcache

--- a/apps/web/app/(workspace)/favorites/favorites-view.tsx
+++ b/apps/web/app/(workspace)/favorites/favorites-view.tsx
@@ -9,6 +9,7 @@ import {
   useTransition,
   type KeyboardEvent,
   type MouseEvent,
+  type PointerEvent,
 } from "react";
 import { useRouter } from "next/navigation";
 import {
@@ -20,6 +21,7 @@ import {
   Grid2X2,
   Heart,
   List,
+  MoreHorizontal,
   Pin,
   PinOff,
   RefreshCw,
@@ -36,6 +38,8 @@ import { ItemTypeIcon } from "@/app/item-type-icon";
 import { startValidatedDownload } from "@/lib/transfers/download";
 
 import { useTransferContext } from "../transfer-context";
+import { useCoarsePointer } from "../use-coarse-pointer";
+import { WorkspaceActionSheet } from "../workspace-action-sheet";
 import {
   filterFavoriteItems,
   formatFavoriteFileSize,
@@ -127,6 +131,7 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
   const router = useRouter();
   const [, startTransition] = useTransition();
   const { handleDownload } = useTransferContext();
+  const isCoarsePointer = useCoarsePointer();
   const [viewMode, setViewMode] = useState<FavoriteViewMode>("list");
   const [viewReady, setViewReady] = useState(false);
   const [filterType, setFilterType] = useState<FavoriteFilterType>("all");
@@ -150,6 +155,10 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
   const rubberBandStart = useRef<{ startX: number; startY: number } | null>(
     null,
   );
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const suppressNextClickRef = useRef(false);
+  const [actionSheetItem, setActionSheetItem] =
+    useState<FavoriteClientItem | null>(null);
 
   useEffect(() => {
     const stored = window.localStorage.getItem(VIEW_STORAGE_KEY);
@@ -503,12 +512,31 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
 
   const handleFavoritesSurfaceClick = (event: MouseEvent<HTMLDivElement>) => {
     if (didRubberBand.current) return;
+    if (suppressNextClickRef.current) {
+      suppressNextClickRef.current = false;
+      return;
+    }
     const target = event.target as HTMLElement;
     if (target.closest("button, input, select, textarea")) return;
 
     const item = target.closest<HTMLElement>("[data-favorite-item]");
     const key = item?.dataset.favoriteItem;
     if (key && visibleItemByKey.has(key)) {
+      const favorite = visibleItemByKey.get(key)!;
+      if (isCoarsePointer) {
+        if (selectedKeys.size === 0) {
+          openItem(favorite);
+          return;
+        }
+        setSelectedKeys((current) => {
+          const next = new Set(current);
+          if (next.has(key)) next.delete(key);
+          else next.add(key);
+          return next;
+        });
+        setLastSelectedKey(key);
+        return;
+      }
       selectItem(key, event);
       return;
     }
@@ -518,6 +546,7 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
 
   const handleFavoritesMouseDown = useCallback(
     (event: MouseEvent<HTMLDivElement>) => {
+      if (isCoarsePointer) return;
       if (event.button !== 0) return;
 
       const target = event.target as HTMLElement;
@@ -544,8 +573,32 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
         }
       }
     },
-    [],
+    [isCoarsePointer],
   );
+
+  const clearLongPressTimer = () => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  };
+
+  const handleFavoritePointerDown = (
+    item: FavoriteClientItem,
+    event: PointerEvent<HTMLElement>,
+  ) => {
+    if (!isCoarsePointer || event.pointerType === "mouse") return;
+    const target = event.target as HTMLElement;
+    if (target.closest("button, input, select, textarea, a")) return;
+    clearLongPressTimer();
+    suppressNextClickRef.current = false;
+    const key = getItemKey(item);
+    longPressTimerRef.current = setTimeout(() => {
+      suppressNextClickRef.current = true;
+      setSelectedKeys(new Set([key]));
+      setLastSelectedKey(key);
+    }, 420);
+  };
 
   const handleFavoriteItemKeyDown = (
     item: FavoriteClientItem,
@@ -564,6 +617,7 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
 
   useEffect(() => {
     const onMove = (event: globalThis.MouseEvent) => {
+      if (isCoarsePointer) return;
       const container = listRef.current;
       if (!container) return;
 
@@ -654,10 +708,11 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
     window.addEventListener("mouseup", onUp);
 
     return () => {
+      clearLongPressTimer();
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
     };
-  }, []);
+  }, [isCoarsePointer]);
 
   const renderSortButton = (
     key: FavoriteSortKey,
@@ -678,6 +733,22 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
 
   const renderItemActions = (item: FavoriteClientItem) => {
     const pinned = item.quickAccessPinnedAt != null;
+
+    if (isCoarsePointer) {
+      return (
+        <button
+          aria-label={`Actions for ${item.name}`}
+          className="favorites-action-btn"
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            setActionSheetItem(item);
+          }}
+        >
+          <MoreHorizontal size={13} aria-hidden />
+        </button>
+      );
+    }
 
     return (
       <>
@@ -1016,6 +1087,12 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
                       event.stopPropagation();
                       openItem(item);
                     }}
+                    onPointerCancel={clearLongPressTimer}
+                    onPointerDown={(event) =>
+                      handleFavoritePointerDown(item, event)
+                    }
+                    onPointerLeave={clearLongPressTimer}
+                    onPointerUp={clearLongPressTimer}
                   >
                     <span className="favorites-row-thumb">
                       <FavoriteIcon item={item} />
@@ -1070,6 +1147,12 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
                       event.stopPropagation();
                       openItem(item);
                     }}
+                    onPointerCancel={clearLongPressTimer}
+                    onPointerDown={(event) =>
+                      handleFavoritePointerDown(item, event)
+                    }
+                    onPointerLeave={clearLongPressTimer}
+                    onPointerUp={clearLongPressTimer}
                   >
                     <div
                       className="favorites-grid-preview"
@@ -1109,6 +1192,42 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
           </div>
         )}
       </div>
+      {isCoarsePointer && selectedItems.length > 0 ? (
+        <div className="workspace-selection-bar" role="region">
+          <span>
+            {selectedItems.length} item
+            {selectedItems.length === 1 ? "" : "s"}
+          </span>
+          <button
+            type="button"
+            onClick={() =>
+              void handleDownload(selectedItems.map((item) => item.id))
+            }
+          >
+            Download
+          </button>
+          <button
+            className="is-danger"
+            type="button"
+            onClick={() => void removeFavorites(selectedItems)}
+          >
+            Remove
+          </button>
+          <button type="button" onClick={clearSelection}>
+            Clear
+          </button>
+        </div>
+      ) : null}
+      <WorkspaceActionSheet
+        groups={
+          actionSheetItem ? getFavoriteItemContextGroups(actionSheetItem) : []
+        }
+        itemName={actionSheetItem?.name}
+        open={actionSheetItem !== null}
+        onOpenChange={(open) => {
+          if (!open) setActionSheetItem(null);
+        }}
+      />
     </DashboardPageContextMenu>
   );
 }

--- a/apps/web/app/(workspace)/files/files-row.tsx
+++ b/apps/web/app/(workspace)/files/files-row.tsx
@@ -10,17 +10,22 @@ import {
   Briefcase,
   Download,
   FolderOpen,
+  MoreHorizontal,
   Share2,
   type LucideIcon,
 } from "lucide-react";
 
 import { getItemVisual } from "@/app/item-visuals";
 import { ItemTypeIcon } from "@/app/item-type-icon";
-import { DashboardItemContextMenu } from "@/app/dashboard-context-menu";
+import {
+  DashboardItemContextMenu,
+  type DashboardContextMenuGroup,
+} from "@/app/dashboard-context-menu";
 import { formatDateTime } from "@/app/auth-ui";
 import type { FileSummary, FolderSummary } from "@/server/files/types";
 import type { ShareLinkSummary } from "@/server/sharing";
 import { FOLDER_ICON_MAP } from "./files-properties-panel";
+import { WorkspaceActionSheet } from "../workspace-action-sheet";
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -61,6 +66,7 @@ type BaseFolderRowProps = {
   onRenameSubmit: () => void;
   onRenameCancel: () => void;
   onClick: (e: React.MouseEvent) => void;
+  onLongPress: () => void;
   onOpen: () => void;
   onStartRename: () => void;
   onFavorite: () => void;
@@ -70,6 +76,7 @@ type BaseFolderRowProps = {
   onMoveTo: (destinationId: string) => void;
   onDownload: () => void;
   rowRef: (el: HTMLDivElement | null) => void;
+  touchMode: boolean;
 };
 
 type BaseFileRowProps = {
@@ -88,6 +95,7 @@ type BaseFileRowProps = {
   onRenameSubmit: () => void;
   onRenameCancel: () => void;
   onClick: (e: React.MouseEvent) => void;
+  onLongPress: () => void;
   onOpen: () => void;
   onStartRename: () => void;
   onFavorite: () => void;
@@ -97,6 +105,7 @@ type BaseFileRowProps = {
   onMoveTo: (destinationId: string) => void;
   onDownload: () => void;
   rowRef: (el: HTMLDivElement | null) => void;
+  touchMode: boolean;
 };
 
 type FilesRowProps = BaseFolderRowProps | BaseFileRowProps;
@@ -114,10 +123,12 @@ export function FilesRow(props: FilesRowProps) {
     isFavorite,
     availableMoveTargets,
     shareProps,
+    touchMode,
     onRenameChange,
     onRenameSubmit,
     onRenameCancel,
     onClick,
+    onLongPress,
     onOpen,
     onStartRename,
     onFavorite,
@@ -133,6 +144,15 @@ export function FilesRow(props: FilesRowProps) {
   const onDownload = props.onDownload;
 
   const renameInputRef = useRef<HTMLInputElement>(null);
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const suppressNextClickRef = useRef(false);
+  const [actionSheetOpen, setActionSheetOpen] = useState(false);
+
+  useEffect(() => {
+    return () => {
+      if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current);
+    };
+  }, []);
 
   const rowClasses = [
     "explorer-row",
@@ -189,173 +209,231 @@ export function FilesRow(props: FilesRowProps) {
       : "Link inactive"
     : null;
 
+  const contextGroups: DashboardContextMenuGroup[] = [
+    {
+      actions: [
+        {
+          label:
+            props.kind === "folder"
+              ? "Open"
+              : props.data.viewerKind
+                ? "Open"
+                : "Download",
+          shortcut: "↵",
+          onSelect: onOpen,
+        },
+        {
+          hidden: !(
+            isMultiSelected ||
+            props.kind === "folder" ||
+            props.data.viewerKind
+          ),
+          label: isMultiSelected
+            ? `Download ${selectedCount} items as zip`
+            : props.kind === "folder"
+              ? "Download as zip"
+              : "Download",
+          onSelect: onDownload,
+        },
+      ],
+    },
+    {
+      actions: [
+        {
+          disabled: isMultiSelected,
+          label: "Rename",
+          shortcut: "F2",
+          onSelect: onStartRename,
+        },
+        {
+          label: isFavorite ? "Remove from favourites" : "Add to favourites",
+          onSelect: onFavorite,
+        },
+        {
+          label: shareLabel ? "Share — manage link" : "Share",
+          onSelect: shareProps.onShare,
+        },
+        {
+          hidden: props.kind !== "folder",
+          label: "Change icon…",
+          onSelect: onProperties,
+        },
+        {
+          label: "Properties",
+          onSelect: onProperties,
+        },
+      ],
+    },
+    {
+      actions: [
+        {
+          label: isMultiSelected ? `Cut ${selectedCount} items` : "Cut",
+          shortcut: "⌘X",
+          onSelect: onCut,
+        },
+        availableMoveTargets.length > 0
+          ? {
+              label: "Move to…",
+              subActions: availableMoveTargets.map((target) => ({
+                label: target.pathLabel,
+                onSelect: () => onMoveTo(target.id),
+              })),
+            }
+          : {
+              disabled: true,
+              label: "Move to…",
+            },
+      ],
+    },
+    {
+      actions: [
+        {
+          destructive: true,
+          label: isMultiSelected
+            ? `Move ${selectedCount} items to trash`
+            : "Move to trash",
+          shortcut: "Del",
+          onSelect: onTrash,
+        },
+      ],
+    },
+  ];
+
+  const clearLongPressTimer = () => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  };
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!touchMode || event.pointerType === "mouse" || isRenaming) return;
+    const target = event.target as HTMLElement;
+    if (target.closest("button, input, a")) return;
+    clearLongPressTimer();
+    suppressNextClickRef.current = false;
+    longPressTimerRef.current = setTimeout(() => {
+      suppressNextClickRef.current = true;
+      onLongPress();
+    }, 420);
+  };
+
+  const handleRowClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (suppressNextClickRef.current) {
+      suppressNextClickRef.current = false;
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    if (touchMode && !isRenaming) {
+      if (selectedCount > 0) onClick(event);
+      else onOpen();
+      return;
+    }
+
+    onClick(event);
+  };
+
   return (
-    <DashboardItemContextMenu
-      groups={[
-        {
-          actions: [
-            {
-              label:
-                props.kind === "folder"
-                  ? "Open"
-                  : props.data.viewerKind
-                    ? "Open"
-                    : "Download",
-              shortcut: "↵",
-              onSelect: onOpen,
-            },
-            {
-              hidden: !(
-                isMultiSelected ||
-                props.kind === "folder" ||
-                props.data.viewerKind
-              ),
-              label: isMultiSelected
-                ? `Download ${selectedCount} items as zip`
-                : props.kind === "folder"
-                  ? "Download as zip"
-                  : "Download",
-              onSelect: onDownload,
-            },
-          ],
-        },
-        {
-          actions: [
-            {
-              disabled: isMultiSelected,
-              label: "Rename",
-              shortcut: "F2",
-              onSelect: onStartRename,
-            },
-            {
-              label: isFavorite
-                ? "Remove from favourites"
-                : "Add to favourites",
-              onSelect: onFavorite,
-            },
-            {
-              label: shareLabel ? "Share — manage link" : "Share",
-              onSelect: shareProps.onShare,
-            },
-            {
-              hidden: props.kind !== "folder",
-              label: "Change icon…",
-              onSelect: onProperties,
-            },
-            {
-              label: "Properties",
-              onSelect: onProperties,
-            },
-          ],
-        },
-        {
-          actions: [
-            {
-              label: isMultiSelected ? `Cut ${selectedCount} items` : "Cut",
-              shortcut: "⌘X",
-              onSelect: onCut,
-            },
-            availableMoveTargets.length > 0
-              ? {
-                  label: "Move to…",
-                  subActions: availableMoveTargets.map((target) => ({
-                    label: target.pathLabel,
-                    onSelect: () => onMoveTo(target.id),
-                  })),
-                }
-              : {
-                  disabled: true,
-                  label: "Move to…",
-                },
-          ],
-        },
-        {
-          actions: [
-            {
-              destructive: true,
-              label: isMultiSelected
-                ? `Move ${selectedCount} items to trash`
-                : "Move to trash",
-              shortcut: "Del",
-              onSelect: onTrash,
-            },
-          ],
-        },
-      ]}
-    >
-      <div
-        ref={rowRef}
-        data-file-row={props.data.id}
-        className={rowClasses}
-        onClick={onClick}
-        onDoubleClick={onOpen}
-        role="row"
-        aria-selected={isSelected}
-        tabIndex={isSelected ? 0 : -1}
-      >
-        {/* Icon */}
-        <div className="explorer-row-icon" role="gridcell">
-          <ItemTypeIcon
-            icon={props.kind === "folder" ? IconComponent : undefined}
-            size={16}
-            visual={visual}
-          />
-        </div>
-
-        {/* Name */}
-        <div className="explorer-row-name-cell" role="gridcell">
-          {isRenaming ? (
-            <input
-              ref={renameInputRef}
-              className="explorer-row-rename"
-              value={renameValue}
-              autoFocus
-              onChange={(e) => onRenameChange(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  onRenameSubmit();
-                }
-                if (e.key === "Escape") {
-                  e.preventDefault();
-                  onRenameCancel();
-                }
-                // Stop propagation so row keyboard handlers don't fire
-                e.stopPropagation();
-              }}
-              onBlur={onRenameSubmit}
-              onClick={(e) => e.stopPropagation()}
-            />
-          ) : (
-            <>
-              <span className="explorer-row-name" title={name}>
-                {name}
-              </span>
-              {shareProps.share?.status === "active" && (
-                <Share2
-                  size={10}
-                  className="explorer-row-share-badge"
-                  aria-label="Shared"
-                />
-              )}
-            </>
-          )}
-        </div>
-
-        {/* Size */}
-        <span className="explorer-row-meta" role="gridcell">
-          {size}
-        </span>
-
-        {/* Date */}
-        <span
-          className="explorer-row-meta"
-          role="gridcell"
-          suppressHydrationWarning
+    <>
+      <DashboardItemContextMenu groups={contextGroups}>
+        <div
+          ref={rowRef}
+          data-file-row={props.data.id}
+          className={rowClasses}
+          onClick={handleRowClick}
+          onDoubleClick={touchMode ? undefined : onOpen}
+          onPointerCancel={clearLongPressTimer}
+          onPointerDown={handlePointerDown}
+          onPointerLeave={clearLongPressTimer}
+          onPointerUp={clearLongPressTimer}
+          role="row"
+          aria-selected={isSelected}
+          tabIndex={isSelected ? 0 : -1}
         >
-          {date}
-        </span>
-      </div>
-    </DashboardItemContextMenu>
+          {/* Icon */}
+          <div className="explorer-row-icon" role="gridcell">
+            <ItemTypeIcon
+              icon={props.kind === "folder" ? IconComponent : undefined}
+              size={16}
+              visual={visual}
+            />
+          </div>
+
+          {/* Name */}
+          <div className="explorer-row-name-cell" role="gridcell">
+            {isRenaming ? (
+              <input
+                ref={renameInputRef}
+                className="explorer-row-rename"
+                value={renameValue}
+                autoFocus
+                onChange={(e) => onRenameChange(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    onRenameSubmit();
+                  }
+                  if (e.key === "Escape") {
+                    e.preventDefault();
+                    onRenameCancel();
+                  }
+                  // Stop propagation so row keyboard handlers don't fire
+                  e.stopPropagation();
+                }}
+                onBlur={onRenameSubmit}
+                onClick={(e) => e.stopPropagation()}
+              />
+            ) : (
+              <>
+                <span className="explorer-row-name" title={name}>
+                  {name}
+                </span>
+                {shareProps.share?.status === "active" && (
+                  <Share2
+                    size={10}
+                    className="explorer-row-share-badge"
+                    aria-label="Shared"
+                  />
+                )}
+              </>
+            )}
+          </div>
+
+          {/* Size */}
+          <span className="explorer-row-meta" role="gridcell">
+            {size}
+          </span>
+
+          {/* Date */}
+          <span
+            className="explorer-row-meta"
+            role="gridcell"
+            suppressHydrationWarning
+          >
+            {date}
+          </span>
+
+          <button
+            aria-label={`Actions for ${name}`}
+            className="explorer-row-mobile-action"
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              setActionSheetOpen(true);
+            }}
+          >
+            <MoreHorizontal size={16} aria-hidden />
+          </button>
+        </div>
+      </DashboardItemContextMenu>
+      <WorkspaceActionSheet
+        groups={contextGroups}
+        itemName={name}
+        open={actionSheetOpen}
+        onOpenChange={setActionSheetOpen}
+      />
+    </>
   );
 }

--- a/apps/web/app/(workspace)/files/files-view.tsx
+++ b/apps/web/app/(workspace)/files/files-view.tsx
@@ -35,6 +35,7 @@ import {
   formatSpeed,
   formatEta,
 } from "../transfer-context";
+import { useCoarsePointer } from "../use-coarse-pointer";
 import type { ShareLinkSummary } from "@/server/sharing";
 
 // ---------------------------------------------------------------------------
@@ -114,6 +115,7 @@ export function FilesView({
   const router = useRouter();
   const pathname = usePathname();
   const rawSearchParams = useSearchParams();
+  const isCoarsePointer = useCoarsePointer();
 
   // ---- Transfer context (upload + download state lives in WorkspaceProvider) ----
   const {
@@ -293,6 +295,17 @@ export function FilesView({
       // the mouseup; ignore it so we don't clobber the band selection.
       if (didRubberBand.current) return;
 
+      if (isCoarsePointer && selectedIdsRef.current.size > 0) {
+        setSelectedIds((prev) => {
+          const next = new Set(prev);
+          if (next.has(id)) next.delete(id);
+          else next.add(id);
+          return next;
+        });
+        setLastSelectedId(id);
+        return;
+      }
+
       if (e.ctrlKey || e.metaKey) {
         setSelectedIds((prev) => {
           const next = new Set(prev);
@@ -313,8 +326,13 @@ export function FilesView({
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [lastSelectedId, allItems.length],
+    [isCoarsePointer, lastSelectedId, allItems.length],
   );
+
+  const selectSingleItem = useCallback((id: string) => {
+    setSelectedIds(new Set([id]));
+    setLastSelectedId(id);
+  }, []);
 
   // ---------------------------------------------------------------------------
   // Keyboard shortcuts
@@ -722,6 +740,7 @@ export function FilesView({
 
   const handleListMouseDown = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
+      if (isCoarsePointer) return;
       if (e.button !== 0) return;
       const target = e.target as HTMLElement;
       // Let rename inputs and buttons handle their own events
@@ -747,7 +766,7 @@ export function FilesView({
       }
       // Row click: wait for drag threshold in the window mousemove handler
     },
-    [],
+    [isCoarsePointer],
   );
 
   // Attach rubber-band move/end handlers to window so they fire even when the
@@ -755,6 +774,7 @@ export function FilesView({
   // are no stale closures and the effect never needs to re-run.
   useEffect(() => {
     const onMove = (e: MouseEvent) => {
+      if (isCoarsePointer) return;
       const container = listRef.current;
       if (!container) return;
 
@@ -848,8 +868,7 @@ export function FilesView({
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [isCoarsePointer]);
 
   // ---------------------------------------------------------------------------
   // Properties panel target
@@ -1188,6 +1207,7 @@ export function FilesView({
                   onRenameSubmit={() => submitRename(folder.id, "folder")}
                   onRenameCancel={cancelRename}
                   onClick={(e) => handleRowClick(folder.id, e)}
+                  onLongPress={() => selectSingleItem(folder.id)}
                   onOpen={() => openItem(folder.id)}
                   onStartRename={() => beginRename(folder.id, folder.name)}
                   onFavorite={() =>
@@ -1249,6 +1269,7 @@ export function FilesView({
                     if (el) rowRefs.current.set(folder.id, el);
                     else rowRefs.current.delete(folder.id);
                   }}
+                  touchMode={isCoarsePointer}
                 />
               );
             })}
@@ -1332,6 +1353,7 @@ export function FilesView({
                   onRenameSubmit={() => submitRename(file.id, "file")}
                   onRenameCancel={cancelRename}
                   onClick={(e) => handleRowClick(file.id, e)}
+                  onLongPress={() => selectSingleItem(file.id)}
                   onOpen={() => openItem(file.id)}
                   onStartRename={() => beginRename(file.id, file.name)}
                   onFavorite={() =>
@@ -1393,10 +1415,40 @@ export function FilesView({
                     if (el) rowRefs.current.set(file.id, el);
                     else rowRefs.current.delete(file.id);
                   }}
+                  touchMode={isCoarsePointer}
                 />
               );
             })}
           </div>
+
+          {isCoarsePointer && selectedIds.size > 0 ? (
+            <div className="workspace-selection-bar" role="region">
+              <span>
+                {selectedIds.size} item{selectedIds.size === 1 ? "" : "s"}
+              </span>
+              <button
+                type="button"
+                onClick={() =>
+                  handleDownload(Array.from(selectedIdsRef.current))
+                }
+              >
+                Download
+              </button>
+              <button type="button" onClick={cutSelectedItems}>
+                Cut
+              </button>
+              <button
+                className="is-danger"
+                type="button"
+                onClick={handleTrashSelected}
+              >
+                Trash
+              </button>
+              <button type="button" onClick={() => setSelectedIds(new Set())}>
+                Clear
+              </button>
+            </div>
+          ) : null}
 
           {/* ---- Drag-to-upload overlay ---- */}
           {isDragOver && (

--- a/apps/web/app/(workspace)/layout.tsx
+++ b/apps/web/app/(workspace)/layout.tsx
@@ -14,6 +14,7 @@ import { readInstanceUpdateCheck } from "@staaash/db/instance";
 
 import { InstanceBadge } from "./instance-badge";
 import { TopbarActions } from "./topbar-actions";
+import { WorkspaceMobileNav } from "./workspace-mobile-nav";
 import { WorkspaceNav } from "./workspace-nav";
 import { WorkspaceStorage } from "./workspace-storage";
 
@@ -145,6 +146,24 @@ export default async function WorkspaceLayout({
           </main>
         </div>
       </div>
+      {session ? (
+        <WorkspaceMobileNav
+          appVersion={appVersion}
+          avatarUrl={session.user.avatarUrl ?? null}
+          diskCapacityBytes={diskCapacityBytes?.toString() ?? null}
+          diskUsedBytes={diskUsedBytes?.toString() ?? null}
+          initials={initials}
+          isOwner={session.user.role === "owner"}
+          latestVersion={instanceUpdateState?.latestAvailableVersion ?? null}
+          limitBytes={limitBytes?.toString() ?? null}
+          nodeVersion={process.version}
+          repository={settings.updateCheckRepository || null}
+          updateStatus={instanceUpdateState?.updateCheckStatus ?? null}
+          usedBytes={usedBytes.toString()}
+          userLabel={userLabel}
+          username={session.user.username}
+        />
+      ) : null}
 
       {/* Toaster outside workspace-shell grid — fixed elements still consume a grid cell. */}
       <Toaster position="bottom-right" richColors />

--- a/apps/web/app/(workspace)/recent/recent-view.tsx
+++ b/apps/web/app/(workspace)/recent/recent-view.tsx
@@ -9,6 +9,7 @@ import {
   useTransition,
   type KeyboardEvent,
   type MouseEvent,
+  type PointerEvent,
 } from "react";
 import { useRouter } from "next/navigation";
 import {
@@ -18,6 +19,7 @@ import {
   ExternalLink,
   Grid2X2,
   List,
+  MoreHorizontal,
   RefreshCw,
   RotateCcw,
   Trash2,
@@ -35,6 +37,8 @@ import { ItemTypeIcon } from "@/app/item-type-icon";
 import { startValidatedDownload } from "@/lib/transfers/download";
 
 import { useTransferContext } from "../transfer-context";
+import { useCoarsePointer } from "../use-coarse-pointer";
+import { WorkspaceActionSheet } from "../workspace-action-sheet";
 import {
   filterRecentItems,
   formatRecentFileSize,
@@ -133,6 +137,7 @@ export function RecentView({ error, items, success }: RecentViewProps) {
   const router = useRouter();
   const [, startTransition] = useTransition();
   const { handleDownload } = useTransferContext();
+  const isCoarsePointer = useCoarsePointer();
   const [viewMode, setViewMode] = useState<RecentViewMode>("list");
   const [filterType, setFilterType] = useState<RecentFilterType>("all");
   const [sortKey, setSortKey] = useState<RecentSortKey>("uploadedAt");
@@ -154,6 +159,10 @@ export function RecentView({ error, items, success }: RecentViewProps) {
   const rubberBandStart = useRef<{ startX: number; startY: number } | null>(
     null,
   );
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const suppressNextClickRef = useRef(false);
+  const [actionSheetItem, setActionSheetItem] =
+    useState<RecentClientItem | null>(null);
 
   const visibleItems = useMemo(() => {
     const itemsWithOptimisticState = items.map((item) => {
@@ -233,6 +242,32 @@ export function RecentView({ error, items, success }: RecentViewProps) {
   ) => {
     event.preventDefault();
     event.stopPropagation();
+    if (suppressNextClickRef.current) {
+      suppressNextClickRef.current = false;
+      return;
+    }
+
+    if (isCoarsePointer) {
+      if (item.deletedAt) {
+        setActionSheetItem(item);
+        return;
+      }
+
+      if (selectedIds.size > 0) {
+        setSelectedIds((current) => {
+          const next = new Set(current);
+          if (next.has(item.id)) next.delete(item.id);
+          else next.add(item.id);
+          return next;
+        });
+        setLastSelectedId(item.id);
+        return;
+      }
+
+      openItem(item);
+      return;
+    }
+
     if (didRubberBand.current || item.deletedAt) return;
 
     if (event.ctrlKey || event.metaKey) {
@@ -431,6 +466,7 @@ export function RecentView({ error, items, success }: RecentViewProps) {
 
   const handleRecentMouseDown = useCallback(
     (event: MouseEvent<HTMLDivElement>) => {
+      if (isCoarsePointer) return;
       if (event.button !== 0) return;
 
       const target = event.target as HTMLElement;
@@ -458,11 +494,37 @@ export function RecentView({ error, items, success }: RecentViewProps) {
         }
       }
     },
-    [],
+    [isCoarsePointer],
   );
+
+  const clearLongPressTimer = () => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  };
+
+  const handleRecentPointerDown = (
+    item: RecentClientItem,
+    event: PointerEvent<HTMLElement>,
+  ) => {
+    if (!isCoarsePointer || event.pointerType === "mouse" || item.deletedAt) {
+      return;
+    }
+    const target = event.target as HTMLElement;
+    if (target.closest("button, input, select, textarea, a")) return;
+    clearLongPressTimer();
+    suppressNextClickRef.current = false;
+    longPressTimerRef.current = setTimeout(() => {
+      suppressNextClickRef.current = true;
+      setSelectedIds(new Set([item.id]));
+      setLastSelectedId(item.id);
+    }, 420);
+  };
 
   useEffect(() => {
     const onMove = (event: globalThis.MouseEvent) => {
+      if (isCoarsePointer) return;
       const container = listRef.current;
       if (!container) return;
 
@@ -554,10 +616,11 @@ export function RecentView({ error, items, success }: RecentViewProps) {
     window.addEventListener("mouseup", onUp);
 
     return () => {
+      clearLongPressTimer();
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
     };
-  }, []);
+  }, [isCoarsePointer]);
 
   const renderSortButton = (
     key: RecentSortKey,
@@ -576,72 +639,85 @@ export function RecentView({ error, items, success }: RecentViewProps) {
     </button>
   );
 
-  const renderItemActions = (item: RecentClientItem) => (
-    <>
-      {item.deletedAt ? (
-        <>
-          <form action={getRestoreHref(item)} method="post">
-            <input name="redirectTo" type="hidden" value="/recent" />
+  const renderItemActions = (item: RecentClientItem) =>
+    isCoarsePointer ? (
+      <button
+        aria-label={`Actions for ${item.name}`}
+        className="recent-action-btn"
+        type="button"
+        onClick={(event) => {
+          event.stopPropagation();
+          setActionSheetItem(item);
+        }}
+      >
+        <MoreHorizontal size={13} aria-hidden />
+      </button>
+    ) : (
+      <>
+        {item.deletedAt ? (
+          <>
+            <form action={getRestoreHref(item)} method="post">
+              <input name="redirectTo" type="hidden" value="/recent" />
+              <button
+                aria-label={`Restore ${item.name}`}
+                className="recent-action-btn"
+                type="submit"
+                onClick={(event) => event.stopPropagation()}
+              >
+                <RotateCcw size={13} aria-hidden />
+              </button>
+            </form>
             <button
-              aria-label={`Restore ${item.name}`}
-              className="recent-action-btn"
-              type="submit"
-              onClick={(event) => event.stopPropagation()}
+              aria-label={`Delete ${item.name} from Trash`}
+              className="recent-action-btn recent-action-btn-danger"
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                router.push(getTrashItemHref(item));
+              }}
             >
-              <RotateCcw size={13} aria-hidden />
+              <Trash2 size={13} aria-hidden />
             </button>
-          </form>
-          <button
-            aria-label={`Delete ${item.name} from Trash`}
-            className="recent-action-btn recent-action-btn-danger"
-            type="button"
-            onClick={(event) => {
-              event.stopPropagation();
-              router.push(getTrashItemHref(item));
-            }}
-          >
-            <Trash2 size={13} aria-hidden />
-          </button>
-        </>
-      ) : (
-        <>
-          <button
-            aria-label={`Open ${item.name}`}
-            className="recent-action-btn"
-            type="button"
-            onClick={(event) => {
-              event.stopPropagation();
-              openItem(item);
-            }}
-          >
-            <ExternalLink size={13} aria-hidden />
-          </button>
-          <button
-            aria-label={`Download ${item.name}`}
-            className="recent-action-btn"
-            type="button"
-            onClick={(event) => {
-              event.stopPropagation();
-              void downloadItem(item);
-            }}
-          >
-            <Download size={13} aria-hidden />
-          </button>
-          <button
-            aria-label={`Move ${item.name} to trash`}
-            className="recent-action-btn recent-action-btn-danger"
-            type="button"
-            onClick={(event) => {
-              event.stopPropagation();
-              void trashItems([item]);
-            }}
-          >
-            <Trash2 size={13} aria-hidden />
-          </button>
-        </>
-      )}
-    </>
-  );
+          </>
+        ) : (
+          <>
+            <button
+              aria-label={`Open ${item.name}`}
+              className="recent-action-btn"
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                openItem(item);
+              }}
+            >
+              <ExternalLink size={13} aria-hidden />
+            </button>
+            <button
+              aria-label={`Download ${item.name}`}
+              className="recent-action-btn"
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                void downloadItem(item);
+              }}
+            >
+              <Download size={13} aria-hidden />
+            </button>
+            <button
+              aria-label={`Move ${item.name} to trash`}
+              className="recent-action-btn recent-action-btn-danger"
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                void trashItems([item]);
+              }}
+            >
+              <Trash2 size={13} aria-hidden />
+            </button>
+          </>
+        )}
+      </>
+    );
 
   const getRecentItemContextGroups = (
     item: RecentClientItem,
@@ -900,6 +976,12 @@ export function RecentView({ error, items, success }: RecentViewProps) {
                         if (deleted) return;
                         openItem(item);
                       }}
+                      onPointerCancel={clearLongPressTimer}
+                      onPointerDown={(event) =>
+                        handleRecentPointerDown(item, event)
+                      }
+                      onPointerLeave={clearLongPressTimer}
+                      onPointerUp={clearLongPressTimer}
                     >
                       <span className="recent-row-thumb">
                         <ItemIcon item={item} />
@@ -1002,6 +1084,12 @@ export function RecentView({ error, items, success }: RecentViewProps) {
                           if (deleted) return;
                           openItem(item);
                         }}
+                        onPointerCancel={clearLongPressTimer}
+                        onPointerDown={(event) =>
+                          handleRecentPointerDown(item, event)
+                        }
+                        onPointerLeave={clearLongPressTimer}
+                        onPointerUp={clearLongPressTimer}
                       >
                         <div
                           className="recent-grid-card-preview"
@@ -1040,6 +1128,48 @@ export function RecentView({ error, items, success }: RecentViewProps) {
           ))}
         </div>
       )}
+      {isCoarsePointer && selectedItems.length > 0 ? (
+        <div className="workspace-selection-bar" role="region">
+          <span>
+            {selectedItems.length} item
+            {selectedItems.length === 1 ? "" : "s"}
+          </span>
+          <button
+            type="button"
+            onClick={() =>
+              void handleDownload(selectedItems.map((item) => item.id))
+            }
+          >
+            Download
+          </button>
+          <button
+            className="is-danger"
+            type="button"
+            onClick={() => void trashItems(selectedItems)}
+          >
+            Trash
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setSelectedIds(new Set());
+              setLastSelectedId(null);
+            }}
+          >
+            Clear
+          </button>
+        </div>
+      ) : null}
+      <WorkspaceActionSheet
+        groups={
+          actionSheetItem ? getRecentItemContextGroups(actionSheetItem) : []
+        }
+        itemName={actionSheetItem?.name}
+        open={actionSheetItem !== null}
+        onOpenChange={(open) => {
+          if (!open) setActionSheetItem(null);
+        }}
+      />
     </DashboardPageContextMenu>
   );
 }

--- a/apps/web/app/(workspace)/search/page.tsx
+++ b/apps/web/app/(workspace)/search/page.tsx
@@ -51,41 +51,42 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
   const success = getSingleSearchParam(resolvedSearchParams, "success");
 
   return (
-    <WorkspacePresetPageContextMenu className="workspace-page" preset="search">
-      <section className="panel stack">
-        <div className="pill">Search</div>
-        <h1>Files search</h1>
-        <p className="muted">
-          Search scans active private files and folders with one mixed ranking
-          across names, extensions, and logical path tokens.
-        </p>
-      </section>
+    <WorkspacePresetPageContextMenu
+      className="workspace-page search-page"
+      preset="search"
+    >
+      <header className="search-header">
+        <div className="search-header-copy">
+          <h1>Search</h1>
+          <p className="muted search-description">
+            Find active files and folders by name, extension, or path segment.
+          </p>
+        </div>
+        {query.length > 0 ? (
+          <span className="section-count">
+            {allItems.length} match{allItems.length === 1 ? "" : "es"}
+          </span>
+        ) : null}
+      </header>
 
       {error ? <FlashMessage>{error}</FlashMessage> : null}
       {success ? <FlashMessage tone="success">{success}</FlashMessage> : null}
 
-      <section className="panel stack">
-        <div className="split">
-          <div className="stack">
-            <h2>Results</h2>
-            <p className="muted">
-              Query:{" "}
-              {query.length > 0 ? (
-                <strong>{query}</strong>
-              ) : (
-                "enter a search above"
-              )}
-            </p>
-          </div>
-          {query.length > 0 ? (
-            <span className="pill">
-              {allItems.length} match{allItems.length === 1 ? "" : "es"}
-            </span>
-          ) : null}
+      <section className="search-results" aria-labelledby="search-results">
+        <div className="search-results-head">
+          <h2 id="search-results">Results</h2>
+          <p className="muted search-query">
+            Query:{" "}
+            {query.length > 0 ? (
+              <strong>{query}</strong>
+            ) : (
+              "enter a search above"
+            )}
+          </p>
         </div>
 
         {query.length === 0 ? (
-          <div className="workspace-empty-state">
+          <div className="workspace-empty-state search-empty-state">
             <h2>Search your files</h2>
             <p className="muted">
               Use the top-bar search field to find active files and folders by

--- a/apps/web/app/(workspace)/shared/shared-table.tsx
+++ b/apps/web/app/(workspace)/shared/shared-table.tsx
@@ -174,136 +174,217 @@ export function SharedTable({ items }: SharedTableProps) {
           <p className="muted">Try a different type.</p>
         </div>
       ) : (
-        <div className="st-wrap">
-          <table className="st-table">
-            <colgroup>
-              <col className="st-col-name" />
-              <col className="st-col-location" />
-              <col className="st-col-type" />
-              <col className="st-col-expires" />
-              <col className="st-col-status" />
-              <col className="st-col-actions" />
-            </colgroup>
-            <thead>
-              <tr>
-                <th className="st-th" scope="col">
-                  Name
-                </th>
-                <th className="st-th" scope="col">
-                  Location
-                </th>
-                <th className="st-th" scope="col">
-                  Type
-                </th>
-                <th className="st-th" scope="col">
-                  Expires
-                </th>
-                <th className="st-th" scope="col">
-                  Status
-                </th>
-                <th className="st-th" scope="col">
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {visibleItems.map(
-                ({
-                  share,
-                  canManage,
-                  expiresLabel,
-                  expiryTone,
-                  statusLabel,
-                }) => {
-                  const locationLabel = getShareLocationLabel(share);
-
-                  return (
-                    <DashboardItemContextMenu
-                      groups={getShareItemContextGroups({
-                        share,
-                        canManage,
-                        expiresLabel,
-                        expiryTone,
-                        statusLabel,
-                      })}
-                      key={share.id}
+        <>
+          <div className="st-card-list">
+            {visibleItems.map(
+              ({ share, canManage, expiresLabel, expiryTone, statusLabel }) => {
+                const locationLabel = getShareLocationLabel(share);
+                return (
+                  <DashboardItemContextMenu
+                    groups={getShareItemContextGroups({
+                      share,
+                      canManage,
+                      expiresLabel,
+                      expiryTone,
+                      statusLabel,
+                    })}
+                    key={share.id}
+                  >
+                    <article
+                      className={`st-card${share.status === "active" ? "" : " st-card--inactive"}`}
+                      id={`mobile-${share.id}`}
                     >
-                      <tr
-                        className={`st-tr${share.status === "active" ? "" : " st-tr--inactive"}`}
-                        id={share.id}
-                      >
-                        <td className="st-td st-name-cell">
-                          <span className="st-name">
-                            <span
-                              className="st-name-text"
-                              title={share.target.name}
-                            >
-                              {share.target.name}
-                            </span>
-                          </span>
-                        </td>
-                        <td className="st-td st-muted">
-                          <span className="st-location" title={locationLabel}>
-                            {locationLabel}
-                          </span>
-                        </td>
-                        <td className="st-td st-muted">
-                          {getShareTypeLabel(share)}
-                        </td>
-                        <td
-                          className={`st-td st-mono st-expires--${expiryTone}`}
+                      <div className="st-card-head">
+                        <span
+                          className="st-name-text"
+                          title={share.target.name}
                         >
-                          {expiresLabel}
-                        </td>
-                        <td className="st-td">
-                          <span
-                            className={`sl-badge sl-badge--${getStatusClass(share.status)}`}
-                          >
-                            {statusLabel}
+                          {share.target.name}
+                        </span>
+                        <span
+                          className={`sl-badge sl-badge--${getStatusClass(share.status)}`}
+                        >
+                          {statusLabel}
+                        </span>
+                      </div>
+                      <dl className="st-card-meta">
+                        <div>
+                          <dt>Location</dt>
+                          <dd>{locationLabel}</dd>
+                        </div>
+                        <div>
+                          <dt>Type</dt>
+                          <dd>{getShareTypeLabel(share)}</dd>
+                        </div>
+                        <div>
+                          <dt>Expires</dt>
+                          <dd className={`st-mono st-expires--${expiryTone}`}>
+                            {expiresLabel}
+                          </dd>
+                        </div>
+                      </dl>
+                      <div className="st-card-actions">
+                        <button
+                          className="st-action"
+                          disabled={!canManage}
+                          onClick={() =>
+                            setShareDialogTarget({
+                              targetType: share.target.targetType,
+                              targetId: share.target.id,
+                              share,
+                            })
+                          }
+                          type="button"
+                        >
+                          Manage
+                        </button>
+                        {share.hasPassword ? (
+                          <span className="st-password-hint">
+                            <KeyRound
+                              aria-label="Password protected"
+                              size={13}
+                            />
                           </span>
-                        </td>
-                        <td className="st-td">
-                          <div className="st-actions">
-                            <button
-                              className="st-action"
-                              disabled={!canManage}
-                              onClick={() =>
-                                setShareDialogTarget({
-                                  targetType: share.target.targetType,
-                                  targetId: share.target.id,
-                                  share,
-                                })
-                              }
-                              type="button"
-                            >
-                              Manage
-                            </button>
-                            <span
-                              aria-hidden={!share.hasPassword}
-                              className="st-password-hint"
-                              title={
-                                share.hasPassword
-                                  ? "Password protected"
-                                  : undefined
-                              }
-                            >
-                              {share.hasPassword ? (
-                                <KeyRound
-                                  aria-label="Password protected"
-                                  size={13}
-                                />
-                              ) : null}
+                        ) : null}
+                      </div>
+                    </article>
+                  </DashboardItemContextMenu>
+                );
+              },
+            )}
+          </div>
+
+          <div className="st-wrap">
+            <table className="st-table">
+              <colgroup>
+                <col className="st-col-name" />
+                <col className="st-col-location" />
+                <col className="st-col-type" />
+                <col className="st-col-expires" />
+                <col className="st-col-status" />
+                <col className="st-col-actions" />
+              </colgroup>
+              <thead>
+                <tr>
+                  <th className="st-th" scope="col">
+                    Name
+                  </th>
+                  <th className="st-th" scope="col">
+                    Location
+                  </th>
+                  <th className="st-th" scope="col">
+                    Type
+                  </th>
+                  <th className="st-th" scope="col">
+                    Expires
+                  </th>
+                  <th className="st-th" scope="col">
+                    Status
+                  </th>
+                  <th className="st-th" scope="col">
+                    Actions
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleItems.map(
+                  ({
+                    share,
+                    canManage,
+                    expiresLabel,
+                    expiryTone,
+                    statusLabel,
+                  }) => {
+                    const locationLabel = getShareLocationLabel(share);
+
+                    return (
+                      <DashboardItemContextMenu
+                        groups={getShareItemContextGroups({
+                          share,
+                          canManage,
+                          expiresLabel,
+                          expiryTone,
+                          statusLabel,
+                        })}
+                        key={share.id}
+                      >
+                        <tr
+                          className={`st-tr${share.status === "active" ? "" : " st-tr--inactive"}`}
+                          id={share.id}
+                        >
+                          <td className="st-td st-name-cell">
+                            <span className="st-name">
+                              <span
+                                className="st-name-text"
+                                title={share.target.name}
+                              >
+                                {share.target.name}
+                              </span>
                             </span>
-                          </div>
-                        </td>
-                      </tr>
-                    </DashboardItemContextMenu>
-                  );
-                },
-              )}
-            </tbody>
-          </table>
-        </div>
+                          </td>
+                          <td className="st-td st-muted">
+                            <span className="st-location" title={locationLabel}>
+                              {locationLabel}
+                            </span>
+                          </td>
+                          <td className="st-td st-muted">
+                            {getShareTypeLabel(share)}
+                          </td>
+                          <td
+                            className={`st-td st-mono st-expires--${expiryTone}`}
+                          >
+                            {expiresLabel}
+                          </td>
+                          <td className="st-td">
+                            <span
+                              className={`sl-badge sl-badge--${getStatusClass(share.status)}`}
+                            >
+                              {statusLabel}
+                            </span>
+                          </td>
+                          <td className="st-td">
+                            <div className="st-actions">
+                              <button
+                                className="st-action"
+                                disabled={!canManage}
+                                onClick={() =>
+                                  setShareDialogTarget({
+                                    targetType: share.target.targetType,
+                                    targetId: share.target.id,
+                                    share,
+                                  })
+                                }
+                                type="button"
+                              >
+                                Manage
+                              </button>
+                              <span
+                                aria-hidden={!share.hasPassword}
+                                className="st-password-hint"
+                                title={
+                                  share.hasPassword
+                                    ? "Password protected"
+                                    : undefined
+                                }
+                              >
+                                {share.hasPassword ? (
+                                  <KeyRound
+                                    aria-label="Password protected"
+                                    size={13}
+                                  />
+                                ) : null}
+                              </span>
+                            </div>
+                          </td>
+                        </tr>
+                      </DashboardItemContextMenu>
+                    );
+                  },
+                )}
+              </tbody>
+            </table>
+          </div>
+        </>
       )}
 
       {shareDialogTarget ? (

--- a/apps/web/app/(workspace)/use-coarse-pointer.ts
+++ b/apps/web/app/(workspace)/use-coarse-pointer.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useCoarsePointer() {
+  const [isCoarsePointer, setIsCoarsePointer] = useState(false);
+
+  useEffect(() => {
+    const query = window.matchMedia("(pointer: coarse)");
+    const sync = () => setIsCoarsePointer(query.matches);
+    sync();
+    query.addEventListener("change", sync);
+    return () => query.removeEventListener("change", sync);
+  }, []);
+
+  return isCoarsePointer;
+}

--- a/apps/web/app/(workspace)/workspace-action-sheet.tsx
+++ b/apps/web/app/(workspace)/workspace-action-sheet.tsx
@@ -33,8 +33,13 @@ export function WorkspaceActionSheet({
       <DialogContent
         className="workspace-bottom-sheet workspace-action-sheet"
         showCloseButton={false}
+        onSwipeClose={() => onOpenChange(false)}
       >
-        <div className="workspace-bottom-sheet-handle" aria-hidden />
+        <div
+          className="workspace-bottom-sheet-handle"
+          data-bottom-sheet-drag-handle
+          aria-hidden
+        />
         <div className="workspace-action-sheet-head">
           <DialogTitle className="workspace-action-sheet-title">
             {title}

--- a/apps/web/app/(workspace)/workspace-action-sheet.tsx
+++ b/apps/web/app/(workspace)/workspace-action-sheet.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { Fragment } from "react";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { getVisibleDashboardMenuGroups } from "@/app/dashboard-context-menu-model";
+import type { DashboardContextMenuGroup } from "@/app/dashboard-context-menu";
+
+type WorkspaceActionSheetProps = {
+  groups: DashboardContextMenuGroup[];
+  itemName?: string;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  title?: string;
+};
+
+export function WorkspaceActionSheet({
+  groups,
+  itemName,
+  onOpenChange,
+  open,
+  title = "Actions",
+}: WorkspaceActionSheetProps) {
+  const visibleGroups = getVisibleDashboardMenuGroups(groups);
+
+  const runAction = (action: { disabled?: boolean; onSelect?: () => void }) => {
+    if (action.disabled) return;
+    action.onSelect?.();
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="workspace-bottom-sheet workspace-action-sheet"
+        showCloseButton={false}
+      >
+        <div className="workspace-bottom-sheet-handle" aria-hidden />
+        <div className="workspace-action-sheet-head">
+          <DialogTitle className="workspace-action-sheet-title">
+            {title}
+          </DialogTitle>
+          {itemName ? (
+            <p className="workspace-action-sheet-subtitle">{itemName}</p>
+          ) : null}
+        </div>
+
+        <div className="workspace-action-sheet-groups">
+          {visibleGroups.map((group, groupIndex) => (
+            <div className="workspace-action-sheet-group" key={groupIndex}>
+              {group.actions.map((action) => (
+                <Fragment key={action.label}>
+                  {action.subActions && action.subActions.length > 0 ? (
+                    <details className="workspace-action-sheet-details">
+                      <summary
+                        className={`workspace-action-sheet-item${action.disabled ? " is-disabled" : ""}`}
+                      >
+                        <span className="workspace-action-sheet-icon">
+                          {action.icon}
+                        </span>
+                        <span>{action.label}</span>
+                      </summary>
+                      <div className="workspace-action-sheet-subitems">
+                        {getVisibleDashboardMenuGroups([
+                          { actions: action.subActions },
+                        ])[0]?.actions.map((subAction) => (
+                          <button
+                            className="workspace-action-sheet-subitem"
+                            disabled={subAction.disabled}
+                            key={subAction.label}
+                            type="button"
+                            onClick={() => runAction(subAction)}
+                          >
+                            {subAction.label}
+                          </button>
+                        ))}
+                      </div>
+                    </details>
+                  ) : (
+                    <button
+                      className={`workspace-action-sheet-item${action.destructive ? " is-destructive" : ""}`}
+                      disabled={action.disabled}
+                      type="button"
+                      onClick={() => runAction(action)}
+                    >
+                      <span className="workspace-action-sheet-icon">
+                        {action.icon}
+                      </span>
+                      <span>{action.label}</span>
+                      {action.shortcut ? (
+                        <span className="workspace-action-sheet-shortcut">
+                          {action.shortcut}
+                        </span>
+                      ) : null}
+                    </button>
+                  )}
+                </Fragment>
+              ))}
+            </div>
+          ))}
+        </div>
+
+        <button
+          className="workspace-action-sheet-cancel"
+          type="button"
+          onClick={() => onOpenChange(false)}
+        >
+          Cancel
+        </button>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/app/(workspace)/workspace-mobile-nav.tsx
+++ b/apps/web/app/(workspace)/workspace-mobile-nav.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  Home,
+  FolderOpen,
+  MoreHorizontal,
+  Search,
+  Upload,
+  Wrench,
+  Settings2,
+  LogOut,
+} from "lucide-react";
+import { useState } from "react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+import { InstanceBadge } from "./instance-badge";
+import { WorkspaceStorage } from "./workspace-storage";
+import { workspaceNavGroups, type WorkspaceNavItem } from "./workspace-nav";
+
+type UpdateStatus =
+  | "up-to-date"
+  | "update-available"
+  | "unavailable"
+  | "error"
+  | null;
+
+type WorkspaceMobileNavProps = {
+  appVersion: string;
+  avatarUrl: string | null;
+  diskCapacityBytes: string | null;
+  diskUsedBytes: string | null;
+  initials: string;
+  isOwner: boolean;
+  latestVersion: string | null;
+  limitBytes: string | null;
+  nodeVersion: string;
+  repository: string | null;
+  updateStatus: UpdateStatus;
+  usedBytes: string;
+  userLabel: string | null;
+  username: string;
+};
+
+const primaryItems = [
+  { href: "/home", label: "Home", icon: Home },
+  { href: "/files", label: "Files", icon: FolderOpen, matchPrefix: "/files" },
+  { href: "/search", label: "Search", icon: Search },
+] satisfies WorkspaceNavItem[];
+
+const moreItems = workspaceNavGroups
+  .flatMap((group) => group.items)
+  .filter(
+    (item) => !primaryItems.some((primary) => primary.href === item.href),
+  );
+
+const isItemActive = (pathname: string, item: WorkspaceNavItem) => {
+  const prefix = item.matchPrefix ?? item.href;
+  return pathname === item.href || pathname.startsWith(`${prefix}/`);
+};
+
+function UploadButton() {
+  return (
+    <button
+      className="workspace-mobile-nav-item"
+      type="button"
+      onClick={() => window.dispatchEvent(new Event("staaash:upload-click"))}
+    >
+      <Upload size={18} strokeWidth={2} aria-hidden />
+      <span>Upload</span>
+    </button>
+  );
+}
+
+export function WorkspaceMobileNav(props: WorkspaceMobileNavProps) {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <nav className="workspace-mobile-nav" aria-label="Workspace mobile">
+      {primaryItems.map((item) => {
+        const Icon = item.icon;
+        const active = isItemActive(pathname, item);
+
+        return (
+          <Link
+            aria-current={active ? "page" : undefined}
+            className={`workspace-mobile-nav-item${active ? " is-active" : ""}`}
+            href={item.href}
+            key={item.href}
+          >
+            <Icon size={18} strokeWidth={2} aria-hidden />
+            <span>{item.label}</span>
+          </Link>
+        );
+      })}
+
+      <UploadButton />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogTrigger className="workspace-mobile-nav-item" aria-label="More">
+          <MoreHorizontal size={18} strokeWidth={2} aria-hidden />
+          <span>More</span>
+        </DialogTrigger>
+        <DialogContent
+          className="workspace-bottom-sheet workspace-more-sheet"
+          showCloseButton={false}
+        >
+          <div className="workspace-bottom-sheet-handle" aria-hidden />
+          <div className="workspace-more-head">
+            <DialogTitle className="workspace-more-title">Staaash</DialogTitle>
+            <span className="workspace-more-user">
+              {props.userLabel ?? `@${props.username}`}
+            </span>
+          </div>
+
+          <div className="workspace-more-profile">
+            <span className="workspace-avatar" aria-hidden>
+              {props.avatarUrl ? (
+                <img
+                  src={props.avatarUrl}
+                  alt=""
+                  className="workspace-avatar-img"
+                />
+              ) : (
+                <span className="workspace-avatar-initials">
+                  {props.initials}
+                </span>
+              )}
+            </span>
+            <div>
+              <span className="workspace-more-profile-name">
+                {props.userLabel ?? props.username}
+              </span>
+              <span className="workspace-more-profile-meta">
+                @{props.username}
+              </span>
+            </div>
+          </div>
+
+          <div className="workspace-more-links">
+            {moreItems.map((item) => {
+              const Icon = item.icon;
+              const active = isItemActive(pathname, item);
+              return (
+                <Link
+                  aria-current={active ? "page" : undefined}
+                  className={`workspace-more-link${active ? " is-active" : ""}`}
+                  href={item.href}
+                  key={item.href}
+                  onClick={() => setOpen(false)}
+                >
+                  <Icon size={17} strokeWidth={1.9} aria-hidden />
+                  <span>{item.label}</span>
+                </Link>
+              );
+            })}
+          </div>
+
+          <div className="workspace-more-storage">
+            <WorkspaceStorage
+              usedBytes={props.usedBytes}
+              limitBytes={props.limitBytes}
+              diskUsedBytes={props.diskUsedBytes}
+              diskCapacityBytes={props.diskCapacityBytes}
+              isAdmin={props.isOwner}
+            />
+          </div>
+
+          <div className="workspace-more-system">
+            <InstanceBadge
+              appVersion={props.appVersion}
+              nodeVersion={props.nodeVersion}
+              updateStatus={props.updateStatus}
+              latestVersion={props.latestVersion}
+              repository={props.repository}
+            />
+          </div>
+
+          <div className="workspace-more-actions">
+            <Link
+              className="workspace-more-action"
+              href="/settings"
+              onClick={() => setOpen(false)}
+            >
+              <Settings2 size={16} aria-hidden />
+              Settings
+            </Link>
+            {props.isOwner ? (
+              <Link
+                className="workspace-more-action"
+                href="/admin"
+                onClick={() => setOpen(false)}
+              >
+                <Wrench size={16} aria-hidden />
+                Admin
+              </Link>
+            ) : null}
+            <form action="/api/auth/sign-out" method="post">
+              <input type="hidden" name="next" value="/" />
+              <button
+                className="workspace-more-action workspace-more-action-danger"
+                type="submit"
+              >
+                <LogOut size={16} aria-hidden />
+                Sign out
+              </button>
+            </form>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </nav>
+  );
+}

--- a/apps/web/app/(workspace)/workspace-mobile-nav.tsx
+++ b/apps/web/app/(workspace)/workspace-mobile-nav.tsx
@@ -112,13 +112,15 @@ export function WorkspaceMobileNav(props: WorkspaceMobileNavProps) {
         <DialogContent
           className="workspace-bottom-sheet workspace-more-sheet"
           showCloseButton={false}
+          onSwipeClose={() => setOpen(false)}
         >
-          <div className="workspace-bottom-sheet-handle" aria-hidden />
+          <div
+            className="workspace-bottom-sheet-handle"
+            data-bottom-sheet-drag-handle
+            aria-hidden
+          />
           <div className="workspace-more-head">
             <DialogTitle className="workspace-more-title">Staaash</DialogTitle>
-            <span className="workspace-more-user">
-              {props.userLabel ?? `@${props.username}`}
-            </span>
           </div>
 
           <div className="workspace-more-profile">

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -7641,3 +7641,712 @@ main.share-locked-page {
     transition: none;
   }
 }
+
+/* ---- Mobile/tablet workspace support ---- */
+
+.workspace-mobile-nav {
+  display: none;
+}
+
+[data-slot="dialog-content"].workspace-bottom-sheet {
+  top: auto;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  max-width: none;
+  max-height: min(82dvh, 680px);
+  translate: none;
+  transform: none;
+  overflow-y: auto;
+  border-radius: 18px 18px 0 0;
+  padding: 10px 14px max(18px, env(safe-area-inset-bottom));
+  background: var(--popover);
+}
+
+.workspace-bottom-sheet-handle {
+  width: 38px;
+  height: 4px;
+  margin: 0 auto 10px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--foreground) 18%, transparent);
+}
+
+.workspace-more-head,
+.workspace-action-sheet-head {
+  display: grid;
+  gap: 3px;
+  padding: 0 4px 12px;
+}
+
+.workspace-more-title,
+.workspace-action-sheet-title {
+  margin: 0;
+  font-family: var(--font-cabinet), sans-serif;
+  font-size: 1.05rem;
+  font-weight: 650;
+  line-height: 1.2;
+}
+
+.workspace-more-user,
+.workspace-action-sheet-subtitle {
+  overflow: hidden;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-more-profile {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 4px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.workspace-more-profile-name,
+.workspace-more-profile-meta {
+  display: block;
+  line-height: 1.25;
+}
+
+.workspace-more-profile-name {
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.workspace-more-profile-meta {
+  color: var(--muted-foreground);
+  font-size: 12px;
+}
+
+.workspace-more-links,
+.workspace-more-actions,
+.workspace-action-sheet-groups {
+  display: grid;
+  gap: 8px;
+  padding: 12px 0;
+}
+
+.workspace-more-link,
+.workspace-more-action,
+.workspace-action-sheet-item,
+.workspace-action-sheet-cancel {
+  display: flex;
+  min-height: 44px;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 0 12px;
+  border: 0;
+  border-radius: 10px;
+  background: color-mix(in oklab, var(--foreground) 4%, transparent);
+  color: var(--foreground);
+  font: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  text-align: left;
+}
+
+.workspace-more-link.is-active {
+  background: color-mix(in oklab, var(--primary) 12%, transparent);
+  color: color-mix(in oklab, var(--primary) 82%, var(--foreground) 18%);
+}
+
+.workspace-more-action-danger,
+.workspace-action-sheet-item.is-destructive {
+  color: var(--destructive);
+}
+
+.workspace-more-actions form {
+  display: contents;
+}
+
+.workspace-more-storage,
+.workspace-more-system {
+  padding: 12px 4px;
+  border-top: 1px solid var(--border);
+}
+
+.workspace-more-system .instance-badge-trigger {
+  width: auto;
+}
+
+.workspace-action-sheet-group {
+  display: grid;
+  gap: 6px;
+}
+
+.workspace-action-sheet-icon {
+  display: inline-flex;
+  width: 18px;
+  justify-content: center;
+  color: var(--muted-foreground);
+}
+
+.workspace-action-sheet-shortcut {
+  margin-left: auto;
+  color: var(--muted-foreground);
+  font-size: 12px;
+}
+
+.workspace-action-sheet-details {
+  display: grid;
+}
+
+.workspace-action-sheet-details > summary {
+  list-style: none;
+}
+
+.workspace-action-sheet-details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.workspace-action-sheet-subitems {
+  display: grid;
+  gap: 4px;
+  padding: 6px 0 2px 42px;
+}
+
+.workspace-action-sheet-subitem {
+  min-height: 38px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--foreground);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 550;
+  text-align: left;
+}
+
+.workspace-action-sheet-item:disabled,
+.workspace-action-sheet-subitem:disabled,
+.workspace-action-sheet-item.is-disabled {
+  opacity: 0.45;
+}
+
+.workspace-action-sheet-cancel {
+  justify-content: center;
+  margin-top: 4px;
+  background: transparent;
+  color: var(--muted-foreground);
+}
+
+.workspace-selection-bar {
+  position: fixed;
+  right: 10px;
+  bottom: calc(72px + env(safe-area-inset-bottom));
+  left: 10px;
+  z-index: 38;
+  display: none;
+  align-items: center;
+  gap: 6px;
+  min-height: 52px;
+  padding: 7px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: color-mix(in oklab, var(--card) 96%, var(--foreground) 4%);
+  box-shadow: 0 10px 26px
+    color-mix(in oklab, var(--foreground) 16%, transparent);
+}
+
+.workspace-selection-bar span {
+  min-width: 0;
+  flex: 1;
+  padding-left: 8px;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.workspace-selection-bar button {
+  min-height: 38px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 9px;
+  background: color-mix(in oklab, var(--foreground) 7%, transparent);
+  color: var(--foreground);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.workspace-selection-bar button.is-danger {
+  color: var(--destructive);
+}
+
+.explorer-row-mobile-action {
+  display: none;
+}
+
+.st-card-list {
+  display: none;
+}
+
+@media (max-width: 1023px) {
+  .workspace-shell {
+    height: 100dvh;
+    grid-template-columns: 1fr;
+    grid-template-rows: 100dvh;
+  }
+
+  .workspace-sidebar {
+    display: none;
+  }
+
+  .workspace-main {
+    min-height: 0;
+  }
+
+  .workspace-mobile-nav {
+    position: fixed;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 36;
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 2px;
+    padding: 7px max(8px, env(safe-area-inset-left))
+      max(7px, env(safe-area-inset-bottom)) max(8px, env(safe-area-inset-right));
+    border-top: 1px solid var(--border);
+    background: color-mix(in oklab, var(--background) 94%, var(--card) 6%);
+  }
+
+  .workspace-mobile-nav-item {
+    display: flex;
+    min-width: 0;
+    min-height: 50px;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    padding: 4px 2px;
+    border: 0;
+    border-radius: 10px;
+    background: transparent;
+    color: color-mix(in oklab, var(--muted-foreground) 85%, transparent);
+    font: inherit;
+    font-size: 11px;
+    font-weight: 650;
+    line-height: 1;
+  }
+
+  .workspace-mobile-nav-item.is-active,
+  .workspace-mobile-nav-item[aria-expanded="true"] {
+    background: color-mix(in oklab, var(--primary) 10%, transparent);
+    color: color-mix(in oklab, var(--primary) 82%, var(--foreground) 18%);
+  }
+
+  .workspace-topbar {
+    gap: 8px;
+    padding: 9px 14px;
+  }
+
+  .workspace-search {
+    flex-basis: min(100%, 260px);
+    min-height: 40px;
+  }
+
+  .topbar-icon-btn {
+    min-width: 40px;
+    height: 40px;
+    justify-content: center;
+    padding: 0 10px;
+  }
+
+  .topbar-icon-btn span {
+    display: none;
+  }
+
+  .workspace-main > main.workspace-content,
+  .workspace-content {
+    width: 100%;
+    padding: 18px 16px calc(96px + env(safe-area-inset-bottom));
+    overflow-x: hidden;
+  }
+
+  .workspace-page,
+  .explorer-root,
+  .recent-page,
+  .favorites-page,
+  .sl-page {
+    min-width: 0;
+  }
+
+  .workspace-selection-bar {
+    display: flex;
+  }
+
+  .transfer-panel {
+    right: 10px;
+    bottom: calc(76px + env(safe-area-inset-bottom));
+    left: 10px;
+    width: auto;
+    max-width: none;
+    border-radius: 14px;
+  }
+}
+
+@media (min-width: 768px) and (max-width: 1023px) and (orientation: landscape) {
+  .workspace-shell {
+    grid-template-columns: 72px minmax(0, 1fr);
+  }
+
+  .workspace-sidebar {
+    display: flex;
+    padding: 14px 8px;
+  }
+
+  .workspace-brand-area {
+    padding: 0 0 16px;
+    text-align: center;
+  }
+
+  .workspace-brand {
+    font-size: 0;
+  }
+
+  .workspace-brand::before {
+    content: "S";
+    font-size: 25px;
+  }
+
+  .workspace-nav-label,
+  .workspace-nav-link span,
+  .workspace-user-panel,
+  .workspace-instance-footer {
+    display: none;
+  }
+
+  .workspace-nav-link {
+    justify-content: center;
+    min-height: 46px;
+    padding: 0;
+  }
+
+  .workspace-nav-icon {
+    width: 19px;
+    height: 19px;
+  }
+
+  .workspace-mobile-nav {
+    display: none;
+  }
+
+  .workspace-main > main.workspace-content,
+  .workspace-content {
+    padding-bottom: 48px;
+  }
+
+  .workspace-selection-bar,
+  .transfer-panel {
+    bottom: 14px;
+    left: 86px;
+  }
+}
+
+@media (max-width: 720px), (pointer: coarse) {
+  .explorer-col-header,
+  .recent-col-head,
+  .favorites-col-head {
+    display: none;
+  }
+
+  .explorer-list,
+  .recent-table-wrap,
+  .favorites-list-wrap {
+    padding-bottom: 90px;
+  }
+
+  .explorer-row {
+    grid-template-columns: 34px minmax(0, 1fr) 42px;
+    min-height: 56px;
+    padding: 7px 4px;
+    touch-action: manipulation;
+  }
+
+  .explorer-row-name-cell {
+    grid-column: 2;
+  }
+
+  .explorer-row-meta {
+    display: none;
+  }
+
+  .explorer-row-mobile-action {
+    display: inline-flex;
+    grid-column: 3;
+    align-items: center;
+    justify-content: center;
+    width: 38px;
+    height: 38px;
+    border: 0;
+    border-radius: 9px;
+    background: transparent;
+    color: var(--muted-foreground);
+  }
+
+  .explorer-row-name {
+    font-size: 15px;
+  }
+
+  .explorer-header {
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .explorer-title-row {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .explorer-header-actions {
+    width: 100%;
+  }
+
+  .explorer-header-actions [data-slot="popover-trigger"] {
+    width: 100%;
+    min-height: 42px;
+  }
+
+  .explorer-empty {
+    min-height: 180px;
+    padding: 28px 14px;
+  }
+
+  .recent-row,
+  .favorites-row,
+  .trash-row {
+    grid-template-columns: 32px minmax(0, 1fr) 44px;
+    min-height: 62px;
+    padding: 8px 2px;
+    touch-action: manipulation;
+  }
+
+  .recent-row-location,
+  .recent-row-size,
+  .recent-row-time,
+  .favorites-row-location,
+  .favorites-row-size,
+  .favorites-row-time,
+  .trash-row .recent-row-time {
+    display: none;
+  }
+
+  .recent-row-actions,
+  .recent-row-inline-actions,
+  .favorites-row-actions,
+  .trash-row-actions {
+    position: static;
+    grid-column: 3;
+    justify-self: end;
+    opacity: 1;
+    pointer-events: auto;
+    transform: none;
+    box-shadow: none;
+  }
+
+  .recent-action-btn,
+  .favorites-action-btn {
+    width: 38px;
+    height: 38px;
+  }
+
+  .recent-grid-cards,
+  .favorites-grid-cards {
+    grid-template-columns: repeat(auto-fill, minmax(148px, 1fr));
+    padding-bottom: 90px;
+  }
+
+  .recent-grid-card-actions,
+  .favorites-grid-actions {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .recent-toolbar,
+  .favorites-toolbar,
+  .shared-toolbar {
+    align-items: stretch;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .recent-filter-label,
+  .favorites-filter-control {
+    min-height: 42px;
+    flex: 1 1 160px;
+  }
+
+  .recent-type-select,
+  .favorites-filter-control select {
+    flex: 1;
+  }
+
+  .retrieval-row-main {
+    padding: 12px 10px 4px;
+  }
+
+  .retrieval-row-sub {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 8px;
+    padding: 4px 10px 12px;
+  }
+
+  .retrieval-row-actions {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .retrieval-row-actions .button,
+  .retrieval-row-actions button {
+    min-height: 38px;
+  }
+}
+
+@media (max-width: 560px) {
+  .workspace-main > main.workspace-content,
+  .workspace-content {
+    padding-inline: 12px;
+  }
+
+  .workspace-topbar {
+    align-items: stretch;
+  }
+
+  .workspace-search {
+    flex-basis: 100%;
+  }
+
+  .workspace-topbar-tools {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .workspace-breadcrumb-active,
+  .recent-header h1,
+  .favorites-header h1,
+  .shared-header h1 {
+    font-size: 1.28rem;
+  }
+
+  .home-top-grid,
+  .home-bottom-grid,
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .panel {
+    padding: 16px;
+    border-radius: 14px;
+  }
+
+  .split {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .cluster {
+    align-items: stretch;
+  }
+
+  .cluster > * {
+    justify-content: center;
+  }
+
+  .trash-header-action {
+    width: 100%;
+  }
+
+  .trash-header-action .button {
+    width: 100%;
+    min-height: 42px;
+  }
+
+  .st-wrap {
+    display: none;
+  }
+
+  .st-card-list {
+    display: grid;
+    gap: 10px;
+  }
+
+  .st-card {
+    display: grid;
+    gap: 12px;
+    padding: 12px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: color-mix(in oklab, var(--foreground) 3%, transparent);
+  }
+
+  .st-card--inactive {
+    opacity: 0.62;
+  }
+
+  .st-card-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+  }
+
+  .st-card-meta {
+    display: grid;
+    gap: 8px;
+    margin: 0;
+  }
+
+  .st-card-meta div {
+    display: grid;
+    gap: 2px;
+  }
+
+  .st-card-meta dt {
+    color: var(--muted-foreground);
+    font-size: 11px;
+    font-weight: 650;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .st-card-meta dd {
+    min-width: 0;
+    margin: 0;
+    overflow: hidden;
+    color: var(--foreground);
+    font-size: 13px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .st-card-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .st-card-actions .st-action {
+    min-height: 38px;
+    padding-inline: 14px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspace-bottom-sheet,
+  .workspace-mobile-nav-item,
+  .workspace-selection-bar,
+  .transfer-panel,
+  .explorer-row,
+  .recent-row,
+  .favorites-row {
+    transition: none;
+  }
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1578,6 +1578,93 @@ h3 {
   background: color-mix(in oklab, var(--foreground) 2%, var(--card));
 }
 
+/* ---- Search ---- */
+
+.search-page {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-height: 0;
+}
+
+.search-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--foreground) 7%, transparent);
+}
+
+.search-header-copy {
+  display: grid;
+  min-width: 0;
+  gap: 6px;
+}
+
+.search-header h1 {
+  margin: 0;
+  color: var(--foreground);
+  font-family: var(--font-cabinet), sans-serif;
+  font-size: 1.45rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+}
+
+.search-description {
+  max-width: 58ch;
+  font-size: 13.5px;
+  line-height: 1.5;
+}
+
+.search-results {
+  display: grid;
+  gap: 14px;
+}
+
+.search-results-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px 14px;
+  flex-wrap: wrap;
+}
+
+.search-results-head h2 {
+  color: color-mix(in oklab, var(--muted-foreground) 80%, transparent);
+  font-family: var(--font-switzer), "Segoe UI", sans-serif;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.search-query {
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.search-query strong {
+  color: var(--foreground);
+  font-weight: 650;
+}
+
+.search-empty-state h2 {
+  color: var(--foreground);
+  font-family: var(--font-switzer), "Segoe UI", sans-serif;
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.search-empty-state p {
+  max-width: 48ch;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
 /* ---- Home dashboard ---- */
 
 .home-page {
@@ -4108,6 +4195,18 @@ h3 {
   --sidebar-ring: oklch(0.82 0.06 80);
 }
 
+html.dark {
+  color-scheme: dark;
+  background: oklch(0.12 0.008 70);
+  color: oklch(0.95 0.008 78);
+}
+
+html.light {
+  color-scheme: light;
+  background: oklch(0.982 0.006 78);
+  color: oklch(0.21 0.015 72);
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     color-scheme: dark;
@@ -4155,7 +4254,7 @@ h3 {
   }
   html {
     @apply font-sans;
-    background: oklch(8% 0.008 70);
+    background: var(--background);
   }
 }
 
@@ -7654,14 +7753,17 @@ main.share-locked-page {
   bottom: 0 !important;
   left: 0 !important;
   box-sizing: border-box;
-  width: 100dvw !important;
+  width: auto !important;
   min-width: 0;
-  max-width: 100dvw !important;
-  max-height: min(82dvh, 680px);
+  max-width: none !important;
+  max-height: min(82svh, 680px);
+  gap: 0 !important;
   margin: 0 !important;
-  translate: none !important;
-  transform: none !important;
+  translate: 0 0 !important;
+  transform: translateY(var(--bottom-sheet-drag-y, 0px)) !important;
+  scale: none !important;
   overflow-y: auto;
+  overscroll-behavior: contain;
   border-right: 0;
   border-bottom: 0;
   border-left: 0;
@@ -7669,15 +7771,41 @@ main.share-locked-page {
   padding: 10px 14px max(18px, env(safe-area-inset-bottom));
   background: var(--popover);
   box-shadow: none;
-  animation-name: none !important;
+  transition: transform 180ms cubic-bezier(0.22, 1, 0.36, 1);
+  transform-origin: center bottom !important;
+  will-change: transform;
+  animation: none !important;
+}
+
+[data-slot="dialog-content"].workspace-bottom-sheet[data-closing="true"] {
+  pointer-events: none;
 }
 
 .workspace-bottom-sheet-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: auto;
+  height: 34px;
+  margin: -6px -14px 6px;
+  border-radius: 18px 18px 0 0;
+  background: transparent;
+  cursor: grab;
+  touch-action: none;
+  -webkit-touch-callout: none;
+  user-select: none;
+}
+
+.workspace-bottom-sheet-handle::before {
   width: 38px;
   height: 4px;
-  margin: 0 auto 10px;
   border-radius: 999px;
   background: color-mix(in oklab, var(--foreground) 18%, transparent);
+  content: "";
+}
+
+.workspace-bottom-sheet[data-dragging="true"] .workspace-bottom-sheet-handle {
+  cursor: grabbing;
 }
 
 .workspace-more-head,
@@ -7685,6 +7813,13 @@ main.share-locked-page {
   display: grid;
   gap: 3px;
   padding: 0 4px 12px;
+  touch-action: none;
+  user-select: none;
+}
+
+.workspace-bottom-sheet[data-dragging="true"] .workspace-more-head,
+.workspace-bottom-sheet[data-dragging="true"] .workspace-action-sheet-head {
+  cursor: grabbing;
 }
 
 .workspace-more-title,
@@ -7897,6 +8032,7 @@ main.share-locked-page {
 @media (max-width: 1023px) {
   .workspace-shell {
     height: 100dvh;
+    width: 100%;
     grid-template-columns: 1fr;
     grid-template-rows: 100dvh;
   }
@@ -7906,7 +8042,10 @@ main.share-locked-page {
   }
 
   .workspace-main {
+    height: 100dvh;
     min-height: 0;
+    overflow: hidden;
+    padding: 0;
   }
 
   .workspace-mobile-nav {
@@ -7979,6 +8118,7 @@ main.share-locked-page {
 
   .workspace-page,
   .explorer-root,
+  .search-page,
   .recent-page,
   .favorites-page,
   .sl-page {
@@ -8237,7 +8377,14 @@ main.share-locked-page {
     justify-content: flex-end;
   }
 
+  .search-header,
+  .search-results-head {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
   .workspace-breadcrumb-active,
+  .search-header h1,
   .recent-header h1,
   .favorites-header h1,
   .shared-header h1 {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -7642,14 +7642,29 @@ main.share-locked-page {
   display: none;
 }
 
+[data-slot="dialog-overlay"] {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
 [data-slot="dialog-content"].workspace-bottom-sheet {
-  inset: auto 0 0 0 !important;
+  position: fixed !important;
+  top: auto !important;
+  right: 0 !important;
+  bottom: 0 !important;
+  left: 0 !important;
+  box-sizing: border-box;
   width: 100dvw !important;
+  min-width: 0;
   max-width: 100dvw !important;
   max-height: min(82dvh, 680px);
+  margin: 0 !important;
   translate: none !important;
   transform: none !important;
   overflow-y: auto;
+  border-right: 0;
+  border-bottom: 0;
+  border-left: 0;
   border-radius: 18px 18px 0 0;
   padding: 10px 14px max(18px, env(safe-area-inset-bottom));
   background: var(--popover);

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -51,11 +51,7 @@ body {
   margin: 0;
   min-height: 100vh;
   color: inherit;
-  background: linear-gradient(
-    180deg,
-    oklch(99% 0.004 78) 0%,
-    oklch(96.5% 0.008 78) 100%
-  );
+  background: var(--background);
 }
 
 a {
@@ -386,6 +382,7 @@ h3 {
   display: grid;
   grid-template-columns: 216px minmax(0, 1fr);
   grid-template-rows: 100vh;
+  background: var(--background);
 }
 
 .admin-shell {
@@ -1238,6 +1235,7 @@ h3 {
   min-width: 0;
   display: flex;
   flex-direction: column;
+  background: var(--background);
 }
 
 .workspace-topbar {
@@ -1249,6 +1247,7 @@ h3 {
   padding: 10px 28px;
   border-bottom: 1px solid
     color-mix(in oklab, var(--foreground) 8%, transparent);
+  background: var(--background);
 }
 
 .workspace-search {
@@ -1471,6 +1470,7 @@ h3 {
   min-width: 0;
   padding: 24px 32px 56px;
   overflow-y: auto;
+  background: var(--background);
   scrollbar-width: thin;
   scrollbar-color: color-mix(in oklab, var(--foreground) 14%, transparent)
     transparent;
@@ -6932,13 +6932,7 @@ main.share-locked-page {
 }
 
 .light body {
-  background:
-    radial-gradient(
-      circle at top left,
-      color-mix(in oklab, var(--primary) 14%, transparent),
-      transparent 32%
-    ),
-    linear-gradient(180deg, oklch(99% 0.004 78) 0%, oklch(96.5% 0.008 78) 100%);
+  background: var(--background);
 }
 
 /* ============================================================
@@ -7649,19 +7643,18 @@ main.share-locked-page {
 }
 
 [data-slot="dialog-content"].workspace-bottom-sheet {
-  top: auto;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  max-width: none;
+  inset: auto 0 0 0 !important;
+  width: 100dvw !important;
+  max-width: 100dvw !important;
   max-height: min(82dvh, 680px);
-  translate: none;
-  transform: none;
+  translate: none !important;
+  transform: none !important;
   overflow-y: auto;
   border-radius: 18px 18px 0 0;
   padding: 10px 14px max(18px, env(safe-area-inset-bottom));
   background: var(--popover);
+  box-shadow: none;
+  animation-name: none !important;
 }
 
 .workspace-bottom-sheet-handle {

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -82,20 +82,21 @@ function DialogContent({
     target.removeAttribute("data-dragging");
 
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
-      resetBottomSheetDrag(target);
-      target.removeAttribute("data-closing");
+      bottomSheetDrag.current = null;
       onSwipeClose();
       return;
     }
 
     const closeDistance = Math.ceil(target.getBoundingClientRect().height + 48);
     target.style.transition = `transform ${BOTTOM_SHEET_CLOSE_ANIMATION_MS}ms cubic-bezier(0.22, 1, 0.36, 1)`;
+    let didFinishClose = false;
 
     const finishClose = () => {
+      if (didFinishClose) return;
+      didFinishClose = true;
       clearTimeout(fallbackTimer);
       target.removeEventListener("transitionend", handleTransitionEnd);
-      resetBottomSheetDrag(target);
-      target.removeAttribute("data-closing");
+      bottomSheetDrag.current = null;
       onSwipeClose();
     };
 

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -7,6 +7,10 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { XIcon } from "lucide-react";
 
+const BOTTOM_SHEET_CLOSE_THRESHOLD = 64;
+const BOTTOM_SHEET_TOP_DRAG_ZONE = 76;
+const BOTTOM_SHEET_CLOSE_ANIMATION_MS = 180;
+
 function Dialog({ ...props }: DialogPrimitive.Root.Props) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
@@ -31,7 +35,7 @@ function DialogOverlay({
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 isolate z-50 bg-black/30 duration-100 supports-backdrop-filter:backdrop-blur-sm data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "fixed inset-0 isolate z-50 bg-black/30 duration-100 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         className,
       )}
       {...props}
@@ -42,21 +46,243 @@ function DialogOverlay({
 function DialogContent({
   className,
   children,
+  onSwipeClose,
   showCloseButton = true,
   ...props
 }: DialogPrimitive.Popup.Props & {
+  onSwipeClose?: () => void;
   showCloseButton?: boolean;
 }) {
+  const isBottomSheet =
+    typeof className === "string" &&
+    className.includes("workspace-bottom-sheet");
+  const bottomSheetDrag = React.useRef<{
+    input: "pointer" | "touch";
+    lastY: number;
+    pointerId: number | null;
+    startY: number;
+  } | null>(null);
+
+  const resetBottomSheetDrag = (target: HTMLDivElement) => {
+    target.style.transition = "";
+    target.style.removeProperty("--bottom-sheet-drag-y");
+    target.removeAttribute("data-dragging");
+    bottomSheetDrag.current = null;
+  };
+
+  const setBottomSheetDragY = (target: HTMLDivElement, deltaY: number) => {
+    target.style.setProperty("--bottom-sheet-drag-y", `${deltaY}px`);
+  };
+
+  const closeBottomSheetWithMotion = (target: HTMLDivElement) => {
+    if (!onSwipeClose || target.dataset.closing === "true") return;
+
+    bottomSheetDrag.current = null;
+    target.dataset.closing = "true";
+    target.removeAttribute("data-dragging");
+
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      resetBottomSheetDrag(target);
+      target.removeAttribute("data-closing");
+      onSwipeClose();
+      return;
+    }
+
+    const closeDistance = Math.ceil(target.getBoundingClientRect().height + 48);
+    target.style.transition = `transform ${BOTTOM_SHEET_CLOSE_ANIMATION_MS}ms cubic-bezier(0.22, 1, 0.36, 1)`;
+
+    const finishClose = () => {
+      clearTimeout(fallbackTimer);
+      target.removeEventListener("transitionend", handleTransitionEnd);
+      resetBottomSheetDrag(target);
+      target.removeAttribute("data-closing");
+      onSwipeClose();
+    };
+
+    const handleTransitionEnd = (event: TransitionEvent) => {
+      if (event.target === target && event.propertyName === "transform") {
+        finishClose();
+      }
+    };
+
+    const fallbackTimer = window.setTimeout(
+      finishClose,
+      BOTTOM_SHEET_CLOSE_ANIMATION_MS + 80,
+    );
+
+    target.addEventListener("transitionend", handleTransitionEnd);
+    window.requestAnimationFrame(() => {
+      setBottomSheetDragY(target, closeDistance);
+    });
+  };
+
+  const startBottomSheetDrag = (
+    target: HTMLDivElement,
+    eventTarget: EventTarget,
+    clientY: number,
+    input: "pointer" | "touch",
+    pointerId: number | null = null,
+  ) => {
+    if (!isBottomSheet || !onSwipeClose || bottomSheetDrag.current) {
+      return false;
+    }
+    const eventElement = eventTarget instanceof Element ? eventTarget : null;
+    const isHandle = eventElement?.closest("[data-bottom-sheet-drag-handle]");
+    const isInteractive = eventElement?.closest(
+      "a, button, input, select, textarea, summary, [role='button']",
+    );
+    const isTopDragZone =
+      clientY - target.getBoundingClientRect().top <=
+        BOTTOM_SHEET_TOP_DRAG_ZONE && !isInteractive;
+
+    if (!isHandle && !isTopDragZone) {
+      return false;
+    }
+    bottomSheetDrag.current = {
+      input,
+      lastY: clientY,
+      pointerId,
+      startY: clientY,
+    };
+    target.style.transition = "none";
+    target.setAttribute("data-dragging", "true");
+    return true;
+  };
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.pointerType === "touch") return;
+    if (event.defaultPrevented) return;
+    const started = startBottomSheetDrag(
+      event.currentTarget,
+      event.target,
+      event.clientY,
+      "pointer",
+      event.pointerId,
+    );
+    if (!started) return;
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    const drag = bottomSheetDrag.current;
+    if (
+      !drag ||
+      drag.input !== "pointer" ||
+      drag.pointerId !== event.pointerId
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    drag.lastY = event.clientY;
+    const deltaY = Math.max(0, event.clientY - drag.startY);
+    setBottomSheetDragY(event.currentTarget, deltaY);
+  };
+
+  const finishBottomSheetDrag = (target: HTMLDivElement) => {
+    const drag = bottomSheetDrag.current;
+    if (!drag) return;
+
+    const deltaY = Math.max(0, drag.lastY - drag.startY);
+
+    if (deltaY >= BOTTOM_SHEET_CLOSE_THRESHOLD && onSwipeClose) {
+      closeBottomSheetWithMotion(target);
+      return;
+    }
+
+    target.style.transition = "";
+    setBottomSheetDragY(target, 0);
+    target.removeAttribute("data-dragging");
+    bottomSheetDrag.current = null;
+  };
+
+  const handlePointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    const drag = bottomSheetDrag.current;
+    if (
+      !drag ||
+      drag.input !== "pointer" ||
+      drag.pointerId !== event.pointerId
+    ) {
+      return;
+    }
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    finishBottomSheetDrag(event.currentTarget);
+  };
+
+  const handlePointerCancel = (event: React.PointerEvent<HTMLDivElement>) => {
+    const drag = bottomSheetDrag.current;
+    if (
+      !drag ||
+      drag.input !== "pointer" ||
+      drag.pointerId !== event.pointerId
+    ) {
+      return;
+    }
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    resetBottomSheetDrag(event.currentTarget);
+  };
+
+  const handleTouchStart = (event: React.TouchEvent<HTMLDivElement>) => {
+    if (event.defaultPrevented || event.touches.length !== 1) return;
+    const touch = event.touches[0];
+    const started = startBottomSheetDrag(
+      event.currentTarget,
+      event.target,
+      touch.clientY,
+      "touch",
+    );
+    if (!started) return;
+    event.preventDefault();
+  };
+
+  const handleTouchMove = (event: React.TouchEvent<HTMLDivElement>) => {
+    const drag = bottomSheetDrag.current;
+    if (!drag || drag.input !== "touch" || event.touches.length !== 1) return;
+
+    event.preventDefault();
+    const touch = event.touches[0];
+    drag.lastY = touch.clientY;
+    const deltaY = Math.max(0, touch.clientY - drag.startY);
+    setBottomSheetDragY(event.currentTarget, deltaY);
+  };
+
+  const handleTouchEnd = (event: React.TouchEvent<HTMLDivElement>) => {
+    const drag = bottomSheetDrag.current;
+    if (!drag || drag.input !== "touch") return;
+    finishBottomSheetDrag(event.currentTarget);
+  };
+
+  const handleTouchCancel = (event: React.TouchEvent<HTMLDivElement>) => {
+    const drag = bottomSheetDrag.current;
+    if (!drag || drag.input !== "touch") return;
+    resetBottomSheetDrag(event.currentTarget);
+  };
+
   return (
     <DialogPortal>
       <DialogOverlay />
       <DialogPrimitive.Popup
         data-slot="dialog-content"
+        {...props}
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 rounded-4xl bg-popover p-6 text-sm text-popover-foreground shadow-xl ring-1 ring-foreground/5 duration-100 outline-none sm:max-w-md dark:ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          isBottomSheet
+            ? "fixed inset-x-0 bottom-0 z-50 grid w-full gap-6 bg-popover text-sm text-popover-foreground ring-1 ring-foreground/5 duration-100 outline-none dark:ring-foreground/10"
+            : "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 rounded-4xl bg-popover p-6 text-sm text-popover-foreground shadow-xl ring-1 ring-foreground/5 duration-100 outline-none sm:max-w-md dark:ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className,
         )}
-        {...props}
+        onPointerCancel={handlePointerCancel}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onTouchCancel={handleTouchCancel}
+        onTouchEnd={handleTouchEnd}
+        onTouchMove={handleTouchMove}
+        onTouchStart={handleTouchStart}
       >
         {children}
         {showCloseButton && (

--- a/apps/web/e2e/responsive-workspace.spec.ts
+++ b/apps/web/e2e/responsive-workspace.spec.ts
@@ -1,0 +1,114 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type Page } from "@playwright/test";
+
+import { getOwnerCredentials, signIn } from "./helpers";
+
+const expectNoHorizontalOverflow = async (page: Page) => {
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const doc = document.documentElement;
+        return (
+          Math.ceil(Math.max(doc.scrollWidth, document.body.scrollWidth)) <=
+          window.innerWidth + 1
+        );
+      }),
+    )
+    .toBe(true);
+};
+
+test("phone workspace shell exposes bottom nav, upload, and touch file actions", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await signIn(page, getOwnerCredentials());
+
+  await expect(page.locator(".workspace-mobile-nav")).toBeVisible();
+  await expect(page.locator(".workspace-sidebar")).toBeHidden();
+  await expectNoHorizontalOverflow(page);
+
+  const fileChooser = page.waitForEvent("filechooser");
+  await page
+    .locator(".workspace-mobile-nav")
+    .getByRole("button", { name: "Upload" })
+    .click();
+  await fileChooser;
+
+  const row = page.locator("[data-file-row]", {
+    hasText: "shared-preview.png",
+  });
+  await expect(row).toBeVisible();
+
+  await row.dispatchEvent("pointerdown", {
+    clientX: 24,
+    clientY: 24,
+    pointerType: "touch",
+  });
+  await page.waitForTimeout(460);
+  await row.dispatchEvent("pointerup", {
+    clientX: 24,
+    clientY: 24,
+    pointerType: "touch",
+  });
+  await expect(page.getByText("1 item")).toBeVisible();
+
+  await row
+    .getByRole("button", { name: /Actions for shared-preview\.png/ })
+    .click();
+  await expect(page.getByRole("dialog", { name: "Actions" })).toBeVisible();
+});
+
+test("phone workspace routes do not overflow horizontally", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 320, height: 720 });
+  await signIn(page, getOwnerCredentials());
+
+  for (const route of [
+    "/files",
+    "/recent",
+    "/favorites",
+    "/search?q=shared",
+    "/shared",
+    "/trash",
+    "/settings",
+    "/home",
+  ]) {
+    await page.goto(route);
+    await expect(page.locator(".workspace-mobile-nav")).toBeVisible();
+    await expectNoHorizontalOverflow(page);
+  }
+
+  const results = await new AxeBuilder({ page })
+    .include("#main-content")
+    .withTags(["wcag2a", "wcag2aa", "wcag21aa", "wcag22aa"])
+    .analyze();
+  expect(
+    results.violations.filter(
+      (violation) =>
+        violation.impact === "serious" || violation.impact === "critical",
+    ),
+  ).toEqual([]);
+});
+
+test("tablet portrait uses mobile nav and landscape uses compact sidebar", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 768, height: 1024 });
+  await signIn(page, getOwnerCredentials());
+  await expect(page.locator(".workspace-mobile-nav")).toBeVisible();
+  await expect(page.locator(".workspace-sidebar")).toBeHidden();
+  await expectNoHorizontalOverflow(page);
+
+  await page.setViewportSize({ width: 900, height: 600 });
+  await expect(page.locator(".workspace-mobile-nav")).toBeHidden();
+  await expect(page.locator(".workspace-sidebar")).toBeVisible();
+  await expect
+    .poll(() =>
+      page
+        .locator(".workspace-sidebar")
+        .evaluate((node) => node.getBoundingClientRect().width),
+    )
+    .toBeLessThan(100);
+  await expectNoHorizontalOverflow(page);
+});


### PR DESCRIPTION
## 🚀 Summary

Adds responsive workspace support for phones and tablets across the core Staaash routes. Phones now use a bottom nav with Home, Files, Search, Upload, and More, while tablet landscape keeps a compact sidebar.

## 📊 Impacts and Changes

- Adds shared mobile workspace navigation, More sheet, action sheet, and coarse-pointer detection.
- Updates Files, Recent, Favorites, Shared, Trash/Search-adjacent workspace styling, and global workspace CSS for small screens.
- Makes touch item flows usable: tap opens, overflow opens actions, long-press selects, selected items get a bottom action bar.
- Keeps desktop behavior at `1024px+`: sidebar, context menu, double-click, keyboard shortcuts, and rubber-band selection remain intact.
- No schema, auth, storage, or restore behavior changes.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [ ] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

- Added responsive Playwright coverage, but did not run the e2e spec locally because the current e2e bootstrap resets data and needs a confirmed disposable DB/storage setup.
- Manual device acceptance is still needed on iPhone Safari, Android Chrome, and iPad portrait/landscape.

## 🔗 Linked Issues

None.