### PR TITLE
Align workspace empty states

### DIFF
--- a/apps/web/app/(workspace)/recent/recent-view.tsx
+++ b/apps/web/app/(workspace)/recent/recent-view.tsx
@@ -15,6 +15,7 @@ import { useRouter } from "next/navigation";
 import {
   ArrowDown,
   ArrowUp,
+  Clock,
   Download,
   ExternalLink,
   Grid2X2,
@@ -889,7 +890,7 @@ export function RecentView({ error, items, success }: RecentViewProps) {
       {visibleItems.length === 0 ? (
         <div className="recent-empty-state">
           <span className="recent-empty-icon">
-            <ItemTypeIcon size={22} visual={getItemVisual("folder", null)} />
+            <Clock size={22} aria-hidden />
           </span>
           <p>
             {items.length === 0

--- a/apps/web/app/(workspace)/shared/page.tsx
+++ b/apps/web/app/(workspace)/shared/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { headers } from "next/headers";
+import { KeyRound } from "lucide-react";
 
 import {
   FlashMessage,
@@ -108,12 +108,12 @@ export default async function SharedPage({ searchParams }: SharedPageProps) {
 
         {/* Empty state */}
         {allShares.length === 0 ? (
-          <div className="workspace-empty-state">
-            <h2>No shared links yet</h2>
-            <p className="muted">Create a link from any file or folder.</p>
-            <Link className="pill" href="/files">
-              Open files
-            </Link>
+          <div className="shared-empty-state">
+            <span className="shared-empty-icon">
+              <KeyRound size={22} aria-hidden />
+            </span>
+            <p>No shared links yet</p>
+            <span>Create a link from any file or folder.</span>
           </div>
         ) : (
           <div className="sl-page">

--- a/apps/web/app/(workspace)/shared/page.tsx
+++ b/apps/web/app/(workspace)/shared/page.tsx
@@ -1,5 +1,5 @@
 import { headers } from "next/headers";
-import { KeyRound } from "lucide-react";
+import { Share2 } from "lucide-react";
 
 import {
   FlashMessage,
@@ -110,7 +110,7 @@ export default async function SharedPage({ searchParams }: SharedPageProps) {
         {allShares.length === 0 ? (
           <div className="shared-empty-state">
             <span className="shared-empty-icon">
-              <KeyRound size={22} aria-hidden />
+              <Share2 size={22} aria-hidden />
             </span>
             <p>No shared links yet</p>
             <span>Create a link from any file or folder.</span>

--- a/apps/web/app/(workspace)/shared/shared-table.tsx
+++ b/apps/web/app/(workspace)/shared/shared-table.tsx
@@ -169,9 +169,12 @@ export function SharedTable({ items }: SharedTableProps) {
       </div>
 
       {visibleItems.length === 0 ? (
-        <div className="workspace-empty-state">
-          <h2>No shared links match that filter</h2>
-          <p className="muted">Try a different type.</p>
+        <div className="shared-empty-state">
+          <span className="shared-empty-icon">
+            <KeyRound size={22} aria-hidden />
+          </span>
+          <p>No shared links match that filter</p>
+          <span>Try a different type.</span>
         </div>
       ) : (
         <>

--- a/apps/web/app/(workspace)/shared/shared-table.tsx
+++ b/apps/web/app/(workspace)/shared/shared-table.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { KeyRound } from "lucide-react";
+import { KeyRound, Share2 } from "lucide-react";
 import { useMemo, useState, useTransition } from "react";
 
 import { ShareDialog } from "@/app/(workspace)/files/share-dialog";
@@ -171,7 +171,7 @@ export function SharedTable({ items }: SharedTableProps) {
       {visibleItems.length === 0 ? (
         <div className="shared-empty-state">
           <span className="shared-empty-icon">
-            <KeyRound size={22} aria-hidden />
+            <Share2 size={22} aria-hidden />
           </span>
           <p>No shared links match that filter</p>
           <span>Try a different type.</span>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2620,7 +2620,9 @@ h3 {
   pointer-events: auto;
 }
 
-.recent-empty-state {
+.recent-empty-state,
+.favorites-empty-state,
+.shared-empty-state {
   display: flex;
   flex: 1;
   min-height: 320px;
@@ -2632,17 +2634,25 @@ h3 {
   text-align: center;
 }
 
-.recent-empty-state p {
+.recent-empty-state p,
+.favorites-empty-state p,
+.shared-empty-state p {
+  margin: 0;
   color: var(--foreground);
   font-size: 14px;
   font-weight: 650;
 }
 
-.recent-empty-state span {
+.recent-empty-state > span,
+.favorites-empty-state > span,
+.shared-empty-state > span {
+  max-width: 420px;
   font-size: 12px;
 }
 
-.recent-empty-icon {
+.recent-empty-icon,
+.favorites-empty-icon,
+.shared-empty-icon {
   opacity: 0.45;
 }
 
@@ -2904,7 +2914,7 @@ h3 {
   flex-direction: column;
   gap: 18px;
   position: relative;
-  min-height: calc(100vh - 120px);
+  min-height: 0;
   user-select: none;
 }
 
@@ -3197,33 +3207,6 @@ h3 {
 .favorites-grid-card:focus-within .favorites-grid-actions {
   opacity: 1;
   pointer-events: auto;
-}
-
-.favorites-empty-state {
-  display: flex;
-  flex: 1;
-  min-height: 320px;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  color: var(--muted-foreground);
-  text-align: center;
-}
-
-.favorites-empty-state p {
-  color: var(--foreground);
-  font-size: 14px;
-  font-weight: 650;
-}
-
-.favorites-empty-state span {
-  max-width: 420px;
-  font-size: 12px;
-}
-
-.favorites-empty-icon {
-  opacity: 0.45;
 }
 
 @media (max-width: 860px) {


### PR DESCRIPTION
## 🚀 Summary

Align workspace collection empty states so Recent, Favorites, and Shared use the same quiet centered pattern.

## 📊 Impacts and Changes

- Shared no longer uses the dashed cardified empty state or the `Open files` CTA.
- Shared true-empty and filtered-empty states now match the Recent text/icon treatment.
- Favorites empty-state vertical positioning now follows Recent instead of sitting lower.
- No schema, auth, storage, or restore behavior changes.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed (completed by Ares before PR creation; Codex did not rerun by request)
- [x] `pnpm test` passed (completed by Ares before PR creation; Codex did not rerun by request)
- [x] `pnpm build` successful (completed by Ares before PR creation; Codex did not rerun by request)
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

None.

## 🔗 Linked Issues

None.