### PR TITLE
Fix workspace app version fallback

### DIFF
--- a/apps/web/app/(workspace)/layout.tsx
+++ b/apps/web/app/(workspace)/layout.tsx
@@ -3,6 +3,7 @@ import { Search } from "lucide-react";
 
 import { Toaster } from "@/components/ui/sonner";
 import { getInitials } from "@/lib/user";
+import { resolveAppVersion } from "@/server/app-version";
 import { getCurrentSession } from "@/server/auth/session";
 import { getSystemSettings } from "@/server/settings";
 import {
@@ -47,8 +48,7 @@ export default async function WorkspaceLayout({
     getSystemSettings(),
   ]);
 
-  const appVersion =
-    process.env.STAAASH_VERSION ?? process.env.APP_VERSION ?? "0.3.0-beta.1";
+  const appVersion = resolveAppVersion();
 
   const initials = session
     ? getInitials(session.user.displayName, session.user.username)

--- a/apps/web/server/app-version.test.ts
+++ b/apps/web/server/app-version.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { version as packageVersion } from "../package.json";
+
+import { resolveAppVersion } from "./app-version";
+
+describe("resolveAppVersion", () => {
+  it("prefers the explicit Staaash version override", () => {
+    expect(resolveAppVersion("1.2.3", "2.0.0")).toBe("1.2.3");
+  });
+
+  it("uses the app version override when the Staaash version is unset", () => {
+    expect(resolveAppVersion(undefined, "2.0.0")).toBe("2.0.0");
+  });
+
+  it("falls back to the package version", () => {
+    expect(resolveAppVersion(undefined, undefined)).toBe(packageVersion);
+  });
+});

--- a/apps/web/server/app-version.ts
+++ b/apps/web/server/app-version.ts
@@ -1,0 +1,6 @@
+import { version as packageVersion } from "../package.json";
+
+export const resolveAppVersion = (
+  staaashVersion: string | undefined = process.env.STAAASH_VERSION,
+  appVersion: string | undefined = process.env.APP_VERSION,
+) => staaashVersion ?? appVersion ?? packageVersion;


### PR DESCRIPTION
## 🚀 Summary

Fix the workspace instance badge version fallback so it resolves from the app package version instead of a hard-coded release string.

## 📊 Impacts and Changes

Users see the current packaged Staaash version in the workspace badge when `STAAASH_VERSION` and `APP_VERSION` are unset. No schema, auth, storage, or restore behavior changes.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment. No interaction or layout behavior changed.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

None.

## 🔗 Linked Issues

None.