### PR TITLE
Share workspace item helper logic

### DIFF
--- a/apps/web/app/(workspace)/favorites/favorites-helpers.ts
+++ b/apps/web/app/(workspace)/favorites/favorites-helpers.ts
@@ -1,5 +1,16 @@
-import type { ItemVisualKind } from "@/app/item-visuals";
 import type { FavoriteRetrievalItem } from "@/server/retrieval/types";
+
+import {
+  compareWorkspaceStrings,
+  filterWorkspaceItems,
+  formatWorkspaceFileSize,
+  formatWorkspaceRelativeTime,
+  getWorkspaceItemType,
+  getWorkspaceLocationLabel,
+  sortWorkspaceItems,
+  type WorkspaceItemFilterType,
+  type WorkspaceSortDirection,
+} from "../workspace-item-helpers";
 
 export type FavoriteClientItem = {
   favoritedAt: string;
@@ -15,33 +26,13 @@ export type FavoriteClientItem = {
   sizeBytes?: number;
 };
 
-export type FavoriteFilterType =
-  | "all"
-  | "archive"
-  | "audio"
-  | "folder"
-  | "image"
-  | "pdf"
-  | "text"
-  | "video";
+export type FavoriteFilterType = WorkspaceItemFilterType;
 
 export type FavoriteSortKey = "favoritedAt" | "name" | "path" | "size";
-export type FavoriteSortDirection = "asc" | "desc";
-
-function splitPathLabel(pathLabel: string): string[] {
-  return pathLabel
-    .split("/")
-    .map((part) => part.trim())
-    .filter(Boolean);
-}
+export type FavoriteSortDirection = WorkspaceSortDirection;
 
 export function getFavoriteLocationLabel(item: FavoriteRetrievalItem): string {
-  const parts = splitPathLabel(item.pathLabel);
-  const pathWithoutSelf =
-    parts.at(-1) === item.name ? parts.slice(0, -1) : parts;
-  const withoutRoot =
-    pathWithoutSelf.length > 1 ? pathWithoutSelf.slice(1) : [];
-  return withoutRoot.length > 0 ? withoutRoot.join(" / ") : "/";
+  return getWorkspaceLocationLabel(item);
 }
 
 export function toFavoriteClientItem(
@@ -65,86 +56,25 @@ export function toFavoriteClientItem(
 export function getFavoriteType(
   item: Pick<FavoriteClientItem, "kind" | "mimeType">,
 ): FavoriteFilterType {
-  if (item.kind === "folder") return "folder";
-
-  const mime = item.mimeType ?? "";
-  if (mime.startsWith("image/")) return "image";
-  if (mime.startsWith("video/")) return "video";
-  if (mime.startsWith("audio/")) return "audio";
-  if (mime.includes("pdf")) return "pdf";
-  if (
-    mime.startsWith("text/") ||
-    mime.includes("typescript") ||
-    mime.includes("json") ||
-    mime.includes("document")
-  ) {
-    return "text";
-  }
-  if (
-    mime.includes("zip") ||
-    mime.includes("archive") ||
-    mime.includes("tar") ||
-    mime.includes("gzip")
-  ) {
-    return "archive";
-  }
-
-  return "all";
-}
-
-function getFavoriteVisualKind(
-  item: Pick<FavoriteClientItem, "kind" | "mimeType">,
-): ItemVisualKind {
-  const type = getFavoriteType(item);
-  return type === "all" ? "file" : type;
+  return getWorkspaceItemType(item);
 }
 
 export function filterFavoriteItems(
   items: FavoriteClientItem[],
   filterType: FavoriteFilterType,
 ): FavoriteClientItem[] {
-  if (filterType === "all") return items;
-  return items.filter((item) => getFavoriteType(item) === filterType);
+  return filterWorkspaceItems(items, filterType);
 }
 
 export function formatFavoriteFileSize(bytes?: number): string {
-  if (bytes == null) return "-";
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${Math.max(1, Math.round(bytes / 1024))} KB`;
-  if (bytes < 1024 * 1024 * 1024)
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+  return formatWorkspaceFileSize(bytes);
 }
 
 export function formatFavoriteRelativeTime(
   value: Date | string,
   now = new Date(),
 ): string {
-  const date = value instanceof Date ? value : new Date(value);
-  const diffMs = Math.max(0, now.getTime() - date.getTime());
-  const diffMinutes = Math.floor(diffMs / 60000);
-
-  if (diffMinutes < 1) return "Just now";
-  if (diffMinutes < 60) return `${diffMinutes}m ago`;
-
-  const diffHours = Math.floor(diffMinutes / 60);
-  if (diffHours < 24) return `${diffHours}h ago`;
-
-  const diffDays = Math.floor(diffHours / 24);
-  if (diffDays === 1) return "Yesterday";
-  if (diffDays < 7) return `${diffDays} days ago`;
-
-  return date.toLocaleDateString("en", {
-    day: "numeric",
-    month: "short",
-  });
-}
-
-function compareStrings(left: string, right: string): number {
-  return left.localeCompare(right, undefined, {
-    numeric: true,
-    sensitivity: "base",
-  });
+  return formatWorkspaceRelativeTime(value, now);
 }
 
 export function sortFavoriteItems(
@@ -152,32 +82,26 @@ export function sortFavoriteItems(
   sortKey: FavoriteSortKey,
   sortDirection: FavoriteSortDirection,
 ): FavoriteClientItem[] {
-  const direction = sortDirection === "asc" ? 1 : -1;
-
-  return [...items].sort((left, right) => {
-    let delta = 0;
-
-    if (sortKey === "name") {
-      delta = compareStrings(left.name, right.name);
-    } else if (sortKey === "path") {
-      delta = compareStrings(left.locationLabel, right.locationLabel);
-    } else if (sortKey === "size") {
-      delta = (left.sizeBytes ?? -1) - (right.sizeBytes ?? -1);
-    } else {
-      delta =
+  return sortWorkspaceItems(
+    items,
+    sortDirection,
+    (left, right) => {
+      if (sortKey === "name") {
+        return compareWorkspaceStrings(left.name, right.name);
+      }
+      if (sortKey === "path") {
+        return compareWorkspaceStrings(left.locationLabel, right.locationLabel);
+      }
+      if (sortKey === "size") {
+        return (left.sizeBytes ?? -1) - (right.sizeBytes ?? -1);
+      }
+      return (
         new Date(left.favoritedAt).getTime() -
-        new Date(right.favoritedAt).getTime();
-    }
-
-    if (delta === 0) {
-      delta =
-        compareStrings(left.name, right.name) ||
-        left.kind.localeCompare(right.kind) ||
-        left.id.localeCompare(right.id);
-    }
-
-    return delta * direction;
-  });
+        new Date(right.favoritedAt).getTime()
+      );
+    },
+    { includeKindTieBreak: true },
+  );
 }
 
 export function getQuickAccessFavorites(
@@ -192,7 +116,8 @@ export function getQuickAccessFavorites(
 
       if (delta !== 0) return delta;
       return (
-        compareStrings(left.name, right.name) || left.id.localeCompare(right.id)
+        compareWorkspaceStrings(left.name, right.name) ||
+        left.id.localeCompare(right.id)
       );
     });
 }

--- a/apps/web/app/(workspace)/favorites/favorites-view.tsx
+++ b/apps/web/app/(workspace)/favorites/favorites-view.tsx
@@ -39,6 +39,10 @@ import { startValidatedDownload } from "@/lib/transfers/download";
 
 import { useTransferContext } from "../transfer-context";
 import { useCoarsePointer } from "../use-coarse-pointer";
+import {
+  getWorkspaceItemDownloadHref,
+  WORKSPACE_ITEM_FILTERS,
+} from "../workspace-item-helpers";
 import { WorkspaceActionSheet } from "../workspace-action-sheet";
 import {
   filterFavoriteItems,
@@ -71,23 +75,8 @@ type RubberBand = {
 const VIEW_STORAGE_KEY = "staaash:favorites:view";
 const DRAG_THRESHOLD = 5;
 
-const FILTERS: { id: FavoriteFilterType; label: string }[] = [
-  { id: "all", label: "All" },
-  { id: "folder", label: "Folders" },
-  { id: "image", label: "Images" },
-  { id: "pdf", label: "PDFs" },
-  { id: "video", label: "Videos" },
-  { id: "audio", label: "Audio" },
-  { id: "text", label: "Docs" },
-  { id: "archive", label: "Archives" },
-];
-
 function getItemKey(item: Pick<FavoriteClientItem, "id" | "kind">): string {
   return `${item.kind}:${item.id}`;
-}
-
-function getDownloadHref(item: FavoriteClientItem): string {
-  return `/api/files/files/${item.id}/download`;
 }
 
 function getFavoriteEndpoint(item: FavoriteClientItem): string {
@@ -335,11 +324,11 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
       return;
     }
 
+    const downloadHref = getWorkspaceItemDownloadHref(item);
+    if (!downloadHref) return;
+
     try {
-      await startValidatedDownload(
-        getDownloadHref(item),
-        "File download failed",
-      );
+      await startValidatedDownload(downloadHref, "File download failed");
     } catch (err) {
       setActionError(
         err instanceof Error ? err.message : "File download failed",
@@ -966,7 +955,7 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
                 setFilterType(event.target.value as FavoriteFilterType)
               }
             >
-              {FILTERS.map((filter) => (
+              {WORKSPACE_ITEM_FILTERS.map((filter) => (
                 <option key={filter.id} value={filter.id}>
                   {filter.label}
                 </option>

--- a/apps/web/app/(workspace)/recent/recent-helpers.ts
+++ b/apps/web/app/(workspace)/recent/recent-helpers.ts
@@ -1,5 +1,16 @@
-import type { ItemVisualKind } from "@/app/item-visuals";
 import type { RetrievalItem } from "@/server/retrieval/types";
+
+import {
+  compareWorkspaceStrings,
+  filterWorkspaceItems,
+  formatWorkspaceFileSize,
+  formatWorkspaceRelativeTime,
+  getWorkspaceItemType,
+  getWorkspaceLocationLabel,
+  sortWorkspaceItems,
+  type WorkspaceItemFilterType,
+  type WorkspaceSortDirection,
+} from "../workspace-item-helpers";
 
 export type RecentClientItem = {
   deletedAt: string | null;
@@ -16,18 +27,10 @@ export type RecentClientItem = {
   uploadedAt: string;
 };
 
-export type RecentFilterType =
-  | "all"
-  | "archive"
-  | "audio"
-  | "folder"
-  | "image"
-  | "pdf"
-  | "text"
-  | "video";
+export type RecentFilterType = WorkspaceItemFilterType;
 
 export type RecentSortKey = "name" | "path" | "size" | "uploadedAt";
-export type RecentSortDirection = "asc" | "desc";
+export type RecentSortDirection = WorkspaceSortDirection;
 
 const RECENT_GROUP_ORDER = [
   "Today",
@@ -44,20 +47,8 @@ export type RecentGroup<T> = {
   items: T[];
 };
 
-function splitPathLabel(pathLabel: string): string[] {
-  return pathLabel
-    .split("/")
-    .map((part) => part.trim())
-    .filter(Boolean);
-}
-
 export function getRecentLocationLabel(item: RetrievalItem): string {
-  const parts = splitPathLabel(item.pathLabel);
-  const pathWithoutSelf =
-    parts.at(-1) === item.name ? parts.slice(0, -1) : parts;
-  const withoutRoot =
-    pathWithoutSelf.length > 1 ? pathWithoutSelf.slice(1) : [];
-  return withoutRoot.length > 0 ? withoutRoot.join(" / ") : "/";
+  return getWorkspaceLocationLabel(item);
 }
 
 export function toRecentClientItem(item: RetrievalItem): RecentClientItem {
@@ -80,79 +71,25 @@ export function toRecentClientItem(item: RetrievalItem): RecentClientItem {
 export function getRecentType(
   item: Pick<RecentClientItem, "kind" | "mimeType">,
 ): RecentFilterType {
-  if (item.kind === "folder") return "folder";
-
-  const mime = item.mimeType ?? "";
-  if (mime.startsWith("image/")) return "image";
-  if (mime.startsWith("video/")) return "video";
-  if (mime.startsWith("audio/")) return "audio";
-  if (mime.includes("pdf")) return "pdf";
-  if (
-    mime.startsWith("text/") ||
-    mime.includes("typescript") ||
-    mime.includes("json") ||
-    mime.includes("document")
-  ) {
-    return "text";
-  }
-  if (
-    mime.includes("zip") ||
-    mime.includes("archive") ||
-    mime.includes("tar") ||
-    mime.includes("gzip")
-  ) {
-    return "archive";
-  }
-
-  return "all";
-}
-
-function getRecentVisualKind(
-  item: Pick<RecentClientItem, "kind" | "mimeType">,
-): ItemVisualKind {
-  const type = getRecentType(item);
-  return type === "all" ? "file" : type;
+  return getWorkspaceItemType(item);
 }
 
 export function filterRecentItems(
   items: RecentClientItem[],
   filterType: RecentFilterType,
 ): RecentClientItem[] {
-  if (filterType === "all") return items;
-  return items.filter((item) => getRecentType(item) === filterType);
+  return filterWorkspaceItems(items, filterType);
 }
 
 export function formatRecentFileSize(bytes?: number): string {
-  if (bytes == null) return "-";
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${Math.max(1, Math.round(bytes / 1024))} KB`;
-  if (bytes < 1024 * 1024 * 1024)
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+  return formatWorkspaceFileSize(bytes);
 }
 
 export function formatRecentRelativeTime(
   value: Date | string,
   now = new Date(),
 ): string {
-  const date = value instanceof Date ? value : new Date(value);
-  const diffMs = Math.max(0, now.getTime() - date.getTime());
-  const diffMinutes = Math.floor(diffMs / 60000);
-
-  if (diffMinutes < 1) return "Just now";
-  if (diffMinutes < 60) return `${diffMinutes}m ago`;
-
-  const diffHours = Math.floor(diffMinutes / 60);
-  if (diffHours < 24) return `${diffHours}h ago`;
-
-  const diffDays = Math.floor(diffHours / 24);
-  if (diffDays === 1) return "Yesterday";
-  if (diffDays < 7) return `${diffDays} days ago`;
-
-  return date.toLocaleDateString("en", {
-    day: "numeric",
-    month: "short",
-  });
+  return formatWorkspaceRelativeTime(value, now);
 }
 
 export function getRecentDateGroup(
@@ -177,42 +114,24 @@ export function getRecentDateGroup(
   return "Older";
 }
 
-function compareStrings(left: string, right: string): number {
-  return left.localeCompare(right, undefined, {
-    numeric: true,
-    sensitivity: "base",
-  });
-}
-
 export function sortRecentItems(
   items: RecentClientItem[],
   sortKey: RecentSortKey,
   sortDirection: RecentSortDirection,
 ): RecentClientItem[] {
-  const direction = sortDirection === "asc" ? 1 : -1;
-
-  return [...items].sort((left, right) => {
-    let delta = 0;
-
+  return sortWorkspaceItems(items, sortDirection, (left, right) => {
     if (sortKey === "name") {
-      delta = compareStrings(left.name, right.name);
-    } else if (sortKey === "path") {
-      delta = compareStrings(left.locationLabel, right.locationLabel);
-    } else if (sortKey === "size") {
-      delta = (left.sizeBytes ?? -1) - (right.sizeBytes ?? -1);
-    } else {
-      delta =
-        new Date(left.uploadedAt).getTime() -
-        new Date(right.uploadedAt).getTime();
+      return compareWorkspaceStrings(left.name, right.name);
     }
-
-    if (delta === 0) {
-      delta =
-        compareStrings(left.name, right.name) ||
-        left.id.localeCompare(right.id);
+    if (sortKey === "path") {
+      return compareWorkspaceStrings(left.locationLabel, right.locationLabel);
     }
-
-    return delta * direction;
+    if (sortKey === "size") {
+      return (left.sizeBytes ?? -1) - (right.sizeBytes ?? -1);
+    }
+    return (
+      new Date(left.uploadedAt).getTime() - new Date(right.uploadedAt).getTime()
+    );
   });
 }
 

--- a/apps/web/app/(workspace)/recent/recent-view.tsx
+++ b/apps/web/app/(workspace)/recent/recent-view.tsx
@@ -38,6 +38,10 @@ import { startValidatedDownload } from "@/lib/transfers/download";
 
 import { useTransferContext } from "../transfer-context";
 import { useCoarsePointer } from "../use-coarse-pointer";
+import {
+  getWorkspaceItemDownloadHref,
+  WORKSPACE_ITEM_FILTERS,
+} from "../workspace-item-helpers";
 import { WorkspaceActionSheet } from "../workspace-action-sheet";
 import {
   filterRecentItems,
@@ -66,28 +70,13 @@ type RubberBand = {
   startY: number;
 };
 
-const FILTERS: { id: RecentFilterType; label: string }[] = [
-  { id: "all", label: "All" },
-  { id: "folder", label: "Folders" },
-  { id: "image", label: "Images" },
-  { id: "pdf", label: "PDFs" },
-  { id: "video", label: "Videos" },
-  { id: "audio", label: "Audio" },
-  { id: "text", label: "Docs" },
-  { id: "archive", label: "Archives" },
-];
-
 const DRAG_THRESHOLD = 5;
 
 function getOpenHref(item: RecentClientItem): string {
   if (item.kind === "folder") return item.href;
   return item.href.startsWith("/files/view/")
     ? item.href
-    : `/api/files/files/${item.id}/download`;
-}
-
-function getDownloadHref(item: RecentClientItem): string {
-  return `/api/files/files/${item.id}/download`;
+    : (getWorkspaceItemDownloadHref(item) ?? item.href);
 }
 
 function getRestoreHref(item: RecentClientItem): string {
@@ -347,11 +336,11 @@ export function RecentView({ error, items, success }: RecentViewProps) {
       return;
     }
 
+    const downloadHref = getWorkspaceItemDownloadHref(item);
+    if (!downloadHref) return;
+
     try {
-      await startValidatedDownload(
-        getDownloadHref(item),
-        "File download failed",
-      );
+      await startValidatedDownload(downloadHref, "File download failed");
     } catch (err) {
       setActionError(
         err instanceof Error ? err.message : "File download failed",
@@ -869,7 +858,7 @@ export function RecentView({ error, items, success }: RecentViewProps) {
               setFilterType(event.target.value as RecentFilterType)
             }
           >
-            {FILTERS.map((filter) => (
+            {WORKSPACE_ITEM_FILTERS.map((filter) => (
               <option key={filter.id} value={filter.id}>
                 {filter.label}
               </option>

--- a/apps/web/app/(workspace)/workspace-item-helpers.ts
+++ b/apps/web/app/(workspace)/workspace-item-helpers.ts
@@ -1,0 +1,174 @@
+export type WorkspaceItemFilterType =
+  | "all"
+  | "archive"
+  | "audio"
+  | "folder"
+  | "image"
+  | "pdf"
+  | "text"
+  | "video";
+
+export type WorkspaceItemFilterOption = {
+  id: WorkspaceItemFilterType;
+  label: string;
+};
+
+export type WorkspaceSortDirection = "asc" | "desc";
+
+type WorkspaceTypeItem = {
+  kind: "file" | "folder";
+  mimeType?: string | null;
+};
+
+type WorkspaceLocationItem = {
+  name: string;
+  pathLabel: string;
+};
+
+type WorkspaceSortableItem = {
+  id: string;
+  kind?: string;
+  locationLabel: string;
+  name: string;
+  sizeBytes?: number;
+};
+
+type WorkspaceDownloadItem = {
+  id: string;
+  kind: "file" | "folder";
+};
+
+export const WORKSPACE_ITEM_FILTERS: WorkspaceItemFilterOption[] = [
+  { id: "all", label: "All" },
+  { id: "folder", label: "Folders" },
+  { id: "image", label: "Images" },
+  { id: "pdf", label: "PDFs" },
+  { id: "video", label: "Videos" },
+  { id: "audio", label: "Audio" },
+  { id: "text", label: "Docs" },
+  { id: "archive", label: "Archives" },
+];
+
+export function getWorkspaceLocationLabel(item: WorkspaceLocationItem): string {
+  const parts = item.pathLabel
+    .split("/")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const pathWithoutSelf =
+    parts.at(-1) === item.name ? parts.slice(0, -1) : parts;
+  const withoutRoot =
+    pathWithoutSelf.length > 1 ? pathWithoutSelf.slice(1) : [];
+  return withoutRoot.length > 0 ? withoutRoot.join(" / ") : "/";
+}
+
+export function getWorkspaceItemType(
+  item: WorkspaceTypeItem,
+): WorkspaceItemFilterType {
+  if (item.kind === "folder") return "folder";
+
+  const mime = item.mimeType ?? "";
+  if (mime.startsWith("image/")) return "image";
+  if (mime.startsWith("video/")) return "video";
+  if (mime.startsWith("audio/")) return "audio";
+  if (mime.includes("pdf")) return "pdf";
+  if (
+    mime.startsWith("text/") ||
+    mime.includes("typescript") ||
+    mime.includes("json") ||
+    mime.includes("document")
+  ) {
+    return "text";
+  }
+  if (
+    mime.includes("zip") ||
+    mime.includes("archive") ||
+    mime.includes("tar") ||
+    mime.includes("gzip")
+  ) {
+    return "archive";
+  }
+
+  return "all";
+}
+
+export function filterWorkspaceItems<T extends WorkspaceTypeItem>(
+  items: T[],
+  filterType: WorkspaceItemFilterType,
+): T[] {
+  if (filterType === "all") return items;
+  return items.filter((item) => getWorkspaceItemType(item) === filterType);
+}
+
+export function formatWorkspaceFileSize(bytes?: number): string {
+  if (bytes == null) return "-";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.max(1, Math.round(bytes / 1024))} KB`;
+  if (bytes < 1024 * 1024 * 1024)
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+export function formatWorkspaceRelativeTime(
+  value: Date | string,
+  now = new Date(),
+): string {
+  const date = value instanceof Date ? value : new Date(value);
+  const diffMs = Math.max(0, now.getTime() - date.getTime());
+  const diffMinutes = Math.floor(diffMs / 60000);
+
+  if (diffMinutes < 1) return "Just now";
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays < 7) return `${diffDays} days ago`;
+
+  return date.toLocaleDateString("en", {
+    day: "numeric",
+    month: "short",
+  });
+}
+
+export function compareWorkspaceStrings(left: string, right: string): number {
+  return left.localeCompare(right, undefined, {
+    numeric: true,
+    sensitivity: "base",
+  });
+}
+
+export function sortWorkspaceItems<T extends WorkspaceSortableItem>(
+  items: T[],
+  sortDirection: WorkspaceSortDirection,
+  comparePrimary: (left: T, right: T) => number,
+  options: { includeKindTieBreak?: boolean } = {},
+): T[] {
+  const direction = sortDirection === "asc" ? 1 : -1;
+
+  return [...items].sort((left, right) => {
+    let delta = comparePrimary(left, right);
+
+    if (delta === 0) {
+      delta = compareWorkspaceStrings(left.name, right.name);
+    }
+
+    if (delta === 0 && options.includeKindTieBreak) {
+      delta = (left.kind ?? "").localeCompare(right.kind ?? "");
+    }
+
+    if (delta === 0) {
+      delta = left.id.localeCompare(right.id);
+    }
+
+    return delta * direction;
+  });
+}
+
+export function getWorkspaceItemDownloadHref(
+  item: WorkspaceDownloadItem,
+): string | null {
+  if (item.kind === "folder") return null;
+  return `/api/files/files/${item.id}/download`;
+}

--- a/apps/web/server/workspace-item-helpers.test.ts
+++ b/apps/web/server/workspace-item-helpers.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compareWorkspaceStrings,
+  filterWorkspaceItems,
+  formatWorkspaceFileSize,
+  formatWorkspaceRelativeTime,
+  getWorkspaceItemDownloadHref,
+  getWorkspaceItemType,
+  getWorkspaceLocationLabel,
+  sortWorkspaceItems,
+} from "@/app/(workspace)/workspace-item-helpers";
+
+const item = (
+  overrides: Partial<{
+    id: string;
+    kind: "file" | "folder";
+    locationLabel: string;
+    mimeType?: string;
+    name: string;
+    pathLabel: string;
+    sizeBytes?: number;
+  }> = {},
+) => ({
+  id: "file-1",
+  kind: "file" as const,
+  locationLabel: "Design",
+  mimeType: "image/png",
+  name: "hero.png",
+  pathLabel: "Files / Design / hero.png",
+  sizeBytes: 2400000,
+  ...overrides,
+});
+
+describe("workspace item helpers", () => {
+  it("builds compact location labels from retrieval path labels", () => {
+    expect(getWorkspaceLocationLabel(item())).toBe("Design");
+    expect(
+      getWorkspaceLocationLabel(
+        item({
+          name: "Q1.pdf",
+          pathLabel: "Files / Client / Reports / Q1.pdf",
+        }),
+      ),
+    ).toBe("Client / Reports");
+    expect(
+      getWorkspaceLocationLabel(
+        item({
+          kind: "folder",
+          name: "Design",
+          pathLabel: "Files / Design",
+        }),
+      ),
+    ).toBe("/");
+  });
+
+  it("maps file and folder MIME types to workspace filters", () => {
+    expect(
+      getWorkspaceItemType(item({ kind: "folder", mimeType: undefined })),
+    ).toBe("folder");
+    expect(getWorkspaceItemType(item({ mimeType: "image/png" }))).toBe("image");
+    expect(getWorkspaceItemType(item({ mimeType: "video/mp4" }))).toBe("video");
+    expect(getWorkspaceItemType(item({ mimeType: "audio/wav" }))).toBe("audio");
+    expect(getWorkspaceItemType(item({ mimeType: "application/pdf" }))).toBe(
+      "pdf",
+    );
+    expect(getWorkspaceItemType(item({ mimeType: "text/markdown" }))).toBe(
+      "text",
+    );
+    expect(getWorkspaceItemType(item({ mimeType: "application/gzip" }))).toBe(
+      "archive",
+    );
+    expect(
+      getWorkspaceItemType(item({ mimeType: "application/octet-stream" })),
+    ).toBe("all");
+  });
+
+  it("filters items by workspace type", () => {
+    const items = [
+      item({ id: "a", mimeType: "image/png" }),
+      item({ id: "b", mimeType: "video/mp4" }),
+      item({ id: "c", kind: "folder", mimeType: undefined }),
+    ];
+
+    expect(filterWorkspaceItems(items, "all").map((entry) => entry.id)).toEqual(
+      ["a", "b", "c"],
+    );
+    expect(
+      filterWorkspaceItems(items, "folder").map((entry) => entry.id),
+    ).toEqual(["c"]);
+  });
+
+  it("formats file sizes and relative time labels", () => {
+    const now = new Date("2026-05-19T12:00:00.000Z");
+
+    expect(formatWorkspaceFileSize(undefined)).toBe("-");
+    expect(formatWorkspaceFileSize(400)).toBe("400 B");
+    expect(formatWorkspaceFileSize(4200)).toBe("4 KB");
+    expect(formatWorkspaceFileSize(2_400_000)).toBe("2.3 MB");
+    expect(formatWorkspaceFileSize(4_500_000_000)).toBe("4.2 GB");
+
+    expect(formatWorkspaceRelativeTime("2026-05-19T12:00:00.000Z", now)).toBe(
+      "Just now",
+    );
+    expect(formatWorkspaceRelativeTime("2026-05-19T11:55:00.000Z", now)).toBe(
+      "5m ago",
+    );
+    expect(formatWorkspaceRelativeTime("2026-05-19T10:00:00.000Z", now)).toBe(
+      "2h ago",
+    );
+    expect(formatWorkspaceRelativeTime("2026-05-18T10:00:00.000Z", now)).toBe(
+      "Yesterday",
+    );
+  });
+
+  it("sorts with workspace string and tie-break rules", () => {
+    const items = [
+      item({ id: "file-b", kind: "file", name: "Report 2" }),
+      item({ id: "folder-a", kind: "folder", name: "Report 2" }),
+      item({ id: "file-a", kind: "file", name: "Report 10" }),
+    ];
+
+    expect(compareWorkspaceStrings("Report 2", "Report 10")).toBeLessThan(0);
+    expect(
+      sortWorkspaceItems(
+        items,
+        "asc",
+        (left, right) => compareWorkspaceStrings(left.name, right.name),
+        { includeKindTieBreak: true },
+      ).map((entry) => entry.id),
+    ).toEqual(["file-b", "folder-a", "file-a"]);
+    expect(
+      sortWorkspaceItems(items, "desc", () => 0).map((entry) => entry.id),
+    ).toEqual(["file-a", "folder-a", "file-b"]);
+  });
+
+  it("builds direct file download hrefs and leaves folders to archive flow", () => {
+    expect(getWorkspaceItemDownloadHref({ id: "file-1", kind: "file" })).toBe(
+      "/api/files/files/file-1/download",
+    );
+    expect(
+      getWorkspaceItemDownloadHref({ id: "folder-1", kind: "folder" }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## 🚀 Summary

Share the repeated Recent/Favorites item presentation helpers behind one workspace helper module while keeping the existing Recent and Favorites helper APIs intact.

## 📊 Impacts and Changes

- Adds shared workspace item helpers for filters, MIME type labels, compact locations, file sizes, relative times, sorting support, and direct file download hrefs.
- Rewires Recent and Favorites helper modules to delegate duplicated pure logic through the shared helper layer.
- Reuses the shared filter options and file-download href helper in the Recent/Favorites views without changing selection, rubber-band, Trash, or archive-download behavior.
- No schema, auth, storage, restore, or operational changes.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

Additional validation:

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `git diff --check`
- [x] `pnpm dlx fallow@latest dead-code --format json --quiet --summary --explain` reported `0` issues
- [x] `pnpm dlx fallow@latest dupes --format json --quiet --top 25 --skip-local --explain` no longer lists the Recent/Favorites helper clones in the top findings
- [x] Local browser smoke confirmed `/recent` and `/favorites` still load, filters and sorting work, file download works, and folder download still uses the existing zip/archive flow

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

- Fallow still reports some Recent/Favorites view-level interaction duplication. That selection/action-sheet/rubber-band work is intentionally deferred because it is riskier than this pure-helper refactor.
- Fallow CI remains reserved for the next PR.

## 🔗 Linked Issues

None.
