### PR TITLE
Add Fallow baseline config

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+  "ignorePatterns": ["packages/db/src/generated/prisma/**"],
+}

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ playwright-report/
 .stylelintcache
 .parcel-cache/
 .vite/
+.fallow/
 
 # OS and editor noise
 .DS_Store


### PR DESCRIPTION
## 🚀 Summary

Add a minimal Fallow configuration so static analysis ignores tracked Prisma generated output before the cleanup/refactor PRs begin.

## 📊 Impacts and Changes

Maintainers get a quieter Fallow baseline: `packages/db/src/generated/prisma/**` is excluded from Fallow analysis, matching the existing Prettier policy for generated Prisma output. Local `.fallow/` cache files are also ignored by git.

No runtime, API, schema, auth, storage, or restore behavior changes.

## 🧪 Testing Checklist

- [ ] `pnpm lint` passed
- [ ] `pnpm test` passed
- [ ] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

Additional validation run for this config-only change:

- [x] `pnpm --silent dlx fallow@latest config --path` detected `.fallowrc.jsonc`
- [x] `pnpm --silent dlx fallow@latest --format json --quiet --explain` reported `generated_prisma_references: 0`
- [x] `pnpm format:check` passed
- [x] `git diff --check` passed
- [x] `git status --short --ignored -- .fallow` confirmed `.fallow/` is ignored

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

Follow-up PRs will address actionable dead code, targeted duplication/refactor cleanup, and then Fallow CI once the baseline is quieter.

## 🔗 Linked Issues

None.
