### PR TITLE
Add large-upload checksum verification

### DIFF
--- a/apps/web/app/(workspace)/files/files-view.tsx
+++ b/apps/web/app/(workspace)/files/files-view.tsx
@@ -1526,7 +1526,9 @@ function UploadingRow({
         ? "Done"
         : file.resumeHint && file.progress === 0
           ? file.resumeHint
-          : `${file.progress}% · ${formatSpeed(file.speed)}${eta ? ` · ${eta}` : ""}`;
+          : file.statusLabel
+            ? file.statusLabel
+            : `${file.progress}% · ${formatSpeed(file.speed)}${eta ? ` · ${eta}` : ""}`;
 
   return (
     <div className="uploading-row">

--- a/apps/web/app/(workspace)/transfer-context.tsx
+++ b/apps/web/app/(workspace)/transfer-context.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 import { useRouter } from "next/navigation";
 import { randomClientId } from "@/lib/client-id";
+import { computeFileSha256 } from "@/lib/transfers/file-checksum";
 import {
   fetchWithRetry,
   queuedFetch,
@@ -30,6 +31,7 @@ export type UploadingFile = {
   speed: number;
   error?: string;
   resumeHint?: string;
+  statusLabel?: string;
   fileRef?: File;
   fileId?: string;
   folderId?: string;
@@ -62,6 +64,11 @@ const ACTIVE_DOWNLOAD_KEY = "staaash:active-download";
 // fallow-ignore-next-line unused-export
 export const CHUNKED_UPLOAD_THRESHOLD = 100 * 1024 * 1024;
 const CHUNK_SIZE = 10 * 1024 * 1024;
+
+type StoredUploadSession = {
+  sessionId: string;
+  expectedChecksum?: string;
+};
 
 // ---------------------------------------------------------------------------
 // Helpers (also exported for use in display components)
@@ -407,41 +414,85 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
     const sessionStorageKey = `${UPLOAD_SESSION_KEY_PREFIX}:${folderId}:${file.name}:${file.size}`;
     let sessionId: string | null = null;
     let receivedBytes = 0;
-    const startTime = Date.now();
+    let expectedChecksum: string;
+
+    try {
+      setUploadingFiles((prev) =>
+        prev.map((f) =>
+          f.clientKey === clientKey
+            ? {
+                ...f,
+                progress: 0,
+                speed: 0,
+                resumeHint: undefined,
+                statusLabel: "Checking file...",
+              }
+            : f,
+        ),
+      );
+      expectedChecksum = await computeFileSha256(file, signal);
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        uploadAbortControllers.current.delete(clientKey);
+        return;
+      }
+      setUploadingFiles((prev) =>
+        prev.map((f) =>
+          f.clientKey === clientKey
+            ? {
+                ...f,
+                status: "error",
+                error: "Could not check file integrity",
+                statusLabel: undefined,
+              }
+            : f,
+        ),
+      );
+      uploadAbortControllers.current.delete(clientKey);
+      return;
+    }
 
     try {
       const stored = JSON.parse(
         localStorage.getItem(sessionStorageKey) ?? "null",
-      ) as { sessionId: string } | null;
+      ) as StoredUploadSession | null;
       if (stored?.sessionId) {
-        const res = await queuedFetch(
-          "upload",
-          `/api/uploads/sessions/${stored.sessionId}`,
-          { headers: { Accept: "application/json" } },
-          { retries: 3, backoffMs: 500, signal },
-        );
-        if (res.ok) {
-          const data = (await res.json()) as { receivedBytes: number };
-          sessionId = stored.sessionId;
-          receivedBytes = data.receivedBytes;
-          if (receivedBytes > 0) {
-            setUploadingFiles((prev) =>
-              prev.map((f) =>
-                f.clientKey === clientKey
-                  ? {
-                      ...f,
-                      resumeHint: `Resuming from ${formatBytes(receivedBytes)}`,
-                    }
-                  : f,
-              ),
-            );
-          }
-        } else {
+        if (stored.expectedChecksum !== expectedChecksum) {
           localStorage.removeItem(sessionStorageKey);
+        } else {
+          const res = await queuedFetch(
+            "upload",
+            `/api/uploads/sessions/${stored.sessionId}`,
+            { headers: { Accept: "application/json" } },
+            { retries: 3, backoffMs: 500, signal },
+          );
+          if (res.ok) {
+            const data = (await res.json()) as { receivedBytes: number };
+            sessionId = stored.sessionId;
+            receivedBytes = data.receivedBytes;
+            if (receivedBytes > 0) {
+              setUploadingFiles((prev) =>
+                prev.map((f) =>
+                  f.clientKey === clientKey
+                    ? {
+                        ...f,
+                        resumeHint: `Resuming from ${formatBytes(receivedBytes)}`,
+                        statusLabel: undefined,
+                      }
+                    : f,
+                ),
+              );
+            }
+          } else {
+            localStorage.removeItem(sessionStorageKey);
+          }
         }
       }
     } catch (err) {
-      if (err instanceof DOMException && err.name === "AbortError") throw err;
+      if (err instanceof DOMException && err.name === "AbortError") {
+        uploadAbortControllers.current.delete(clientKey);
+        return;
+      }
       localStorage.removeItem(sessionStorageKey);
     }
 
@@ -462,6 +513,7 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
               mimeType: file.type || "application/octet-stream",
               totalSizeBytes: file.size,
               conflictStrategy: "safeRename",
+              expectedChecksum,
             }),
           },
           { retries: 3, backoffMs: 500, signal },
@@ -475,8 +527,15 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
         const data = (await res.json()) as { id: string };
         sessionId = data.id;
         receivedBytes = 0;
-        localStorage.setItem(sessionStorageKey, JSON.stringify({ sessionId }));
+        localStorage.setItem(
+          sessionStorageKey,
+          JSON.stringify({ sessionId, expectedChecksum }),
+        );
       } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          uploadAbortControllers.current.delete(clientKey);
+          return;
+        }
         setUploadingFiles((prev) =>
           prev.map((f) =>
             f.clientKey === clientKey
@@ -485,15 +544,18 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
                   status: "error",
                   error:
                     error instanceof Error ? error.message : "Upload failed",
+                  statusLabel: undefined,
                 }
               : f,
           ),
         );
+        uploadAbortControllers.current.delete(clientKey);
         return;
       }
     }
 
     const sessionStartBytes = receivedBytes;
+    const uploadStartTime = Date.now();
     try {
       while (receivedBytes < file.size) {
         const chunkEnd = Math.min(receivedBytes + CHUNK_SIZE, file.size);
@@ -526,14 +588,20 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
         receivedBytes = data.receivedBytes;
 
         const progress = Math.round((receivedBytes / file.size) * 100);
-        const elapsed = (Date.now() - startTime) / 1000;
+        const elapsed = (Date.now() - uploadStartTime) / 1000;
         const sessionBytes = receivedBytes - sessionStartBytes;
         const speed = elapsed > 0 ? sessionBytes / elapsed : 0;
 
         setUploadingFiles((prev) =>
           prev.map((f) =>
             f.clientKey === clientKey
-              ? { ...f, progress, speed, resumeHint: undefined }
+              ? {
+                  ...f,
+                  progress,
+                  speed,
+                  resumeHint: undefined,
+                  statusLabel: undefined,
+                }
               : f,
           ),
         );
@@ -581,6 +649,7 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
                 ...f,
                 status: "error",
                 error: error instanceof Error ? error.message : "Upload failed",
+                statusLabel: undefined,
               }
             : f,
         ),
@@ -660,6 +729,7 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
               progress: 0,
               speed: 0,
               error: undefined,
+              statusLabel: undefined,
             }
           : f,
       ),

--- a/apps/web/app/(workspace)/transfer-panel.tsx
+++ b/apps/web/app/(workspace)/transfer-panel.tsx
@@ -153,7 +153,9 @@ function PanelUploadRow({
         ? "Done"
         : file.resumeHint && file.progress === 0
           ? file.resumeHint
-          : `${file.progress}% · ${formatSpeed(file.speed)}${eta ? ` · ${eta}` : ""}`;
+          : file.statusLabel
+            ? file.statusLabel
+            : `${file.progress}% · ${formatSpeed(file.speed)}${eta ? ` · ${eta}` : ""}`;
 
   return (
     <div className="transfer-panel-row">

--- a/apps/web/lib/transfers/file-checksum.ts
+++ b/apps/web/lib/transfers/file-checksum.ts
@@ -1,0 +1,26 @@
+import { createSHA256 } from "hash-wasm";
+
+export const CHECKSUM_CHUNK_SIZE = 10 * 1024 * 1024;
+
+export async function computeFileSha256(
+  file: File,
+  signal?: AbortSignal,
+): Promise<string> {
+  const hasher = await createSHA256();
+  hasher.init();
+
+  for (let offset = 0; offset < file.size; offset += CHECKSUM_CHUNK_SIZE) {
+    if (signal?.aborted) {
+      throw new DOMException("Upload cancelled", "AbortError");
+    }
+
+    const chunk = file.slice(offset, offset + CHECKSUM_CHUNK_SIZE);
+    hasher.update(new Uint8Array(await chunk.arrayBuffer()));
+  }
+
+  if (signal?.aborted) {
+    throw new DOMException("Upload cancelled", "AbortError");
+  }
+
+  return hasher.digest("hex");
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,7 @@
     "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "hash-wasm": "^4.12.0",
     "heic-convert": "^2.1.0",
     "lucide-react": "^1.17.0",
     "next": "16.2.6",

--- a/apps/web/server/file-checksum.test.ts
+++ b/apps/web/server/file-checksum.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { computeFileSha256 } from "@/lib/transfers/file-checksum";
+
+describe("file checksum helper", () => {
+  it("computes SHA-256 for a browser File", async () => {
+    const file = new File(["hello world"], "hello.txt", {
+      type: "text/plain",
+    });
+
+    await expect(computeFileSha256(file)).resolves.toBe(
+      "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+    );
+  });
+
+  it("throws AbortError when hashing is cancelled", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      computeFileSha256(
+        new File(["cancelled"], "cancelled.txt"),
+        controller.signal,
+      ),
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
+});

--- a/apps/web/server/origin-guard-routes.test.ts
+++ b/apps/web/server/origin-guard-routes.test.ts
@@ -78,6 +78,18 @@ const crossOriginRequest = (path: string, method: string) =>
     },
   });
 
+const sameOriginJsonRequest = (path: string, method: string, body: unknown) =>
+  new NextRequest(`http://localhost:3000${path}`, {
+    method,
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+      host: "localhost:3000",
+      origin: "http://localhost:3000",
+    },
+    body: JSON.stringify(body),
+  });
+
 const expectCrossOriginRejection = async (response: Response) => {
   expect(response.status).toBe(403);
   await expect(response.json()).resolves.toEqual({
@@ -134,5 +146,72 @@ describe("mutating route same-origin guards", () => {
 
     await expectCrossOriginRejection(response);
     expect(scheduleZipArchiveGenerate).not.toHaveBeenCalled();
+  });
+});
+
+describe("upload session creation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getRequestSession).mockResolvedValue({
+      user: { id: "user-1", role: "owner" },
+    } as Awaited<ReturnType<typeof getRequestSession>>);
+    vi.mocked(createResumableSession).mockResolvedValue({
+      id: "session-1",
+      ownerUserId: "user-1",
+      folderId: null,
+      originalName: "video.mp4",
+      mimeType: "video/mp4",
+      totalSizeBytes: 123,
+      receivedBytes: 0,
+      expectedChecksum:
+        "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+      tmpPath: "/tmp/session-1",
+      conflictStrategy: "safeRename",
+      status: "created",
+      expiresAt: new Date("2026-01-01T00:00:00.000Z"),
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+  });
+
+  it("passes expected checksum into resumable session creation", async () => {
+    const expectedChecksum =
+      "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+
+    const response = await createUploadSession(
+      sameOriginJsonRequest("/api/uploads/sessions", "POST", {
+        folderId: null,
+        originalName: "video.mp4",
+        mimeType: "video/mp4",
+        totalSizeBytes: 123,
+        conflictStrategy: "safeRename",
+        expectedChecksum,
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(createResumableSession).toHaveBeenCalledWith({
+      ownerUserId: "user-1",
+      folderId: null,
+      originalName: "video.mp4",
+      mimeType: "video/mp4",
+      totalSizeBytes: 123,
+      expectedChecksum,
+      conflictStrategy: "safeRename",
+    });
+  });
+
+  it("rejects malformed expected checksums", async () => {
+    const response = await createUploadSession(
+      sameOriginJsonRequest("/api/uploads/sessions", "POST", {
+        folderId: null,
+        originalName: "video.mp4",
+        mimeType: "video/mp4",
+        totalSizeBytes: 123,
+        expectedChecksum: "not-a-sha256",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(createResumableSession).not.toHaveBeenCalled();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      hash-wasm:
+        specifier: ^4.12.0
+        version: 4.12.0
       heic-convert:
         specifier: ^2.1.0
         version: 2.1.0
@@ -2343,6 +2346,9 @@ packages:
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
+
+  hash-wasm@4.12.0:
+    resolution: {integrity: sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ==}
 
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
@@ -5564,6 +5570,8 @@ snapshots:
   graphql@16.14.0: {}
 
   has-symbols@1.1.0: {}
+
+  hash-wasm@4.12.0: {}
 
   hasown@2.0.4:
     dependencies:


### PR DESCRIPTION
## 🚀 Summary

Adds required SHA-256 checksums for large resumable uploads. The browser checks the file before creating the upload session, sends the checksum as `expectedChecksum`, and the existing server-side completion step verifies the committed upload.

## 📊 Impacts and Changes

Large uploads now show `Checking file...` before network upload starts. Existing partial resumable sessions created before this change restart once so the new upload can include a checksum. No schema, auth, storage layout, or restore behavior changes.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [ ] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

Parallel chunk uploads from issue #65 are still deferred. This PR only handles the now-worthy checksum trust slice.

## 🔗 Linked Issues

Refs #65
