### PR TITLE
Improve admin jobs activity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ CLAUDE.md
 .codex/
 .claude/
 .cursor/
+.impeccable/
 .github/copilot-instructions.md
 AGENTS.original.md
 CLAUDE.original.md

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -24,6 +24,26 @@ colors:
   dark-popover: "oklch(0.23 0.012 72)"
   dark-primary: "oklch(0.74 0.08 78)"
   dark-border: "oklch(0.38 0.014 76 / 0.55)"
+  status-succeeded: "oklch(0.46 0.12 145)"
+  status-succeeded-bg: "oklch(0.64 0.11 145 / 0.14)"
+  status-running: "oklch(0.43 0.1 210)"
+  status-running-bg: "oklch(0.65 0.1 210 / 0.14)"
+  status-queued: "oklch(0.48 0.1 78)"
+  status-queued-bg: "oklch(0.74 0.1 78 / 0.16)"
+  status-failed: "color-mix(in oklab, var(--destructive) 86%, var(--foreground))"
+  status-failed-bg: "oklch(0.62 0.16 25 / 0.14)"
+  status-cancelled: "color-mix(in oklab, var(--muted-foreground) 88%, var(--foreground))"
+  status-cancelled-bg: "color-mix(in oklab, var(--foreground) 7%, transparent)"
+  dark-status-succeeded: "oklch(0.78 0.1 145)"
+  dark-status-succeeded-bg: "oklch(0.67 0.12 145 / 0.16)"
+  dark-status-running: "oklch(0.78 0.1 210)"
+  dark-status-running-bg: "oklch(0.68 0.1 210 / 0.16)"
+  dark-status-queued: "oklch(0.82 0.1 78)"
+  dark-status-queued-bg: "oklch(0.74 0.1 78 / 0.17)"
+  dark-status-failed: "oklch(0.78 0.16 25)"
+  dark-status-failed-bg: "oklch(0.62 0.16 25 / 0.16)"
+  dark-status-cancelled: "color-mix(in oklab, var(--muted-foreground) 86%, var(--foreground))"
+  dark-status-cancelled-bg: "color-mix(in oklab, var(--foreground) 8%, transparent)"
 typography:
   display:
     fontFamily: "var(--font-cabinet), sans-serif"
@@ -173,6 +193,14 @@ The palette is a warm neutral system with a low-noise bronze primary. OKLCH is c
 **The Warm Neutral Rule.** Warm neutrals are structural, not nostalgic. They make the file content readable and owned, not paper-themed or cute.
 
 **The Honest Red Rule.** Destructive red appears only when an action or state can harm, block, or permanently remove something.
+
+### Status Semantics
+
+- **Succeeded / healthy** (`--status-succeeded`, `--status-succeeded-bg`): green; completed successfully, ready, healthy, or active.
+- **Running** (`--status-running`, `--status-running-bg`): blue; currently processing, worker-held, or in-flight.
+- **Queued / warning** (`--status-queued`, `--status-queued-bg`): amber; waiting, scheduled, stale, accepted, or needs attention without failure.
+- **Failed / error** (`--status-failed`, `--status-failed-bg`): red; failed, dead, revoked, expired, destructive, or blocked.
+- **Cancelled / muted** (`--status-cancelled`, `--status-cancelled-bg`): neutral; stopped, idle, cancelled, inactive, or deliberately no-op.
 
 ## 3. Typography
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -63,6 +63,8 @@ Files, folders, previews, shares, and operational state are the content. UI chro
 
 Owners need honest status: database, file volume, worker heartbeat, queue backlog, disk warnings, updates, restore reconciliation, and beta upgrade caveats. Do not hide uncertainty behind green-looking summaries.
 
+Use status color consistently across admin and workspace operations: green for succeeded or healthy, blue for running, amber for queued or warning, red for failed or blocked, and neutral for cancelled, idle, or stopped. The same semantic status token should drive dots, text, chips, and badges so operational state never looks arbitrary.
+
 ### Small Architecture, Clear Boundaries
 
 Keep the v1 shape focused: web app, worker, PostgreSQL metadata, and local file storage. Treat microservices, desktop sync, native mobile, S3-compatible storage, and complex collaboration permissions as post-v1 work unless a clear product decision changes that.

--- a/apps/web/app/admin/admin-format.ts
+++ b/apps/web/app/admin/admin-format.ts
@@ -34,25 +34,26 @@ export const getAdminStatusClassName = (status: string) =>
     status === "healthy" ||
     status === "active" ||
     status === "up-to-date" ||
-    status === "succeeded" ||
-    status === "running"
+    status === "succeeded"
       ? "status-healthy"
-      : status === "warning" ||
-          status === "accepted" ||
-          status === "update-available" ||
-          status === "unavailable" ||
-          status === "queued" ||
-          status === "stale"
-        ? "status-warning"
-        : status === "idle" || status === "stopped"
-          ? "status-muted"
-          : status === "cancelled"
-            ? ""
-            : status === "owner"
-              ? "status-owner"
-              : status === "admin"
-                ? "status-healthy"
-                : status === "member"
-                  ? "status-member"
-                  : "status-error"
+      : status === "running"
+        ? "status-running"
+        : status === "warning" ||
+            status === "accepted" ||
+            status === "update-available" ||
+            status === "unavailable" ||
+            status === "queued" ||
+            status === "stale"
+          ? "status-warning"
+          : status === "idle" || status === "stopped"
+            ? "status-muted"
+            : status === "cancelled"
+              ? "status-cancelled"
+              : status === "owner"
+                ? "status-owner"
+                : status === "admin"
+                  ? "status-healthy"
+                  : status === "member"
+                    ? "status-member"
+                    : "status-error"
   }`;

--- a/apps/web/app/admin/jobs/job-operations.tsx
+++ b/apps/web/app/admin/jobs/job-operations.tsx
@@ -68,7 +68,13 @@ type JsonJobEvent = {
   createdAt: string;
 };
 
-type JobTone = "idle" | "queued" | "running" | "failed" | "cancelled";
+type JobTone =
+  | "idle"
+  | "queued"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "cancelled";
 
 const JOB_META: Record<string, { name: string; desc: string }> = {
   "staging.cleanup": {
@@ -248,6 +254,10 @@ function formatJobKind(kind: string) {
   );
 }
 
+function getJobDescription(kind: string) {
+  return JOB_META[kind]?.desc ?? "Background maintenance job.";
+}
+
 function isFinishedJob(job: Pick<JsonBackgroundJob, "status">) {
   return (
     job.status === "succeeded" ||
@@ -286,6 +296,7 @@ function getJobTone(status: JsonBackgroundJob["status"] | null): JobTone {
   if (status === "failed" || status === "dead") return "failed";
   if (status === "running") return "running";
   if (status === "queued") return "queued";
+  if (status === "succeeded") return "succeeded";
   if (status === "cancelled") return "cancelled";
   return "idle";
 }
@@ -347,6 +358,48 @@ function getJobStateLine({
   )}`;
 }
 
+function getJobLastFact({
+  job,
+  nowMs,
+  status,
+}: {
+  job: JsonBackgroundJob | null;
+  nowMs: number | null;
+  status: JsonBackgroundJob["status"] | null;
+}) {
+  if (!job || !status) return "Never run";
+
+  if (status === "running") {
+    return `Started ${formatRelativeTime(
+      job.startedAt ?? job.lockedAt ?? job.updatedAt,
+      nowMs,
+    )}`;
+  }
+
+  if (status === "queued") {
+    return `Queued ${formatRelativeTime(job.createdAt, nowMs)}`;
+  }
+
+  if (status === "failed" || status === "dead") {
+    return `Failed ${formatRelativeTime(
+      job.completedAt ?? job.updatedAt,
+      nowMs,
+    )}`;
+  }
+
+  if (status === "cancelled") {
+    return `Cancelled ${formatRelativeTime(
+      job.cancelledAt ?? job.updatedAt,
+      nowMs,
+    )}`;
+  }
+
+  return `Succeeded ${formatRelativeTime(
+    job.completedAt ?? job.updatedAt,
+    nowMs,
+  )}`;
+}
+
 function getPrimaryActionLabel({
   canRunManually,
   lastRun,
@@ -363,11 +416,15 @@ function getPrimaryActionLabel({
     return "Retry";
   }
 
+  if (status === "running") {
+    return "Running";
+  }
+
   if (canRunManually) {
     return "Run now";
   }
 
-  return "Run now";
+  return "Auto-run only";
 }
 
 function JsonBlock({ value }: { value: Record<string, unknown> | null }) {
@@ -611,6 +668,7 @@ function JobTaskCard({
   workerRunningJobIds: Set<string>;
 }) {
   const jobName = formatJobKind(kind);
+  const jobDescription = getJobDescription(kind);
   const canRunManually = MANUAL_RUN_JOB_KINDS.has(kind);
   const [running, setRunning] = useState(false);
   const [runError, setRunError] = useState<string | null>(null);
@@ -632,6 +690,8 @@ function JobTaskCard({
     lastRun,
     status: displayStatus,
   });
+  const primaryActionIsCommand =
+    primaryActionLabel === "Run now" || primaryActionLabel === "Retry";
 
   useEffect(() => {
     if (!detailsOpen || !selectedHistoryJobId) return;
@@ -767,40 +827,40 @@ function JobTaskCard({
     <article className={`admin-jobs-card admin-jobs-card-${tone}`}>
       <div className="admin-jobs-card-body">
         <div className="admin-jobs-card-head">
-          <span
-            aria-hidden
-            className={`admin-jobs-card-dot admin-jobs-card-dot-${tone}`}
-          />
-          <h2>{jobName}</h2>
-          <p className={`admin-jobs-card-state admin-jobs-card-state-${tone}`}>
-            {getJobStateLine({
-              job: lastRun,
-              nowMs,
-              status: displayStatus,
-              timeZone: instanceTimeZone,
-            })}
-          </p>
+          <div className="admin-jobs-card-title-row">
+            <span
+              aria-hidden
+              className={`admin-jobs-card-dot admin-jobs-card-dot-${tone}`}
+            />
+            <h2>{jobName}</h2>
+          </div>
+          <p className="admin-jobs-card-desc">{jobDescription}</p>
         </div>
 
-        {runError ? <p className="admin-jobs-card-error">{runError}</p> : null}
+        <div className="admin-jobs-card-facts">
+          <p className={`admin-jobs-card-state admin-jobs-card-state-${tone}`}>
+            {getJobLastFact({ job: lastRun, nowMs, status: displayStatus })}
+          </p>
+
+          {runError ? (
+            <p className="admin-jobs-card-error">{runError}</p>
+          ) : null}
+        </div>
       </div>
 
       <div className="admin-jobs-card-actions">
-        <button
-          className="admin-jobs-rail-action admin-jobs-rail-action-primary"
-          disabled={
-            running ||
-            (primaryActionLabel === "Run now" &&
-              (!canRunManually || displayStatus === "running"))
-          }
-          onClick={() => void handlePrimaryAction()}
-          title={
-            !canRunManually ? "Created by uploads or archives." : undefined
-          }
-          type="button"
-        >
-          {running ? "..." : primaryActionLabel}
-        </button>
+        {primaryActionIsCommand ? (
+          <button
+            className="admin-jobs-rail-action admin-jobs-rail-action-primary"
+            disabled={running}
+            onClick={() => void handlePrimaryAction()}
+            type="button"
+          >
+            {running ? "..." : primaryActionLabel}
+          </button>
+        ) : (
+          <span className="admin-jobs-rail-note">{primaryActionLabel}</span>
+        )}
         <button
           className="admin-jobs-rail-action"
           onClick={() => void openDetails()}

--- a/apps/web/app/admin/jobs/job-operations.tsx
+++ b/apps/web/app/admin/jobs/job-operations.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 
-import {
-  formatAdminDateTime,
-  getAdminStatusClassName,
-} from "@/app/admin/admin-format";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+
+import { formatAdminDateTime } from "@/app/admin/admin-format";
 
 export type JsonBackgroundJob = {
   id: string;
@@ -63,6 +63,8 @@ type JsonJobEvent = {
   createdAt: string;
 };
 
+type JobTone = "idle" | "queued" | "running" | "failed" | "cancelled";
+
 const JOB_META: Record<string, { name: string; desc: string }> = {
   "staging.cleanup": {
     name: "Staging Cleanup",
@@ -98,13 +100,20 @@ const JOB_META: Record<string, { name: string; desc: string }> = {
   },
 };
 
+const MANUAL_RUN_JOB_KINDS = new Set([
+  "staging.cleanup",
+  "trash.retention",
+  "update.check",
+  "restore.reconcile",
+]);
+
 const JOB_POLL_MS = 5000;
 const CLOCK_TICK_MS = 1000;
 const HISTORY_VISIBLE_RUNS = 12;
 
 function effectiveStatus(
   job: Pick<JsonBackgroundJob, "status" | "lastError">,
-): string {
+): JsonBackgroundJob["status"] {
   if (job.status === "dead" && job.lastError === "Cancelled by admin.") {
     return "cancelled";
   }
@@ -126,6 +135,77 @@ function formatLocalDateTime(
   return formatAdminDateTime(dateStr, timeZone);
 }
 
+function getLocalDateParts(date: Date, timeZone: string) {
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    day: "2-digit",
+    hour: "2-digit",
+    hour12: false,
+    minute: "2-digit",
+    month: "2-digit",
+    timeZone,
+    year: "numeric",
+  }).formatToParts(date);
+
+  const getPart = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((part) => part.type === type)?.value ?? "";
+
+  return {
+    day: getPart("day"),
+    hour: Number.parseInt(getPart("hour"), 10),
+    minute: getPart("minute"),
+    month: getPart("month"),
+    time: `${getPart("hour")}:${getPart("minute")}`,
+    year: getPart("year"),
+  };
+}
+
+function addDays(date: Date, days: number) {
+  const next = new Date(date);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+function getLocalDateKey(parts: ReturnType<typeof getLocalDateParts>) {
+  return `${parts.year}-${parts.month}-${parts.day}`;
+}
+
+function formatTimelineDate(
+  dateStr: string,
+  nowMs: number | null,
+  timeZone: string,
+  mode: "absolute" | "scheduled" = "absolute",
+) {
+  if (nowMs === null) return formatStableUtcDateTime(dateStr);
+
+  const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) return dateStr;
+
+  const now = new Date(nowMs);
+  const targetParts = getLocalDateParts(date, timeZone);
+  const todayKey = getLocalDateKey(getLocalDateParts(now, timeZone));
+  const tomorrowKey = getLocalDateKey(
+    getLocalDateParts(addDays(now, 1), timeZone),
+  );
+  const targetKey = getLocalDateKey(targetParts);
+
+  if (mode === "scheduled") {
+    if (targetKey === todayKey) return `${targetParts.time} today`;
+    if (targetKey === tomorrowKey && targetParts.hour < 6) {
+      return `${targetParts.time} tonight`;
+    }
+    if (targetKey === tomorrowKey) return `${targetParts.time} tomorrow`;
+  }
+
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    hour: "2-digit",
+    hour12: false,
+    minute: "2-digit",
+    month: "short",
+    timeZone,
+  }).format(date);
+}
+
 function formatRelativeTime(dateStr: string, nowMs: number | null): string {
   if (nowMs === null) {
     return formatStableUtcDateTime(dateStr);
@@ -143,52 +223,6 @@ function formatRelativeTime(dateStr: string, nowMs: number | null): string {
   return `${days}d ${suffix}`;
 }
 
-function getJobDisplayStatus(
-  job: Pick<JsonBackgroundJob, "id" | "status" | "lastError">,
-  workerRunningJobIds: Set<string>,
-): string {
-  if (workerRunningJobIds.has(job.id)) return "running";
-  return effectiveStatus(job);
-}
-
-function getJobTimingLabel(
-  job: JsonBackgroundJob,
-  nowMs: number | null,
-  timeZone?: string,
-  displayStatus = effectiveStatus(job),
-) {
-  if (displayStatus === "queued") {
-    const runAtMs = new Date(job.runAt).getTime();
-    if (nowMs !== null && runAtMs <= nowMs) {
-      return `waiting ${formatRelativeTime(job.runAt, nowMs)}`;
-    }
-    return `scheduled ${formatLocalDateTime(job.runAt, nowMs, timeZone)}`;
-  }
-
-  if (displayStatus === "running") {
-    return `started ${formatRelativeTime(
-      job.startedAt ?? job.lockedAt ?? job.updatedAt,
-      nowMs,
-    )}`;
-  }
-
-  if (displayStatus === "succeeded") {
-    return `completed ${formatRelativeTime(
-      job.completedAt ?? job.updatedAt,
-      nowMs,
-    )}`;
-  }
-
-  if (displayStatus === "cancelled") {
-    return `cancelled ${formatRelativeTime(
-      job.cancelledAt ?? job.updatedAt,
-      nowMs,
-    )}`;
-  }
-
-  return `updated ${formatRelativeTime(job.updatedAt, nowMs)}`;
-}
-
 function formatDuration(seconds: number | null) {
   if (seconds === null) return "none";
   const minutes = Math.floor(seconds / 60);
@@ -198,6 +232,16 @@ function formatDuration(seconds: number | null) {
   const days = Math.floor(hours / 24);
   if (hours < 24) return `${hours}h`;
   return `${days}d`;
+}
+
+function formatJobKind(kind: string) {
+  return (
+    JOB_META[kind]?.name ??
+    kind
+      .split(".")
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ")
+  );
 }
 
 function isFinishedJob(job: JsonBackgroundJob) {
@@ -224,50 +268,348 @@ function selectRepresentativeJob(
   );
 }
 
-function getActiveJobState(
-  jobs: JsonBackgroundJob[],
+function getJobDisplayStatus(
+  job: Pick<JsonBackgroundJob, "id" | "status" | "lastError">,
   workerRunningJobIds: Set<string>,
-) {
-  const hasRunning = jobs.some(
-    (job) => job.status === "running" || workerRunningJobIds.has(job.id),
-  );
-  const hasQueued = jobs.some((job) => job.status === "queued");
-  const activeCount = jobs.filter(
-    (job) => job.status === "queued" || job.status === "running",
-  ).length;
-
-  return { hasRunning, hasQueued, activeCount };
+): JsonBackgroundJob["status"] {
+  if (workerRunningJobIds.has(job.id)) return "running";
+  return effectiveStatus(job);
 }
 
-function JobOperationRow({
-  kind,
+function getJobTone(status: JsonBackgroundJob["status"] | null): JobTone {
+  if (status === "failed" || status === "dead") return "failed";
+  if (status === "running") return "running";
+  if (status === "queued") return "queued";
+  if (status === "cancelled") return "cancelled";
+  return "idle";
+}
+
+function getJobStateLine({
+  job,
+  nowMs,
+  status,
+  timeZone,
+}: {
+  job: JsonBackgroundJob | null;
+  nowMs: number | null;
+  status: JsonBackgroundJob["status"] | null;
+  timeZone: string;
+}) {
+  if (!job || !status) return "Never run";
+
+  if (status === "failed" || status === "dead") {
+    return `Failed ${formatTimelineDate(
+      job.completedAt ?? job.updatedAt,
+      nowMs,
+      timeZone,
+    )} · attempt ${job.attemptCount} of ${job.maxAttempts}`;
+  }
+
+  if (status === "running") {
+    return `Running since ${formatTimelineDate(
+      job.startedAt ?? job.lockedAt ?? job.updatedAt,
+      nowMs,
+      timeZone,
+    )}`;
+  }
+
+  if (status === "queued") {
+    const runAtMs = new Date(job.runAt).getTime();
+    if (nowMs !== null && runAtMs > nowMs) {
+      return `Scheduled for ${formatTimelineDate(
+        job.runAt,
+        nowMs,
+        timeZone,
+        "scheduled",
+      )}`;
+    }
+    return `Queued for ${formatTimelineDate(job.runAt, nowMs, timeZone)}`;
+  }
+
+  if (status === "cancelled") {
+    return `Cancelled ${formatTimelineDate(
+      job.cancelledAt ?? job.updatedAt,
+      nowMs,
+      timeZone,
+    )}`;
+  }
+
+  return `Last run ${formatTimelineDate(
+    job.completedAt ?? job.updatedAt,
+    nowMs,
+    timeZone,
+  )}`;
+}
+
+function getPrimaryActionLabel({
+  canRunManually,
+  lastRun,
+  status,
+}: {
+  canRunManually: boolean;
+  lastRun: JsonBackgroundJob | null;
+  status: JsonBackgroundJob["status"] | null;
+}) {
+  if (
+    lastRun &&
+    (status === "failed" || status === "dead" || status === "cancelled")
+  ) {
+    return "Retry";
+  }
+
+  if (canRunManually) {
+    return "Run now";
+  }
+
+  return "Run now";
+}
+
+function JsonBlock({ value }: { value: Record<string, unknown> | null }) {
+  if (!value || Object.keys(value).length === 0) {
+    return <p className="admin-jobs-modal-empty">No payload recorded.</p>;
+  }
+
+  return (
+    <pre className="admin-jobs-payload">{JSON.stringify(value, null, 2)}</pre>
+  );
+}
+
+function JobEventList({
+  events,
+  nowMs,
+  timeZone,
+}: {
+  events: JsonJobEvent[] | null;
+  nowMs: number | null;
+  timeZone: string;
+}) {
+  if (events === null) {
+    return <p className="admin-jobs-modal-empty">Loading events...</p>;
+  }
+
+  if (events.length === 0) {
+    return <p className="admin-jobs-modal-empty">No events recorded.</p>;
+  }
+
+  return (
+    <div className="admin-jobs-event-list">
+      {events.map((event) => (
+        <div className="admin-jobs-event-row" key={event.id}>
+          <span className="admin-jobs-event-time">
+            {formatLocalDateTime(event.createdAt, nowMs, timeZone)}
+          </span>
+          <span className="admin-jobs-event-main">
+            <strong>{event.type}</strong>
+            {event.message || event.workerId ? (
+              <span>{event.message ?? event.workerId}</span>
+            ) : null}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function JobDetailsModal({
+  actionError,
+  events,
+  history,
+  historyLoading,
+  instanceTimeZone,
+  jobName,
+  nowMs,
+  onJobAction,
+  onSelectHistoryJob,
+  open,
+  selectedHistoryJob,
+  setOpen,
+  workerRunningJobIds,
+}: {
+  actionError: string | null;
+  events: JsonJobEvent[] | null;
+  history: JsonBackgroundJob[] | null;
+  historyLoading: boolean;
+  instanceTimeZone: string;
+  jobName: string;
+  nowMs: number | null;
+  onJobAction: (jobId: string, action: "retry" | "cancel") => void;
+  onSelectHistoryJob: (jobId: string) => void;
+  open: boolean;
+  selectedHistoryJob: JsonBackgroundJob | null;
+  setOpen: (open: boolean) => void;
+  workerRunningJobIds: Set<string>;
+}) {
+  const selectedStatus = selectedHistoryJob
+    ? getJobDisplayStatus(selectedHistoryJob, workerRunningJobIds)
+    : null;
+  const selectedTone = getJobTone(selectedStatus);
+
+  return (
+    <Dialog onOpenChange={setOpen} open={open}>
+      <DialogContent className="admin-jobs-modal">
+        <div className="admin-jobs-modal-head">
+          <div>
+            <DialogTitle>{jobName}</DialogTitle>
+            {selectedHistoryJob ? (
+              <p>
+                {getJobStateLine({
+                  job: selectedHistoryJob,
+                  nowMs,
+                  status: selectedStatus,
+                  timeZone: instanceTimeZone,
+                })}
+              </p>
+            ) : null}
+          </div>
+          {selectedStatus ? (
+            <span
+              className={`admin-jobs-state admin-jobs-state-${selectedTone}`}
+            >
+              <span aria-hidden className="admin-jobs-state-dot" />
+              {selectedStatus}
+            </span>
+          ) : null}
+        </div>
+
+        {actionError ? (
+          <p className="admin-jobs-modal-error">{actionError}</p>
+        ) : null}
+
+        <div className="admin-jobs-modal-layout">
+          <section className="admin-jobs-run-list" aria-label="Recent runs">
+            <h3>Recent runs</h3>
+            {historyLoading ? (
+              <p className="admin-jobs-modal-empty">Loading runs...</p>
+            ) : history && history.length > 0 ? (
+              <div className="admin-jobs-run-buttons">
+                {history.slice(0, HISTORY_VISIBLE_RUNS).map((job) => {
+                  const status = getJobDisplayStatus(job, workerRunningJobIds);
+                  const tone = getJobTone(status);
+                  const selected = selectedHistoryJob?.id === job.id;
+
+                  return (
+                    <button
+                      aria-pressed={selected}
+                      className={`admin-jobs-run-button ${
+                        selected ? "admin-jobs-run-button-selected" : ""
+                      }`}
+                      key={job.id}
+                      onClick={() => onSelectHistoryJob(job.id)}
+                      type="button"
+                    >
+                      <span
+                        aria-hidden
+                        className={`admin-jobs-run-dot admin-jobs-run-dot-${tone}`}
+                      />
+                      <span>
+                        <strong>{status}</strong>
+                        <small>
+                          {formatRelativeTime(job.updatedAt, nowMs)}
+                        </small>
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            ) : (
+              <p className="admin-jobs-modal-empty">No runs recorded yet.</p>
+            )}
+          </section>
+
+          <section className="admin-jobs-run-detail">
+            {selectedHistoryJob ? (
+              <>
+                {selectedHistoryJob.lastError ? (
+                  <div className="admin-jobs-modal-section">
+                    <h3>Error</h3>
+                    <p className="admin-jobs-modal-error">
+                      {selectedHistoryJob.lastError}
+                    </p>
+                  </div>
+                ) : null}
+
+                <div className="admin-jobs-modal-section">
+                  <h3>Events</h3>
+                  <JobEventList
+                    events={events}
+                    nowMs={nowMs}
+                    timeZone={instanceTimeZone}
+                  />
+                </div>
+
+                <div className="admin-jobs-modal-section">
+                  <h3>Payload</h3>
+                  <JsonBlock value={selectedHistoryJob.payloadJson} />
+                </div>
+
+                <div className="admin-jobs-modal-actions">
+                  {selectedHistoryJob.status === "failed" ||
+                  selectedHistoryJob.status === "dead" ||
+                  selectedHistoryJob.status === "cancelled" ? (
+                    <button
+                      className="admin-jobs-button admin-jobs-button-primary"
+                      onClick={() =>
+                        onJobAction(selectedHistoryJob.id, "retry")
+                      }
+                      type="button"
+                    >
+                      Retry
+                    </button>
+                  ) : null}
+                  {selectedHistoryJob.status === "queued" ||
+                  selectedHistoryJob.status === "running" ? (
+                    <button
+                      className="admin-jobs-button admin-jobs-button-danger"
+                      onClick={() =>
+                        onJobAction(selectedHistoryJob.id, "cancel")
+                      }
+                      type="button"
+                    >
+                      Cancel
+                    </button>
+                  ) : null}
+                  <button
+                    className="admin-jobs-button"
+                    onClick={() => {
+                      void navigator.clipboard.writeText(selectedHistoryJob.id);
+                    }}
+                    type="button"
+                  >
+                    Copy ID
+                  </button>
+                </div>
+              </>
+            ) : (
+              <p className="admin-jobs-modal-empty">No run selected.</p>
+            )}
+          </section>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function JobTaskCard({
   initialLastRun,
+  instanceTimeZone,
+  kind,
   nowMs,
   workerRunningJobIds,
-  instanceTimeZone,
 }: {
-  kind: string;
   initialLastRun: JsonBackgroundJob | null;
+  instanceTimeZone: string;
+  kind: string;
   nowMs: number | null;
   workerRunningJobIds: Set<string>;
-  instanceTimeZone: string;
 }) {
-  const meta = JOB_META[kind];
+  const jobName = formatJobKind(kind);
+  const canRunManually = MANUAL_RUN_JOB_KINDS.has(kind);
   const [lastRun, setLastRun] = useState<JsonBackgroundJob | null>(
     initialLastRun,
   );
-  const [activeJobState, setActiveJobState] = useState({
-    hasRunning: initialLastRun?.status === "running",
-    hasQueued: initialLastRun?.status === "queued",
-    activeCount:
-      initialLastRun?.status === "queued" ||
-      initialLastRun?.status === "running"
-        ? 1
-        : 0,
-  });
   const [running, setRunning] = useState(false);
   const [runError, setRunError] = useState<string | null>(null);
-  const [historyOpen, setHistoryOpen] = useState(false);
+  const [detailsOpen, setDetailsOpen] = useState(false);
   const [history, setHistory] = useState<JsonBackgroundJob[] | null>(null);
   const [historyLoading, setHistoryLoading] = useState(false);
   const [selectedHistoryJobId, setSelectedHistoryJobId] = useState<
@@ -276,10 +618,15 @@ function JobOperationRow({
   const [events, setEvents] = useState<JsonJobEvent[] | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
-  const isActive = activeJobState.hasQueued || activeJobState.hasRunning;
-  const lastRunStatus = lastRun
+  const displayStatus = lastRun
     ? getJobDisplayStatus(lastRun, workerRunningJobIds)
     : null;
+  const tone = getJobTone(displayStatus);
+  const primaryActionLabel = getPrimaryActionLabel({
+    canRunManually,
+    lastRun,
+    status: displayStatus,
+  });
 
   useEffect(() => {
     let cancelled = false;
@@ -294,8 +641,7 @@ function JobOperationRow({
         const latest = selectRepresentativeJob(jobs, workerRunningJobIds);
         if (!cancelled) {
           setLastRun(latest);
-          setActiveJobState(getActiveJobState(jobs, workerRunningJobIds));
-          if (historyOpen) {
+          if (detailsOpen) {
             setHistory(jobs);
             setSelectedHistoryJobId((current) => current ?? latest?.id ?? null);
           }
@@ -310,64 +656,10 @@ function JobOperationRow({
       cancelled = true;
       clearInterval(id);
     };
-  }, [kind, historyOpen, workerRunningJobIds]);
-
-  const handleRun = async () => {
-    setRunning(true);
-    setRunError(null);
-    try {
-      const runRes = await fetch("/api/admin/jobs/run", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ kind }),
-      });
-      if (!runRes.ok) {
-        const body = await runRes.json().catch(() => null);
-        setRunError(body?.error ?? `Request failed (${runRes.status}).`);
-        return;
-      }
-      const res = await fetch(`/api/admin/jobs?kind=${kind}&limit=100`);
-      if (res.ok) {
-        const data = await res.json();
-        const jobs: JsonBackgroundJob[] = data.items ?? [];
-        const job = selectRepresentativeJob(jobs, workerRunningJobIds);
-        setLastRun(job);
-        setActiveJobState(getActiveJobState(jobs, workerRunningJobIds));
-        if (historyOpen && job) {
-          setHistory((prev) =>
-            prev ? [job, ...prev.filter((j) => j.id !== job.id)] : [job],
-          );
-        }
-      }
-    } finally {
-      setRunning(false);
-    }
-  };
-
-  const postJobAction = async (jobId: string, action: "retry" | "cancel") => {
-    setActionError(null);
-    const res = await fetch(`/api/admin/jobs/${jobId}/${action}`, {
-      method: "POST",
-    });
-    if (!res.ok) {
-      const body = await res.json().catch(() => null);
-      setActionError(body?.error ?? `Request failed (${res.status}).`);
-      return;
-    }
-    const updated = await fetch(
-      `/api/admin/jobs?kind=${encodeURIComponent(kind)}&limit=100`,
-    );
-    if (updated.ok) {
-      const data = await updated.json();
-      const jobs: JsonBackgroundJob[] = data.items ?? [];
-      setHistory(jobs);
-      setLastRun(selectRepresentativeJob(jobs, workerRunningJobIds));
-      setActiveJobState(getActiveJobState(jobs, workerRunningJobIds));
-    }
-  };
+  }, [kind, detailsOpen, workerRunningJobIds]);
 
   useEffect(() => {
-    if (!historyOpen || !selectedHistoryJobId) return;
+    if (!detailsOpen || !selectedHistoryJobId) return;
 
     let cancelled = false;
     setEvents(null);
@@ -384,263 +676,166 @@ function JobOperationRow({
     return () => {
       cancelled = true;
     };
-  }, [historyOpen, selectedHistoryJobId]);
+  }, [detailsOpen, selectedHistoryJobId]);
 
-  const handleToggleHistory = async () => {
-    const opening = !historyOpen;
-    setHistoryOpen(opening);
-    if (opening && history === null) {
-      setHistoryLoading(true);
-      try {
-        const res = await fetch(`/api/admin/jobs?kind=${kind}&limit=100`);
-        if (res.ok) {
-          const data = await res.json();
-          const jobs: JsonBackgroundJob[] = data.items ?? [];
-          const selected = selectRepresentativeJob(jobs, workerRunningJobIds);
-          setHistory(jobs);
-          setSelectedHistoryJobId(selected?.id ?? jobs[0]?.id ?? null);
-        }
-      } finally {
-        setHistoryLoading(false);
+  const refreshJobs = async () => {
+    const updated = await fetch(
+      `/api/admin/jobs?kind=${encodeURIComponent(kind)}&limit=100`,
+    );
+    if (!updated.ok) return;
+
+    const data = await updated.json();
+    const jobs: JsonBackgroundJob[] = data.items ?? [];
+    setHistory(jobs);
+    setLastRun(selectRepresentativeJob(jobs, workerRunningJobIds));
+    setSelectedHistoryJobId((current) => current ?? jobs[0]?.id ?? null);
+  };
+
+  const openDetails = async () => {
+    setDetailsOpen(true);
+    setSelectedHistoryJobId((current) => current ?? lastRun?.id ?? null);
+    if (history !== null) return;
+
+    setHistoryLoading(true);
+    try {
+      const res = await fetch(
+        `/api/admin/jobs?kind=${encodeURIComponent(kind)}&limit=100`,
+      );
+      if (res.ok) {
+        const data = await res.json();
+        const jobs: JsonBackgroundJob[] = data.items ?? [];
+        const selected = selectRepresentativeJob(jobs, workerRunningJobIds);
+        setHistory(jobs);
+        setSelectedHistoryJobId(selected?.id ?? jobs[0]?.id ?? null);
       }
+    } finally {
+      setHistoryLoading(false);
     }
   };
 
-  const visibleHistory = history?.slice(0, HISTORY_VISIBLE_RUNS) ?? [];
+  const handleRun = async () => {
+    if (!canRunManually) {
+      await openDetails();
+      return;
+    }
+
+    setRunning(true);
+    setRunError(null);
+    try {
+      const runRes = await fetch("/api/admin/jobs/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind }),
+      });
+      if (!runRes.ok) {
+        const body = await runRes.json().catch(() => null);
+        setRunError(body?.error ?? `Request failed (${runRes.status}).`);
+        return;
+      }
+      await refreshJobs();
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const postJobAction = async (jobId: string, action: "retry" | "cancel") => {
+    setActionError(null);
+    setRunError(null);
+    const res = await fetch(`/api/admin/jobs/${jobId}/${action}`, {
+      method: "POST",
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => null);
+      const message = body?.error ?? `Request failed (${res.status}).`;
+      setActionError(message);
+      setRunError(message);
+      return;
+    }
+    await refreshJobs();
+  };
+
+  const handlePrimaryAction = async () => {
+    if (
+      lastRun &&
+      (displayStatus === "failed" ||
+        displayStatus === "dead" ||
+        displayStatus === "cancelled")
+    ) {
+      await postJobAction(lastRun.id, "retry");
+      return;
+    }
+
+    await handleRun();
+  };
+
   const selectedHistoryJob =
     history?.find((job) => job.id === selectedHistoryJobId) ??
-    visibleHistory[0] ??
-    null;
+    history?.[0] ??
+    lastRun;
 
   return (
-    <>
-      <div className="admin-op-row">
-        <div className="admin-op-meta">
-          <span className="admin-op-name">{meta?.name ?? kind}</span>
-          <span className="admin-op-desc">{meta?.desc}</span>
-          {lastRun ? (
-            <span className="admin-op-last">
-              <span className={getAdminStatusClassName(lastRunStatus ?? "")}>
-                {lastRunStatus}
-              </span>{" "}
-              ·{" "}
-              {getJobTimingLabel(
-                lastRun,
-                nowMs,
-                instanceTimeZone,
-                lastRunStatus ?? undefined,
-              )}
-              {activeJobState.activeCount > 1 && (
-                <>
-                  {" "}
-                  · <strong>{activeJobState.activeCount} active</strong>
-                </>
-              )}
-            </span>
-          ) : (
-            <span className="admin-op-last">Never run</span>
-          )}
+    <article className={`admin-jobs-card admin-jobs-card-${tone}`}>
+      <div className="admin-jobs-card-body">
+        <div className="admin-jobs-card-head">
+          <span
+            aria-hidden
+            className={`admin-jobs-card-dot admin-jobs-card-dot-${tone}`}
+          />
+          <h2>{jobName}</h2>
+          <p className={`admin-jobs-card-state admin-jobs-card-state-${tone}`}>
+            {getJobStateLine({
+              job: lastRun,
+              nowMs,
+              status: displayStatus,
+              timeZone: instanceTimeZone,
+            })}
+          </p>
         </div>
-        <div className="admin-op-actions">
-          <button
-            className="button button-secondary"
-            disabled={running || isActive}
-            onClick={handleRun}
-            style={{ fontSize: "0.8125rem" }}
-          >
-            {running
-              ? "Queuing…"
-              : activeJobState.hasRunning
-                ? "Running"
-                : activeJobState.hasQueued
-                  ? "Scheduled"
-                  : "Run"}
-          </button>
-          <button
-            className="button button-secondary"
-            onClick={handleToggleHistory}
-            style={{ fontSize: "0.8125rem" }}
-          >
-            History {historyOpen ? "▴" : "▾"}
-          </button>
-          {runError ? (
-            <span
-              className="muted"
-              style={{ fontSize: "0.8125rem", color: "var(--destructive)" }}
-            >
-              {runError}
-            </span>
-          ) : null}
-          {actionError ? (
-            <span
-              className="muted"
-              style={{ fontSize: "0.8125rem", color: "var(--destructive)" }}
-            >
-              {actionError}
-            </span>
-          ) : null}
-        </div>
+
+        {runError ? <p className="admin-jobs-card-error">{runError}</p> : null}
       </div>
-      {historyOpen && (
-        <div className="admin-job-history-panel">
-          {historyLoading ? (
-            <p
-              className="muted"
-              style={{ fontSize: "0.8125rem", padding: "8px 0" }}
-            >
-              Loading…
-            </p>
-          ) : history && history.length > 0 ? (
-            <div className="admin-job-history-layout">
-              <div className="admin-job-run-list">
-                <div className="admin-job-history-head">
-                  <span>Recent runs</span>
-                  <span className="muted">
-                    {visibleHistory.length} of {history.length}
-                  </span>
-                </div>
-                {visibleHistory.map((job) => {
-                  const displayStatus = getJobDisplayStatus(
-                    job,
-                    workerRunningJobIds,
-                  );
-                  return (
-                    <button
-                      className={`admin-job-run-button ${
-                        selectedHistoryJob?.id === job.id
-                          ? "admin-job-run-button-active"
-                          : ""
-                      }`}
-                      key={job.id}
-                      onClick={() => setSelectedHistoryJobId(job.id)}
-                      type="button"
-                    >
-                      <span className={getAdminStatusClassName(displayStatus)}>
-                        {displayStatus}
-                      </span>
-                      <span>
-                        {getJobTimingLabel(
-                          job,
-                          nowMs,
-                          instanceTimeZone,
-                          displayStatus,
-                        )}
-                      </span>
-                    </button>
-                  );
-                })}
-              </div>
 
-              <div className="admin-job-detail">
-                {selectedHistoryJob ? (
-                  <>
-                    <div className="admin-job-detail-head">
-                      <div>
-                        <p className="admin-job-detail-title">
-                          {getJobTimingLabel(
-                            selectedHistoryJob,
-                            nowMs,
-                            instanceTimeZone,
-                            getJobDisplayStatus(
-                              selectedHistoryJob,
-                              workerRunningJobIds,
-                            ),
-                          )}
-                        </p>
-                        <p className="muted admin-job-detail-id">
-                          {selectedHistoryJob.id}
-                        </p>
-                      </div>
-                      <span
-                        className={getAdminStatusClassName(
-                          getJobDisplayStatus(
-                            selectedHistoryJob,
-                            workerRunningJobIds,
-                          ),
-                        )}
-                      >
-                        {getJobDisplayStatus(
-                          selectedHistoryJob,
-                          workerRunningJobIds,
-                        )}
-                      </span>
-                    </div>
+      <div className="admin-jobs-card-actions">
+        <button
+          className="admin-jobs-rail-action admin-jobs-rail-action-primary"
+          disabled={
+            running ||
+            (primaryActionLabel === "Run now" &&
+              (!canRunManually || displayStatus === "running"))
+          }
+          onClick={() => void handlePrimaryAction()}
+          title={
+            !canRunManually ? "Created by uploads or archives." : undefined
+          }
+          type="button"
+        >
+          {running ? "..." : primaryActionLabel}
+        </button>
+        <button
+          className="admin-jobs-rail-action"
+          onClick={() => void openDetails()}
+          type="button"
+        >
+          Details
+        </button>
+      </div>
 
-                    {selectedHistoryJob.lastError ? (
-                      <p className="admin-job-detail-error">
-                        {selectedHistoryJob.lastError}
-                      </p>
-                    ) : null}
-
-                    <div className="admin-job-detail-actions">
-                      {selectedHistoryJob.status === "failed" ||
-                      selectedHistoryJob.status === "dead" ||
-                      selectedHistoryJob.status === "cancelled" ? (
-                        <button
-                          className="button button-secondary"
-                          onClick={() =>
-                            void postJobAction(selectedHistoryJob.id, "retry")
-                          }
-                          style={{ fontSize: "0.75rem", padding: "4px 10px" }}
-                        >
-                          Retry
-                        </button>
-                      ) : null}
-                      {selectedHistoryJob.status === "queued" ||
-                      selectedHistoryJob.status === "running" ? (
-                        <button
-                          className="button button-secondary"
-                          onClick={() =>
-                            void postJobAction(selectedHistoryJob.id, "cancel")
-                          }
-                          style={{ fontSize: "0.75rem", padding: "4px 10px" }}
-                        >
-                          Cancel
-                        </button>
-                      ) : null}
-                    </div>
-
-                    <div className="admin-job-events">
-                      <p className="admin-eyebrow">Events</p>
-                      {events === null ? (
-                        <p className="muted admin-job-events-empty">Loading…</p>
-                      ) : events.length > 0 ? (
-                        events.map((event) => (
-                          <div className="admin-job-event-row" key={event.id}>
-                            <span className="status-chip">{event.type}</span>
-                            <span className="muted">
-                              {formatLocalDateTime(
-                                event.createdAt,
-                                nowMs,
-                                instanceTimeZone,
-                              )}
-                            </span>
-                            <span className="muted">
-                              {event.message ?? event.workerId ?? ""}
-                            </span>
-                          </div>
-                        ))
-                      ) : (
-                        <p className="muted admin-job-events-empty">
-                          No events recorded.
-                        </p>
-                      )}
-                    </div>
-                  </>
-                ) : null}
-              </div>
-            </div>
-          ) : (
-            <p
-              className="muted"
-              style={{ fontSize: "0.8125rem", padding: "8px 0" }}
-            >
-              No runs recorded yet.
-            </p>
-          )}
-        </div>
-      )}
-    </>
+      <JobDetailsModal
+        actionError={actionError}
+        events={events}
+        history={history}
+        historyLoading={historyLoading}
+        instanceTimeZone={instanceTimeZone}
+        jobName={jobName}
+        nowMs={nowMs}
+        onJobAction={(jobId, action) => void postJobAction(jobId, action)}
+        onSelectHistoryJob={setSelectedHistoryJobId}
+        open={detailsOpen}
+        selectedHistoryJob={selectedHistoryJob}
+        setOpen={setDetailsOpen}
+        workerRunningJobIds={workerRunningJobIds}
+      />
+    </article>
   );
 }
 
@@ -661,12 +856,9 @@ export function JobOperations({
   const [nowMs, setNowMs] = useState<number | null>(null);
   const activeQueueCount =
     summary.statusCounts.queued + summary.statusCounts.running;
-  const activeWorkers = summary.workers.filter(
+  const onlineWorkers = summary.workers.filter(
     (worker) => worker.status !== "stopped" && worker.status !== "stale",
-  );
-  const inactiveWorkers = summary.workers.filter(
-    (worker) => worker.status === "stopped" || worker.status === "stale",
-  );
+  ).length;
   const workerRunningJobIds = useMemo(
     () =>
       new Set(
@@ -699,104 +891,51 @@ export function JobOperations({
   }, []);
 
   return (
-    <div className="stack" style={{ gap: "24px" }}>
-      <dl className="admin-kv-strip">
-        <div className="admin-kv-item">
-          <dt className="admin-kv-label">Queue</dt>
-          <dd className="admin-kv-value">{activeQueueCount}</dd>
-          <dd className="admin-kv-sub">
-            {summary.statusCounts.queued} scheduled ·{" "}
-            {summary.statusCounts.running} running
-          </dd>
+    <div className="admin-jobs-page">
+      <header className="admin-jobs-header">
+        <h1>Jobs</h1>
+        <div className="admin-jobs-summary" aria-label="Queue summary">
+          <span>
+            <strong>{summary.statusCounts.running}</strong> running
+          </span>
+          <span>
+            <strong>{summary.statusCounts.queued}</strong> queued
+          </span>
+          <span className="admin-jobs-summary-danger">
+            <strong>{summary.failed + summary.dead}</strong> failed
+          </span>
+          <span>
+            <strong>{onlineWorkers}</strong> worker
+            {onlineWorkers === 1 ? "" : "s"}
+          </span>
+          <span>
+            oldest due{" "}
+            <strong>{formatDuration(summary.oldestDueQueuedAgeSeconds)}</strong>
+          </span>
+          <span>
+            active <strong>{activeQueueCount}</strong>
+          </span>
         </div>
-        <div className="admin-kv-item">
-          <dt className="admin-kv-label">Failures</dt>
-          <dd className="admin-kv-value">{summary.failed + summary.dead}</dd>
-          <dd className="admin-kv-sub">
-            {summary.failed} failed · {summary.dead} dead
-          </dd>
-        </div>
-        <div className="admin-kv-item">
-          <dt className="admin-kv-label">Due backlog</dt>
-          <dd className="admin-kv-value">
-            {formatDuration(summary.oldestDueQueuedAgeSeconds)}
-          </dd>
-          <dd className="admin-kv-sub">
-            next{" "}
-            {summary.nextQueuedRunAt
-              ? formatLocalDateTime(
-                  summary.nextQueuedRunAt,
-                  nowMs,
-                  instanceTimeZone,
-                )
-              : "none"}{" "}
-            · {summary.staleRunning} stale running
-          </dd>
-        </div>
-        <div className="admin-kv-item">
-          <dt className="admin-kv-label">Time zone</dt>
-          <dd className="admin-kv-value">{instanceTimeZone}</dd>
-          <dd className="admin-kv-sub">maintenance schedule</dd>
-        </div>
-      </dl>
+        <Link className="admin-jobs-schedule-link" href="/admin/settings">
+          Schedule
+        </Link>
+      </header>
 
-      {summary.workers.length > 0 ? (
-        <section>
-          <p className="admin-eyebrow">Workers</p>
-          <div className="admin-worker-grid">
-            {activeWorkers.map((worker) => (
-              <div className="admin-worker-row" key={worker.id}>
-                <span className={getAdminStatusClassName(worker.status)}>
-                  {worker.status}
-                </span>
-                <span className="admin-worker-name">
-                  {worker.hostname}:{worker.pid}
-                </span>
-                <span className="muted">
-                  last seen {formatRelativeTime(worker.lastHeartbeatAt, nowMs)}
-                </span>
-              </div>
-            ))}
-          </div>
-          {inactiveWorkers.length > 0 ? (
-            <details className="admin-worker-archive">
-              <summary>
-                {inactiveWorkers.length} stopped or stale worker
-                {inactiveWorkers.length === 1 ? "" : "s"}
-              </summary>
-              <div className="admin-worker-grid admin-worker-grid-archived">
-                {inactiveWorkers.map((worker) => (
-                  <div className="admin-worker-row" key={worker.id}>
-                    <span className={getAdminStatusClassName(worker.status)}>
-                      {worker.status}
-                    </span>
-                    <span className="admin-worker-name">
-                      {worker.hostname}:{worker.pid}
-                    </span>
-                    <span className="muted">
-                      last seen{" "}
-                      {formatRelativeTime(worker.lastHeartbeatAt, nowMs)}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </details>
-          ) : null}
-        </section>
-      ) : null}
-
-      <div className="admin-op-list">
-        {jobKinds.map((kind) => (
-          <JobOperationRow
-            initialLastRun={initialLastRuns[kind] ?? null}
-            key={kind}
-            kind={kind}
-            nowMs={nowMs}
-            workerRunningJobIds={workerRunningJobIds}
-            instanceTimeZone={instanceTimeZone}
-          />
-        ))}
-      </div>
+      <section className="admin-jobs-grid" aria-label="Background jobs">
+        {jobKinds.map((kind) => {
+          const lastRun = initialLastRuns[kind] ?? null;
+          return (
+            <JobTaskCard
+              initialLastRun={lastRun}
+              instanceTimeZone={instanceTimeZone}
+              key={kind}
+              kind={kind}
+              nowMs={nowMs}
+              workerRunningJobIds={workerRunningJobIds}
+            />
+          );
+        })}
+      </section>
     </div>
   );
 }

--- a/apps/web/app/admin/jobs/job-operations.tsx
+++ b/apps/web/app/admin/jobs/job-operations.tsx
@@ -4,6 +4,14 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 import { formatAdminDateTime } from "@/app/admin/admin-format";
 
@@ -120,6 +128,30 @@ const MANUAL_RUN_JOB_KINDS = new Set([
 
 const CLOCK_TICK_MS = 1000;
 const HISTORY_VISIBLE_RUNS = 12;
+const ACTIVITY_PAGE_SIZE = 25;
+
+type ActivityFilter = "all" | "active" | "failed" | "done";
+
+type JsonJobListResponse = {
+  items: JsonBackgroundJob[];
+  nextCursor: string | null;
+};
+
+const ACTIVITY_FILTER_LABELS: Record<ActivityFilter, string> = {
+  all: "All",
+  active: "Active",
+  failed: "Failed",
+  done: "Done",
+};
+
+const ACTIVITY_FILTER_STATUSES: Record<
+  Exclude<ActivityFilter, "all">,
+  JsonBackgroundJob["status"][]
+> = {
+  active: ["queued", "running"],
+  failed: ["failed", "dead"],
+  done: ["succeeded", "cancelled"],
+};
 
 function effectiveStatus(
   job: Pick<JsonBackgroundJob, "status" | "lastError">,
@@ -425,6 +457,98 @@ function getPrimaryActionLabel({
   }
 
   return "Auto-run only";
+}
+
+function buildJobsUrl({
+  cursor,
+  kind,
+  limit = ACTIVITY_PAGE_SIZE,
+  status,
+}: {
+  cursor?: string | null;
+  kind?: string | null;
+  limit?: number;
+  status?: JsonBackgroundJob["status"] | null;
+}) {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (cursor) params.set("cursor", cursor);
+  if (kind) params.set("kind", kind);
+  if (status) params.set("status", status);
+  return `/api/admin/jobs?${params.toString()}`;
+}
+
+function sortJobsByUpdatedAt(jobs: JsonBackgroundJob[]) {
+  return [...jobs].sort(
+    (left, right) =>
+      new Date(right.updatedAt).getTime() -
+        new Date(left.updatedAt).getTime() || right.id.localeCompare(left.id),
+  );
+}
+
+function mergeJobsById(
+  current: JsonBackgroundJob[],
+  incoming: JsonBackgroundJob[],
+) {
+  const byId = new Map<string, JsonBackgroundJob>();
+  for (const job of [...current, ...incoming]) {
+    byId.set(job.id, job);
+  }
+  return sortJobsByUpdatedAt([...byId.values()]);
+}
+
+async function fetchActivityJobs({
+  cursor = null,
+  filter,
+  kind,
+}: {
+  cursor?: string | null;
+  filter: ActivityFilter;
+  kind: string | null;
+}) {
+  if (filter === "all") {
+    const res = await fetch(buildJobsUrl({ cursor, kind }));
+    if (!res.ok) throw new Error(`Request failed (${res.status}).`);
+    return (await res.json()) as JsonJobListResponse;
+  }
+
+  const pages = await Promise.all(
+    ACTIVITY_FILTER_STATUSES[filter].map(async (status) => {
+      const res = await fetch(
+        buildJobsUrl({ kind, limit: ACTIVITY_PAGE_SIZE, status }),
+      );
+      if (!res.ok) throw new Error(`Request failed (${res.status}).`);
+      return (await res.json()) as JsonJobListResponse;
+    }),
+  );
+
+  return {
+    items: sortJobsByUpdatedAt(pages.flatMap((page) => page.items)).slice(
+      0,
+      ACTIVITY_PAGE_SIZE,
+    ),
+    nextCursor: null,
+  } satisfies JsonJobListResponse;
+}
+
+function getActivityDetail(job: JsonBackgroundJob) {
+  if (job.lastError) return job.lastError;
+  if (job.fileName) return job.fileName;
+  if (job.dedupeKey) return job.dedupeKey;
+  return job.id;
+}
+
+function jobMatchesActivityView({
+  filter,
+  job,
+  kind,
+}: {
+  filter: ActivityFilter;
+  job: JsonBackgroundJob;
+  kind: string | null;
+}) {
+  if (kind && job.kind !== kind) return false;
+  if (filter === "all") return true;
+  return ACTIVITY_FILTER_STATUSES[filter].includes(effectiveStatus(job));
 }
 
 function JsonBlock({ value }: { value: Record<string, unknown> | null }) {
@@ -889,6 +1013,352 @@ function JobTaskCard({
   );
 }
 
+function JobActivityPanel({
+  instanceTimeZone,
+  jobKinds,
+  liveJobs,
+  nowMs,
+  onLastRunChange,
+  workerRunningJobIds,
+}: {
+  instanceTimeZone: string;
+  jobKinds: string[];
+  liveJobs: JsonBackgroundJob[];
+  nowMs: number | null;
+  onLastRunChange: (kind: string, job: JsonBackgroundJob | null) => void;
+  workerRunningJobIds: Set<string>;
+}) {
+  const [filter, setFilter] = useState<ActivityFilter>("all");
+  const [kindFilter, setKindFilter] = useState("all");
+  const [items, setItems] = useState<JsonBackgroundJob[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  const [selectedKind, setSelectedKind] = useState<string | null>(null);
+  const [history, setHistory] = useState<JsonBackgroundJob[] | null>(null);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [selectedHistoryJobId, setSelectedHistoryJobId] = useState<
+    string | null
+  >(null);
+  const [events, setEvents] = useState<JsonJobEvent[] | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const selectedHistoryJob =
+    history?.find((job) => job.id === selectedHistoryJobId) ??
+    history?.[0] ??
+    items.find((job) => job.id === selectedHistoryJobId) ??
+    null;
+
+  const kindFilterOptions = useMemo(
+    () => [
+      { label: "All jobs", value: "all" },
+      ...jobKinds.map((kind) => ({ label: formatJobKind(kind), value: kind })),
+    ],
+    [jobKinds],
+  );
+  const activityKind = kindFilter === "all" ? null : kindFilter;
+  const isInitialActivityLoad = loading && items.length === 0;
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setLoadError(null);
+    setNextCursor(null);
+
+    void fetchActivityJobs({ filter, kind: activityKind })
+      .then((data) => {
+        if (cancelled) return;
+        setItems(data.items);
+        setNextCursor(data.nextCursor);
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setLoadError(
+            error instanceof Error ? error.message : "Failed to load jobs.",
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activityKind, filter]);
+
+  useEffect(() => {
+    if (liveJobs.length === 0) return;
+
+    setItems((current) => {
+      const liveJobIds = new Set(liveJobs.map((job) => job.id));
+      const visibleLiveJobs = liveJobs.filter((job) =>
+        jobMatchesActivityView({ filter, job, kind: activityKind }),
+      );
+      const visibleLiveJobIds = new Set(visibleLiveJobs.map((job) => job.id));
+
+      return mergeJobsById(
+        current.filter(
+          (job) => !liveJobIds.has(job.id) || visibleLiveJobIds.has(job.id),
+        ),
+        visibleLiveJobs,
+      );
+    });
+  }, [activityKind, filter, liveJobs]);
+
+  useEffect(() => {
+    if (!selectedHistoryJobId || liveJobs.length === 0) return;
+    const liveSelectedJob = liveJobs.find(
+      (job) => job.id === selectedHistoryJobId,
+    );
+    if (!liveSelectedJob) return;
+
+    setHistory((current) =>
+      current ? mergeJobsById(current, [liveSelectedJob]) : current,
+    );
+  }, [liveJobs, selectedHistoryJobId]);
+
+  useEffect(() => {
+    if (!detailsOpen || !selectedHistoryJobId) return;
+
+    let cancelled = false;
+    setEvents(null);
+    void fetch(`/api/admin/jobs/${selectedHistoryJobId}/events`)
+      .then(async (res) => {
+        if (!res.ok || cancelled) return;
+        const data = await res.json();
+        setEvents(data.items ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setEvents([]);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [detailsOpen, selectedHistoryJobId]);
+
+  const refreshActivity = async () => {
+    const data = await fetchActivityJobs({ filter, kind: activityKind });
+    setItems(data.items);
+    setNextCursor(data.nextCursor);
+  };
+
+  const refreshHistory = async (kind: string, selectedJobId?: string) => {
+    setHistoryLoading(true);
+    try {
+      const res = await fetch(buildJobsUrl({ kind, limit: 100 }));
+      if (!res.ok) return;
+      const data = (await res.json()) as JsonJobListResponse;
+      const nextSelectedJobId =
+        selectedJobId && data.items.some((job) => job.id === selectedJobId)
+          ? selectedJobId
+          : (data.items[0]?.id ?? null);
+
+      setHistory(data.items);
+      onLastRunChange(
+        kind,
+        selectRepresentativeJob(data.items, workerRunningJobIds),
+      );
+      setSelectedHistoryJobId(nextSelectedJobId);
+    } finally {
+      setHistoryLoading(false);
+    }
+  };
+
+  const openDetails = async (job: JsonBackgroundJob) => {
+    setActionError(null);
+    setDetailsOpen(true);
+    setSelectedKind(job.kind);
+    setHistory([job]);
+    setSelectedHistoryJobId(job.id);
+    await refreshHistory(job.kind, job.id);
+  };
+
+  const postJobAction = async (jobId: string, action: "retry" | "cancel") => {
+    if (!selectedKind) return;
+    setActionError(null);
+    const res = await fetch(`/api/admin/jobs/${jobId}/${action}`, {
+      method: "POST",
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => null);
+      setActionError(body?.error ?? `Request failed (${res.status}).`);
+      return;
+    }
+    await Promise.all([refreshActivity(), refreshHistory(selectedKind, jobId)]);
+  };
+
+  const loadMore = async () => {
+    if (!nextCursor || loadingMore) return;
+    setLoadingMore(true);
+    setLoadError(null);
+    try {
+      const data = await fetchActivityJobs({
+        cursor: nextCursor,
+        filter,
+        kind: activityKind,
+      });
+      setItems((current) => mergeJobsById(current, data.items));
+      setNextCursor(data.nextCursor);
+    } catch (error) {
+      setLoadError(
+        error instanceof Error ? error.message : "Failed to load jobs.",
+      );
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  return (
+    <section className="admin-jobs-activity" aria-label="Job activity">
+      <div className="admin-jobs-activity-head">
+        <div>
+          <h2>Job activity</h2>
+          <p>Recent queued, running, failed, and completed work.</p>
+        </div>
+        <div className="admin-jobs-activity-controls">
+          <div className="admin-jobs-activity-tabs">
+            {(Object.keys(ACTIVITY_FILTER_LABELS) as ActivityFilter[]).map(
+              (value) => (
+                <button
+                  aria-pressed={filter === value}
+                  className={
+                    filter === value ? "admin-jobs-activity-tab-active" : ""
+                  }
+                  key={value}
+                  onClick={() => setFilter(value)}
+                  type="button"
+                >
+                  {ACTIVITY_FILTER_LABELS[value]}
+                </button>
+              ),
+            )}
+          </div>
+          <div className="admin-jobs-kind-filter">
+            <Select
+              items={kindFilterOptions}
+              onValueChange={(value) => setKindFilter(value ?? "all")}
+              value={kindFilter}
+            >
+              <SelectTrigger
+                aria-label="Kind"
+                className="admin-jobs-kind-select-trigger"
+              >
+                <SelectValue placeholder="Kind" />
+              </SelectTrigger>
+              <SelectContent
+                align="end"
+                alignItemWithTrigger={false}
+                className="admin-jobs-kind-select-content"
+              >
+                <SelectGroup>
+                  {kindFilterOptions.map((option) => (
+                    <SelectItem
+                      className="admin-jobs-kind-select-item"
+                      key={option.value}
+                      value={option.value}
+                    >
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </div>
+
+      {loadError ? (
+        <p className="admin-jobs-activity-error">{loadError}</p>
+      ) : null}
+
+      <div className="admin-jobs-activity-list">
+        {isInitialActivityLoad ? (
+          <p className="admin-jobs-activity-empty">Loading activity...</p>
+        ) : items.length > 0 ? (
+          <>
+            {loading ? (
+              <p className="admin-jobs-activity-updating">Updating...</p>
+            ) : null}
+            {items.map((job) => {
+              const status = getJobDisplayStatus(job, workerRunningJobIds);
+              const tone = getJobTone(status);
+
+              return (
+                <button
+                  className="admin-jobs-activity-row"
+                  key={job.id}
+                  onClick={() => void openDetails(job)}
+                  type="button"
+                >
+                  <span
+                    aria-hidden
+                    className={`admin-jobs-run-dot admin-jobs-run-dot-${tone}`}
+                  />
+                  <span className="admin-jobs-activity-main">
+                    <strong>{formatJobKind(job.kind)}</strong>
+                    <small>
+                      {getJobStateLine({
+                        job,
+                        nowMs,
+                        status,
+                        timeZone: instanceTimeZone,
+                      })}
+                    </small>
+                  </span>
+                  <span
+                    className={`admin-jobs-activity-status admin-jobs-state-${tone}`}
+                  >
+                    {status}
+                  </span>
+                  <span className="admin-jobs-activity-attempt">
+                    {job.attemptCount}/{job.maxAttempts}
+                  </span>
+                  <span className="admin-jobs-activity-detail">
+                    {getActivityDetail(job)}
+                  </span>
+                </button>
+              );
+            })}
+          </>
+        ) : (
+          <p className="admin-jobs-activity-empty">No jobs match this view.</p>
+        )}
+      </div>
+
+      {nextCursor ? (
+        <button
+          className="admin-jobs-activity-more"
+          disabled={loadingMore}
+          onClick={() => void loadMore()}
+          type="button"
+        >
+          {loadingMore ? "Loading..." : "Load more"}
+        </button>
+      ) : null}
+
+      <JobDetailsModal
+        actionError={actionError}
+        events={events}
+        history={history}
+        historyLoading={historyLoading}
+        instanceTimeZone={instanceTimeZone}
+        jobName={selectedKind ? formatJobKind(selectedKind) : "Job"}
+        nowMs={nowMs}
+        onJobAction={(jobId, action) => void postJobAction(jobId, action)}
+        onSelectHistoryJob={setSelectedHistoryJobId}
+        open={detailsOpen}
+        selectedHistoryJob={selectedHistoryJob}
+        setOpen={setDetailsOpen}
+        workerRunningJobIds={workerRunningJobIds}
+      />
+    </section>
+  );
+}
+
 type Props = {
   initialLastRuns: Record<string, JsonBackgroundJob | null>;
   initialSummary: JsonJobSummary;
@@ -931,6 +1401,13 @@ export function JobOperations({
           .filter((jobId): jobId is string => Boolean(jobId)),
       ),
     [summary.workers],
+  );
+  const liveJobs = useMemo(
+    () =>
+      Object.values(lastRuns).filter(
+        (job): job is JsonBackgroundJob => job !== null,
+      ),
+    [lastRuns],
   );
 
   useEffect(() => {
@@ -1009,6 +1486,20 @@ export function JobOperations({
           );
         })}
       </section>
+
+      <JobActivityPanel
+        instanceTimeZone={instanceTimeZone}
+        jobKinds={jobKinds}
+        liveJobs={liveJobs}
+        nowMs={nowMs}
+        onLastRunChange={(updatedKind, job) => {
+          setLastRuns((current) => ({
+            ...current,
+            [updatedKind]: job,
+          }));
+        }}
+        workerRunningJobIds={workerRunningJobIds}
+      />
     </div>
   );
 }

--- a/apps/web/app/admin/jobs/job-operations.tsx
+++ b/apps/web/app/admin/jobs/job-operations.tsx
@@ -907,9 +907,21 @@ export function JobOperations({
   const [nowMs, setNowMs] = useState<number | null>(null);
   const activeQueueCount =
     summary.statusCounts.queued + summary.statusCounts.running;
+  const failedCount = summary.failed + summary.dead;
+  const oldestDueLabel = formatDuration(summary.oldestDueQueuedAgeSeconds);
   const onlineWorkers = summary.workers.filter(
     (worker) => worker.status !== "stopped" && worker.status !== "stale",
   ).length;
+  const workerNoun = onlineWorkers === 1 ? "worker" : "workers";
+  const workerLabel = `${onlineWorkers} ${workerNoun}`;
+  const queueSummaryLabel = [
+    `${summary.statusCounts.running} running`,
+    `${summary.statusCounts.queued} queued`,
+    `${failedCount} failed`,
+    workerLabel,
+    `oldest due ${oldestDueLabel}`,
+    `active ${activeQueueCount}`,
+  ].join(", ");
   const workerRunningJobIds = useMemo(
     () =>
       new Set(
@@ -948,7 +960,10 @@ export function JobOperations({
     <div className="admin-jobs-page">
       <header className="admin-jobs-header">
         <h1>Jobs</h1>
-        <div className="admin-jobs-summary" aria-label="Queue summary">
+        <div
+          className="admin-jobs-summary"
+          aria-label={`Queue summary: ${queueSummaryLabel}.`}
+        >
           <span>
             <strong>{summary.statusCounts.running}</strong> running
           </span>
@@ -956,15 +971,13 @@ export function JobOperations({
             <strong>{summary.statusCounts.queued}</strong> queued
           </span>
           <span className="admin-jobs-summary-danger">
-            <strong>{summary.failed + summary.dead}</strong> failed
+            <strong>{failedCount}</strong> failed
           </span>
           <span>
-            <strong>{onlineWorkers}</strong> worker
-            {onlineWorkers === 1 ? "" : "s"}
+            <strong>{onlineWorkers}</strong> {workerNoun}
           </span>
           <span>
-            oldest due{" "}
-            <strong>{formatDuration(summary.oldestDueQueuedAgeSeconds)}</strong>
+            oldest due <strong>{oldestDueLabel}</strong>
           </span>
           <span>
             active <strong>{activeQueueCount}</strong>

--- a/apps/web/app/admin/jobs/job-operations.tsx
+++ b/apps/web/app/admin/jobs/job-operations.tsx
@@ -54,6 +54,11 @@ type JsonJobSummary = {
   workers: JsonWorker[];
 };
 
+type JsonJobState = {
+  summary: JsonJobSummary;
+  lastRuns: Record<string, JsonBackgroundJob | null>;
+};
+
 type JsonJobEvent = {
   id: string;
   type: string;
@@ -107,7 +112,6 @@ const MANUAL_RUN_JOB_KINDS = new Set([
   "restore.reconcile",
 ]);
 
-const JOB_POLL_MS = 5000;
 const CLOCK_TICK_MS = 1000;
 const HISTORY_VISIBLE_RUNS = 12;
 
@@ -244,7 +248,7 @@ function formatJobKind(kind: string) {
   );
 }
 
-function isFinishedJob(job: JsonBackgroundJob) {
+function isFinishedJob(job: Pick<JsonBackgroundJob, "status">) {
   return (
     job.status === "succeeded" ||
     job.status === "failed" ||
@@ -272,7 +276,9 @@ function getJobDisplayStatus(
   job: Pick<JsonBackgroundJob, "id" | "status" | "lastError">,
   workerRunningJobIds: Set<string>,
 ): JsonBackgroundJob["status"] {
-  if (workerRunningJobIds.has(job.id)) return "running";
+  if (!isFinishedJob(job) && workerRunningJobIds.has(job.id)) {
+    return "running";
+  }
   return effectiveStatus(job);
 }
 
@@ -590,23 +596,22 @@ function JobDetailsModal({
 }
 
 function JobTaskCard({
-  initialLastRun,
   instanceTimeZone,
   kind,
+  lastRun,
   nowMs,
+  onLastRunChange,
   workerRunningJobIds,
 }: {
-  initialLastRun: JsonBackgroundJob | null;
   instanceTimeZone: string;
   kind: string;
+  lastRun: JsonBackgroundJob | null;
   nowMs: number | null;
+  onLastRunChange: (kind: string, job: JsonBackgroundJob | null) => void;
   workerRunningJobIds: Set<string>;
 }) {
   const jobName = formatJobKind(kind);
   const canRunManually = MANUAL_RUN_JOB_KINDS.has(kind);
-  const [lastRun, setLastRun] = useState<JsonBackgroundJob | null>(
-    initialLastRun,
-  );
   const [running, setRunning] = useState(false);
   const [runError, setRunError] = useState<string | null>(null);
   const [detailsOpen, setDetailsOpen] = useState(false);
@@ -629,36 +634,6 @@ function JobTaskCard({
   });
 
   useEffect(() => {
-    let cancelled = false;
-    const poll = async () => {
-      try {
-        const res = await fetch(
-          `/api/admin/jobs?kind=${encodeURIComponent(kind)}&limit=100`,
-        );
-        if (!res.ok || cancelled) return;
-        const data = await res.json();
-        const jobs: JsonBackgroundJob[] = data.items ?? [];
-        const latest = selectRepresentativeJob(jobs, workerRunningJobIds);
-        if (!cancelled) {
-          setLastRun(latest);
-          if (detailsOpen) {
-            setHistory(jobs);
-            setSelectedHistoryJobId((current) => current ?? latest?.id ?? null);
-          }
-        }
-      } catch {
-        // network error — ignore, retry next tick
-      }
-    };
-    void poll();
-    const id = setInterval(() => void poll(), JOB_POLL_MS);
-    return () => {
-      cancelled = true;
-      clearInterval(id);
-    };
-  }, [kind, detailsOpen, workerRunningJobIds]);
-
-  useEffect(() => {
     if (!detailsOpen || !selectedHistoryJobId) return;
 
     let cancelled = false;
@@ -678,6 +653,21 @@ function JobTaskCard({
     };
   }, [detailsOpen, selectedHistoryJobId]);
 
+  useEffect(() => {
+    if (!detailsOpen || !lastRun) return;
+
+    setHistory((current) => {
+      if (!current) return current;
+      const withoutLatest = current.filter((job) => job.id !== lastRun.id);
+      return [lastRun, ...withoutLatest].sort(
+        (left, right) =>
+          new Date(right.updatedAt).getTime() -
+          new Date(left.updatedAt).getTime(),
+      );
+    });
+    setSelectedHistoryJobId((current) => current ?? lastRun.id);
+  }, [detailsOpen, lastRun]);
+
   const refreshJobs = async () => {
     const updated = await fetch(
       `/api/admin/jobs?kind=${encodeURIComponent(kind)}&limit=100`,
@@ -687,7 +677,7 @@ function JobTaskCard({
     const data = await updated.json();
     const jobs: JsonBackgroundJob[] = data.items ?? [];
     setHistory(jobs);
-    setLastRun(selectRepresentativeJob(jobs, workerRunningJobIds));
+    onLastRunChange(kind, selectRepresentativeJob(jobs, workerRunningJobIds));
     setSelectedHistoryJobId((current) => current ?? jobs[0]?.id ?? null);
   };
 
@@ -853,6 +843,7 @@ export function JobOperations({
   instanceTimeZone,
 }: Props) {
   const [summary, setSummary] = useState(initialSummary);
+  const [lastRuns, setLastRuns] = useState(initialLastRuns);
   const [nowMs, setNowMs] = useState<number | null>(null);
   const activeQueueCount =
     summary.statusCounts.queued + summary.statusCounts.running;
@@ -871,16 +862,19 @@ export function JobOperations({
   );
 
   useEffect(() => {
-    let cancelled = false;
-    const poll = async () => {
-      const res = await fetch("/api/admin/jobs/summary");
-      if (!res.ok || cancelled) return;
-      setSummary(await res.json());
+    const source = new EventSource("/api/admin/jobs/state/stream");
+    const onState = (event: Event) => {
+      const state = JSON.parse(
+        (event as MessageEvent<string>).data,
+      ) as JsonJobState;
+      setSummary(state.summary);
+      setLastRuns(state.lastRuns);
     };
-    const id = setInterval(() => void poll(), JOB_POLL_MS);
+    source.addEventListener("state", onState);
+
     return () => {
-      cancelled = true;
-      clearInterval(id);
+      source.removeEventListener("state", onState);
+      source.close();
     };
   }, []);
 
@@ -923,14 +917,20 @@ export function JobOperations({
 
       <section className="admin-jobs-grid" aria-label="Background jobs">
         {jobKinds.map((kind) => {
-          const lastRun = initialLastRuns[kind] ?? null;
+          const lastRun = lastRuns[kind] ?? null;
           return (
             <JobTaskCard
-              initialLastRun={lastRun}
               instanceTimeZone={instanceTimeZone}
               key={kind}
               kind={kind}
+              lastRun={lastRun}
               nowMs={nowMs}
+              onLastRunChange={(updatedKind, job) => {
+                setLastRuns((current) => ({
+                  ...current,
+                  [updatedKind]: job,
+                }));
+              }}
               workerRunningJobIds={workerRunningJobIds}
             />
           );

--- a/apps/web/app/admin/jobs/page.tsx
+++ b/apps/web/app/admin/jobs/page.tsx
@@ -42,34 +42,24 @@ export default async function AdminJobsPage() {
     );
 
   return (
-    <main className="stack" style={{ gap: "40px" }}>
-      <section>
-        <h1 style={{ marginBottom: "8px" }}>Workers</h1>
-        <p className="muted" style={{ maxWidth: "56ch" }}>
-          Run and monitor background operations on this instance.
-        </p>
-      </section>
-
-      <section>
-        <JobOperations
-          initialLastRuns={initialLastRuns}
-          initialSummary={{
-            ...queueSummary,
-            nextQueuedRunAt:
-              queueSummary.nextQueuedRunAt?.toISOString() ?? null,
-            workers: queueSummary.workers.map((worker) => ({
-              ...worker,
-              startedAt: worker.startedAt.toISOString(),
-              lastHeartbeatAt: worker.lastHeartbeatAt.toISOString(),
-              stoppedAt: worker.stoppedAt?.toISOString() ?? null,
-              createdAt: worker.createdAt.toISOString(),
-              updatedAt: worker.updatedAt.toISOString(),
-            })),
-          }}
-          jobKinds={[...ALL_SUPPORTED_JOB_KINDS]}
-          instanceTimeZone={settings.timeZone}
-        />
-      </section>
+    <main>
+      <JobOperations
+        initialLastRuns={initialLastRuns}
+        initialSummary={{
+          ...queueSummary,
+          nextQueuedRunAt: queueSummary.nextQueuedRunAt?.toISOString() ?? null,
+          workers: queueSummary.workers.map((worker) => ({
+            ...worker,
+            startedAt: worker.startedAt.toISOString(),
+            lastHeartbeatAt: worker.lastHeartbeatAt.toISOString(),
+            stoppedAt: worker.stoppedAt?.toISOString() ?? null,
+            createdAt: worker.createdAt.toISOString(),
+            updatedAt: worker.updatedAt.toISOString(),
+          })),
+        }}
+        jobKinds={[...ALL_SUPPORTED_JOB_KINDS]}
+        instanceTimeZone={settings.timeZone}
+      />
     </main>
   );
 }

--- a/apps/web/app/admin/jobs/page.tsx
+++ b/apps/web/app/admin/jobs/page.tsx
@@ -1,6 +1,11 @@
 import { ALL_SUPPORTED_JOB_KINDS } from "@staaash/db/jobs";
 
-import { getAdminJobSummary, getLastRunPerKind } from "@/server/admin/jobs";
+import {
+  getAdminJobSummary,
+  getLastRunPerKind,
+  toJsonAdminJob,
+  toJsonAdminJobSummary,
+} from "@/server/admin/jobs";
 import { getSystemSettings } from "@/server/settings";
 
 import { type JsonBackgroundJob, JobOperations } from "./job-operations";
@@ -18,26 +23,7 @@ export default async function AdminJobsPage() {
     Object.fromEntries(
       Object.entries(lastRunPerKind).map(([kind, job]) => [
         kind,
-        job
-          ? {
-              id: job.id,
-              kind: job.kind,
-              status: job.status,
-              runAt: job.runAt.toISOString(),
-              lockedAt: job.lockedAt?.toISOString() ?? null,
-              leaseExpiresAt: job.leaseExpiresAt?.toISOString() ?? null,
-              startedAt: job.startedAt?.toISOString() ?? null,
-              completedAt: job.completedAt?.toISOString() ?? null,
-              cancelledAt: job.cancelledAt?.toISOString() ?? null,
-              createdAt: job.createdAt.toISOString(),
-              updatedAt: job.updatedAt.toISOString(),
-              lastError: job.lastError,
-              attemptCount: job.attemptCount,
-              maxAttempts: job.maxAttempts,
-              dedupeKey: job.dedupeKey,
-              payloadJson: job.payloadJson as Record<string, unknown> | null,
-            }
-          : null,
+        job ? toJsonAdminJob(job) : null,
       ]),
     );
 
@@ -45,18 +31,7 @@ export default async function AdminJobsPage() {
     <main>
       <JobOperations
         initialLastRuns={initialLastRuns}
-        initialSummary={{
-          ...queueSummary,
-          nextQueuedRunAt: queueSummary.nextQueuedRunAt?.toISOString() ?? null,
-          workers: queueSummary.workers.map((worker) => ({
-            ...worker,
-            startedAt: worker.startedAt.toISOString(),
-            lastHeartbeatAt: worker.lastHeartbeatAt.toISOString(),
-            stoppedAt: worker.stoppedAt?.toISOString() ?? null,
-            createdAt: worker.createdAt.toISOString(),
-            updatedAt: worker.updatedAt.toISOString(),
-          })),
-        }}
+        initialSummary={toJsonAdminJobSummary(queueSummary)}
         jobKinds={[...ALL_SUPPORTED_JOB_KINDS]}
         instanceTimeZone={settings.timeZone}
       />

--- a/apps/web/app/api/admin/jobs/state/stream/route.ts
+++ b/apps/web/app/api/admin/jobs/state/stream/route.ts
@@ -1,0 +1,161 @@
+import { createRequire } from "node:module";
+
+import { NextRequest, NextResponse } from "next/server";
+
+import { BACKGROUND_JOB_STATE_CHANGED_CHANNEL } from "@staaash/db/jobs";
+
+import { enforceSameOrigin, requireOwnerApiSession } from "@/server/admin/http";
+import {
+  getAdminJobStateSnapshot,
+  toJsonAdminJobStateSnapshot,
+} from "@/server/admin/jobs";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const HEARTBEAT_MS = 25_000;
+const ACTIVE_STATE_CHECK_MS = 1000;
+const SNAPSHOT_DEBOUNCE_MS = 50;
+const require = createRequire(import.meta.url);
+
+type PgClient = {
+  connect(): Promise<void>;
+  end(): Promise<void>;
+  on(event: "notification", listener: () => void): void;
+  query(query: string): Promise<unknown>;
+};
+
+const { Client } = require("pg") as {
+  Client: new (options: { connectionString: string }) => PgClient;
+};
+
+export async function GET(request: NextRequest) {
+  const sameOriginError = enforceSameOrigin(request);
+  if (sameOriginError) return sameOriginError;
+
+  const auth = await requireOwnerApiSession(request);
+  if (!auth.ok) return auth.response;
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    return NextResponse.json(
+      { error: "DATABASE_URL is not configured." },
+      { status: 500 },
+    );
+  }
+
+  const encoder = new TextEncoder();
+  let cleanup: (() => Promise<void>) | null = null;
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      let closed = false;
+      let lastPayload = "";
+      let snapshotInFlight = false;
+      let snapshotQueued = false;
+      let snapshotTimer: ReturnType<typeof setTimeout> | null = null;
+      let activeStateTimer: ReturnType<typeof setInterval> | null = null;
+      let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+      const pgClient = new Client({ connectionString: databaseUrl });
+
+      const cleanupResources = async () => {
+        if (closed) return;
+        closed = true;
+        if (snapshotTimer) clearTimeout(snapshotTimer);
+        if (activeStateTimer) clearInterval(activeStateTimer);
+        if (heartbeatTimer) clearInterval(heartbeatTimer);
+        request.signal.removeEventListener("abort", onAbort);
+        await pgClient.end().catch(() => undefined);
+      };
+
+      const close = async () => {
+        await cleanupResources();
+        try {
+          controller.close();
+        } catch {
+          // stream may already be closed by client disconnect
+        }
+      };
+
+      const sendSnapshot = async () => {
+        if (closed) return;
+        if (snapshotInFlight) {
+          snapshotQueued = true;
+          return;
+        }
+        snapshotInFlight = true;
+        snapshotQueued = false;
+        try {
+          const snapshot = await getAdminJobStateSnapshot();
+          const state = toJsonAdminJobStateSnapshot(snapshot);
+          const hasDueOrRunningWork =
+            state.summary.statusCounts.running > 0 ||
+            state.summary.oldestDueQueuedAgeSeconds !== null;
+
+          if (hasDueOrRunningWork && !activeStateTimer) {
+            activeStateTimer = setInterval(
+              scheduleSnapshot,
+              ACTIVE_STATE_CHECK_MS,
+            );
+          } else if (!hasDueOrRunningWork && activeStateTimer) {
+            clearInterval(activeStateTimer);
+            activeStateTimer = null;
+          }
+
+          const payload = JSON.stringify(state);
+          if (payload === lastPayload) return;
+          lastPayload = payload;
+          controller.enqueue(
+            encoder.encode(`event: state\ndata: ${payload}\n\n`),
+          );
+        } finally {
+          snapshotInFlight = false;
+          if (snapshotQueued) {
+            scheduleSnapshot();
+          }
+        }
+      };
+
+      const scheduleSnapshot = () => {
+        if (closed || snapshotTimer) return;
+        snapshotTimer = setTimeout(() => {
+          snapshotTimer = null;
+          void sendSnapshot().catch(() => undefined);
+        }, SNAPSHOT_DEBOUNCE_MS);
+      };
+
+      const onAbort = () => {
+        void close();
+      };
+
+      cleanup = close;
+
+      try {
+        await pgClient.connect();
+        await pgClient.query(`LISTEN ${BACKGROUND_JOB_STATE_CHANGED_CHANNEL}`);
+        pgClient.on("notification", scheduleSnapshot);
+        request.signal.addEventListener("abort", onAbort, { once: true });
+
+        await sendSnapshot();
+        heartbeatTimer = setInterval(() => {
+          if (!closed) controller.enqueue(encoder.encode(": keep-alive\n\n"));
+        }, HEARTBEAT_MS);
+      } catch (error) {
+        await cleanupResources();
+        controller.error(error);
+      }
+    },
+    async cancel() {
+      await cleanup?.();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/apps/web/app/api/admin/jobs/summary/route.ts
+++ b/apps/web/app/api/admin/jobs/summary/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { enforceSameOrigin, requireOwnerApiSession } from "@/server/admin/http";
-import { getAdminJobSummary } from "@/server/admin/jobs";
+import { getAdminJobSummary, toJsonAdminJobSummary } from "@/server/admin/jobs";
 
 export async function GET(request: NextRequest) {
   const sameOriginError = enforceSameOrigin(request);
@@ -12,16 +12,5 @@ export async function GET(request: NextRequest) {
 
   const summary = await getAdminJobSummary();
 
-  return NextResponse.json({
-    ...summary,
-    nextQueuedRunAt: summary.nextQueuedRunAt?.toISOString() ?? null,
-    workers: summary.workers.map((worker) => ({
-      ...worker,
-      startedAt: worker.startedAt.toISOString(),
-      lastHeartbeatAt: worker.lastHeartbeatAt.toISOString(),
-      stoppedAt: worker.stoppedAt?.toISOString() ?? null,
-      createdAt: worker.createdAt.toISOString(),
-      updatedAt: worker.updatedAt.toISOString(),
-    })),
-  });
+  return NextResponse.json(toJsonAdminJobSummary(summary));
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -497,7 +497,7 @@ h3 {
 
   .admin-sidebar .workspace-nav-link {
     flex: 0 0 auto;
-    min-height: 36px;
+    min-height: 44px;
     padding: 0 12px;
   }
 
@@ -989,7 +989,7 @@ h3 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 38px;
+  min-height: 44px;
   border-radius: 8px;
   padding: 0 14px;
   background: color-mix(in oklab, var(--foreground) 5%, transparent);
@@ -1551,8 +1551,11 @@ h3 {
 
   .admin-jobs-run-list,
   .admin-jobs-run-detail {
-    overflow: visible;
     padding: 16px;
+  }
+
+  .admin-jobs-run-list {
+    overflow-y: auto;
   }
 
   .admin-jobs-run-detail {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -916,10 +916,39 @@ h3 {
 
 /* ---- Admin: jobs card grid ---- */
 .admin-jobs-page {
+  --admin-job-success: oklch(46% 0.12 145);
+  --admin-job-running: color-mix(
+    in oklab,
+    var(--primary) 86%,
+    var(--foreground)
+  );
+  --admin-job-queued: oklch(48% 0.1 78);
+  --admin-job-failed: color-mix(
+    in oklab,
+    var(--destructive) 86%,
+    var(--foreground)
+  );
+  --admin-job-cancelled: color-mix(
+    in oklab,
+    var(--muted-foreground) 88%,
+    var(--foreground)
+  );
   display: grid;
   width: min(1120px, 100%);
   margin-inline: auto;
   gap: 24px;
+}
+
+.dark .admin-jobs-page {
+  --admin-job-success: oklch(76% 0.13 145);
+  --admin-job-running: oklch(78% 0.1 210);
+  --admin-job-queued: oklch(82% 0.1 78);
+  --admin-job-failed: oklch(78% 0.16 25);
+  --admin-job-cancelled: color-mix(
+    in oklab,
+    var(--muted-foreground) 86%,
+    var(--foreground)
+  );
 }
 
 .admin-jobs-header {
@@ -979,15 +1008,15 @@ h3 {
 
 .admin-jobs-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 520px), 1fr));
   gap: 14px;
   align-items: stretch;
 }
 
 .admin-jobs-card {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 92px;
-  min-height: 126px;
+  grid-template-columns: minmax(0, 1fr) 104px;
+  min-height: 142px;
   overflow: hidden;
   border: 1px solid color-mix(in oklab, var(--foreground) 8%, transparent);
   border-radius: 10px;
@@ -1001,40 +1030,25 @@ h3 {
   border-color: color-mix(in oklab, var(--primary) 24%, var(--border));
 }
 
-.admin-jobs-card-failed {
-  background: color-mix(in oklab, var(--destructive) 5%, var(--card));
-}
-
-.admin-jobs-card-running {
-  background: oklch(64% 0.11 145 / 0.055);
-}
-
-.admin-jobs-card-queued {
-  background: color-mix(in oklab, var(--primary) 5%, var(--card));
-}
-
-.admin-jobs-card-cancelled {
-  background: color-mix(in oklab, var(--foreground) 4%, var(--card));
-}
-
 .admin-jobs-card-body {
   display: grid;
   min-width: 0;
   align-content: center;
-  justify-items: center;
-  gap: 12px;
-  padding: 22px 24px;
+  gap: 13px;
+  padding: 18px 22px;
 }
 
 .admin-jobs-card-head {
   display: grid;
-  justify-items: center;
-  gap: 9px;
-  text-align: center;
+  width: 100%;
+  justify-items: start;
+  gap: 8px;
+  text-align: left;
 }
 
 .admin-jobs-card-head h2 {
   margin: 0;
+  min-width: 0;
   overflow-wrap: anywhere;
   font-family: var(--font-switzer), "Segoe UI", sans-serif;
   font-size: 1.02rem;
@@ -1042,25 +1056,61 @@ h3 {
   line-height: 1.2;
 }
 
+.admin-jobs-card-title-row {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 9px;
+}
+
+.admin-jobs-card-desc {
+  width: 100%;
+  margin: 0;
+  max-width: 62ch;
+  color: var(--muted-foreground);
+  font-size: 0.82rem;
+  line-height: 1.45;
+  text-align: left;
+  text-wrap: pretty;
+}
+
+.admin-jobs-card-facts {
+  display: flex;
+  flex-wrap: wrap;
+  min-width: 0;
+  align-items: baseline;
+  gap: 5px 14px;
+  text-align: left;
+}
+
 .admin-jobs-card-state {
   margin: 0;
   color: var(--muted-foreground);
-  font-size: 0.86rem;
+  font-size: 0.8rem;
   font-weight: 650;
   line-height: 1.35;
+  text-align: inherit;
   text-wrap: pretty;
 }
 
 .admin-jobs-card-state-failed {
-  color: color-mix(in oklab, var(--destructive) 86%, var(--foreground));
+  color: var(--admin-job-failed);
 }
 
 .admin-jobs-card-state-running {
-  color: oklch(43% 0.1 145);
+  color: var(--admin-job-running);
 }
 
 .admin-jobs-card-state-queued {
-  color: color-mix(in oklab, var(--primary) 78%, var(--foreground));
+  color: var(--admin-job-queued);
+}
+
+.admin-jobs-card-state-succeeded {
+  color: var(--admin-job-success);
+}
+
+.admin-jobs-card-state-cancelled {
+  color: var(--admin-job-cancelled);
 }
 
 .admin-jobs-card-dot,
@@ -1076,19 +1126,31 @@ h3 {
 .admin-jobs-card-dot-failed,
 .admin-jobs-state-failed .admin-jobs-state-dot,
 .admin-jobs-run-dot-failed {
-  background: color-mix(in oklab, var(--destructive) 86%, var(--foreground));
+  background: var(--admin-job-failed);
 }
 
 .admin-jobs-card-dot-running,
 .admin-jobs-state-running .admin-jobs-state-dot,
 .admin-jobs-run-dot-running {
-  background: oklch(43% 0.1 145);
+  background: var(--admin-job-running);
 }
 
 .admin-jobs-card-dot-queued,
 .admin-jobs-state-queued .admin-jobs-state-dot,
 .admin-jobs-run-dot-queued {
-  background: color-mix(in oklab, var(--primary) 78%, var(--foreground));
+  background: var(--admin-job-queued);
+}
+
+.admin-jobs-card-dot-succeeded,
+.admin-jobs-state-succeeded .admin-jobs-state-dot,
+.admin-jobs-run-dot-succeeded {
+  background: var(--admin-job-success);
+}
+
+.admin-jobs-card-dot-cancelled,
+.admin-jobs-state-cancelled .admin-jobs-state-dot,
+.admin-jobs-run-dot-cancelled {
+  background: var(--admin-job-cancelled);
 }
 
 .admin-jobs-card-error {
@@ -1096,11 +1158,11 @@ h3 {
   color: color-mix(in oklab, var(--destructive) 84%, var(--foreground));
   font-size: 0.78rem;
   line-height: 1.35;
-  text-align: center;
 }
 
 .admin-jobs-card-actions {
   display: grid;
+  grid-template-rows: repeat(2, minmax(0, 1fr));
   border-left: 1px solid color-mix(in oklab, var(--foreground) 7%, transparent);
   background: color-mix(in oklab, var(--foreground) 4%, transparent);
 }
@@ -1108,6 +1170,7 @@ h3 {
 .admin-jobs-rail-action {
   display: grid;
   place-items: center;
+  min-height: 54px;
   border: 0;
   border-bottom: 1px solid
     color-mix(in oklab, var(--foreground) 7%, transparent);
@@ -1124,7 +1187,25 @@ h3 {
     opacity 140ms ease;
 }
 
+.admin-jobs-rail-note {
+  display: grid;
+  place-items: center;
+  min-height: 54px;
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--foreground) 7%, transparent);
+  padding: 0 10px;
+  color: color-mix(in oklab, var(--foreground) 66%, transparent);
+  font-size: 0.72rem;
+  font-weight: 750;
+  line-height: 1.25;
+  text-align: center;
+}
+
 .admin-jobs-rail-action:last-child {
+  border-bottom: 0;
+}
+
+.admin-jobs-rail-note:last-child {
   border-bottom: 0;
 }
 
@@ -1147,6 +1228,10 @@ h3 {
 }
 
 .admin-jobs-modal {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  grid-template-columns: none;
   width: min(920px, calc(100vw - 32px));
   max-width: none;
   max-height: min(760px, calc(100dvh - 48px));
@@ -1156,12 +1241,17 @@ h3 {
 }
 
 .admin-jobs-modal-head {
+  flex: 0 0 auto;
   display: flex;
   justify-content: space-between;
   gap: 18px;
   align-items: flex-start;
   border-bottom: 1px solid var(--border);
-  padding: 22px 24px 18px;
+  padding: 22px 64px 18px 24px;
+}
+
+.admin-jobs-modal-head > div {
+  min-width: 0;
 }
 
 .admin-jobs-modal-head p {
@@ -1195,6 +1285,7 @@ h3 {
 .admin-jobs-modal-layout {
   display: grid;
   grid-template-columns: minmax(210px, 0.38fr) minmax(0, 1fr);
+  flex: 1 1 auto;
   min-height: 0;
   overflow: hidden;
 }
@@ -1233,7 +1324,7 @@ h3 {
   align-items: center;
   gap: 10px;
   width: 100%;
-  min-height: 42px;
+  min-height: 44px;
   border: 0;
   border-radius: 8px;
   padding: 8px 9px;
@@ -1356,7 +1447,7 @@ h3 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 36px;
+  min-height: 40px;
   border: 0;
   border-radius: 8px;
   padding: 0 12px;
@@ -1406,47 +1497,70 @@ h3 {
     grid-template-columns: minmax(0, 1fr);
   }
 
+  .admin-jobs-card-body {
+    gap: 14px;
+    padding: 18px;
+  }
+
+  .admin-jobs-card-facts {
+    gap: 6px;
+  }
+
   .admin-jobs-card-actions {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-rows: none;
     min-height: 44px;
     border-top: 1px solid color-mix(in oklab, var(--foreground) 7%, transparent);
     border-left: 0;
   }
 
-  .admin-jobs-rail-action {
+  .admin-jobs-rail-action,
+  .admin-jobs-rail-note {
     min-height: 44px;
     border-right: 1px solid
       color-mix(in oklab, var(--foreground) 7%, transparent);
     border-bottom: 0;
   }
 
-  .admin-jobs-rail-action:last-child {
+  .admin-jobs-rail-action:last-child,
+  .admin-jobs-rail-note:last-child {
     border-right: 0;
   }
 
   .admin-jobs-modal {
     width: calc(100vw - 20px);
-    max-height: calc(100dvh - 32px);
+    max-height: calc(100dvh - 24px);
   }
 
   .admin-jobs-modal-head {
     flex-direction: column;
-    padding: 20px 18px 16px;
+    padding: 20px 56px 16px 18px;
   }
 
   .admin-jobs-modal-layout {
     grid-template-columns: 1fr;
+    overflow-y: auto;
   }
 
   .admin-jobs-run-list {
     max-height: 220px;
+    overflow-y: auto;
     border-right: 0;
     border-bottom: 1px solid var(--border);
   }
 
   .admin-jobs-run-list,
   .admin-jobs-run-detail {
+    overflow: visible;
     padding: 16px;
+  }
+
+  .admin-jobs-run-detail {
+    padding-bottom: 28px;
+  }
+
+  .admin-jobs-button {
+    min-height: 44px;
   }
 
   .admin-jobs-event-row {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -41,6 +41,24 @@
   --sidebar-accent-foreground: oklch(0.22 0.015 72);
   --sidebar-border: oklch(0.9 0.009 78);
   --sidebar-ring: oklch(0.68 0.06 80);
+  --status-succeeded: oklch(0.46 0.12 145);
+  --status-succeeded-bg: oklch(0.64 0.11 145 / 0.14);
+  --status-running: oklch(0.43 0.1 210);
+  --status-running-bg: oklch(0.65 0.1 210 / 0.14);
+  --status-queued: oklch(0.48 0.1 78);
+  --status-queued-bg: oklch(0.74 0.1 78 / 0.16);
+  --status-failed: color-mix(
+    in oklab,
+    var(--destructive) 86%,
+    var(--foreground)
+  );
+  --status-failed-bg: oklch(0.62 0.16 25 / 0.14);
+  --status-cancelled: color-mix(
+    in oklab,
+    var(--muted-foreground) 88%,
+    var(--foreground)
+  );
+  --status-cancelled-bg: color-mix(in oklab, var(--foreground) 7%, transparent);
 }
 
 * {
@@ -328,26 +346,32 @@ h3 {
 
 .status-active,
 .status-healthy {
-  background: oklch(64% 0.11 145 / 0.14);
-  color: oklch(43% 0.1 145);
+  background: var(--status-succeeded-bg);
+  color: var(--status-succeeded);
+}
+
+.status-running {
+  background: var(--status-running-bg);
+  color: var(--status-running);
 }
 
 .status-accepted,
 .status-warning {
-  background: oklch(74% 0.1 78 / 0.16);
-  color: oklch(44% 0.08 78);
+  background: var(--status-queued-bg);
+  color: var(--status-queued);
 }
 
 .status-expired,
 .status-revoked,
 .status-error {
-  background: oklch(62% 0.16 25 / 0.14);
-  color: oklch(47% 0.16 25);
+  background: var(--status-failed-bg);
+  color: var(--status-failed);
 }
 
-.status-muted {
-  background: color-mix(in oklab, var(--foreground) 7%, transparent);
-  color: color-mix(in oklab, var(--foreground) 58%, transparent);
+.status-muted,
+.status-cancelled {
+  background: var(--status-cancelled-bg);
+  color: var(--status-cancelled);
 }
 
 .status-owner {
@@ -362,26 +386,32 @@ h3 {
 
 .dark .status-active,
 .dark .status-healthy {
-  background: oklch(67% 0.12 145 / 0.16);
-  color: oklch(78% 0.1 145);
+  background: var(--status-succeeded-bg);
+  color: var(--status-succeeded);
+}
+
+.dark .status-running {
+  background: var(--status-running-bg);
+  color: var(--status-running);
 }
 
 .dark .status-accepted,
 .dark .status-warning {
-  background: oklch(74% 0.1 78 / 0.17);
-  color: oklch(82% 0.09 78);
+  background: var(--status-queued-bg);
+  color: var(--status-queued);
 }
 
 .dark .status-expired,
 .dark .status-revoked,
 .dark .status-error {
-  background: oklch(62% 0.16 25 / 0.16);
-  color: oklch(76% 0.13 25);
+  background: var(--status-failed-bg);
+  color: var(--status-failed);
 }
 
-.dark .status-muted {
-  background: color-mix(in oklab, var(--foreground) 8%, transparent);
-  color: color-mix(in oklab, var(--foreground) 54%, transparent);
+.dark .status-muted,
+.dark .status-cancelled {
+  background: var(--status-cancelled-bg);
+  color: var(--status-cancelled);
 }
 
 .inline-form {
@@ -916,39 +946,10 @@ h3 {
 
 /* ---- Admin: jobs card grid ---- */
 .admin-jobs-page {
-  --admin-job-success: oklch(46% 0.12 145);
-  --admin-job-running: color-mix(
-    in oklab,
-    var(--primary) 86%,
-    var(--foreground)
-  );
-  --admin-job-queued: oklch(48% 0.1 78);
-  --admin-job-failed: color-mix(
-    in oklab,
-    var(--destructive) 86%,
-    var(--foreground)
-  );
-  --admin-job-cancelled: color-mix(
-    in oklab,
-    var(--muted-foreground) 88%,
-    var(--foreground)
-  );
   display: grid;
   width: min(1120px, 100%);
   margin-inline: auto;
   gap: 24px;
-}
-
-.dark .admin-jobs-page {
-  --admin-job-success: oklch(76% 0.13 145);
-  --admin-job-running: oklch(78% 0.1 210);
-  --admin-job-queued: oklch(82% 0.1 78);
-  --admin-job-failed: oklch(78% 0.16 25);
-  --admin-job-cancelled: color-mix(
-    in oklab,
-    var(--muted-foreground) 86%,
-    var(--foreground)
-  );
 }
 
 .admin-jobs-header {
@@ -1094,23 +1095,23 @@ h3 {
 }
 
 .admin-jobs-card-state-failed {
-  color: var(--admin-job-failed);
+  color: var(--status-failed);
 }
 
 .admin-jobs-card-state-running {
-  color: var(--admin-job-running);
+  color: var(--status-running);
 }
 
 .admin-jobs-card-state-queued {
-  color: var(--admin-job-queued);
+  color: var(--status-queued);
 }
 
 .admin-jobs-card-state-succeeded {
-  color: var(--admin-job-success);
+  color: var(--status-succeeded);
 }
 
 .admin-jobs-card-state-cancelled {
-  color: var(--admin-job-cancelled);
+  color: var(--status-cancelled);
 }
 
 .admin-jobs-card-dot,
@@ -1126,31 +1127,31 @@ h3 {
 .admin-jobs-card-dot-failed,
 .admin-jobs-state-failed .admin-jobs-state-dot,
 .admin-jobs-run-dot-failed {
-  background: var(--admin-job-failed);
+  background: var(--status-failed);
 }
 
 .admin-jobs-card-dot-running,
 .admin-jobs-state-running .admin-jobs-state-dot,
 .admin-jobs-run-dot-running {
-  background: var(--admin-job-running);
+  background: var(--status-running);
 }
 
 .admin-jobs-card-dot-queued,
 .admin-jobs-state-queued .admin-jobs-state-dot,
 .admin-jobs-run-dot-queued {
-  background: var(--admin-job-queued);
+  background: var(--status-queued);
 }
 
 .admin-jobs-card-dot-succeeded,
 .admin-jobs-state-succeeded .admin-jobs-state-dot,
 .admin-jobs-run-dot-succeeded {
-  background: var(--admin-job-success);
+  background: var(--status-succeeded);
 }
 
 .admin-jobs-card-dot-cancelled,
 .admin-jobs-state-cancelled .admin-jobs-state-dot,
 .admin-jobs-run-dot-cancelled {
-  background: var(--admin-job-cancelled);
+  background: var(--status-cancelled);
 }
 
 .admin-jobs-card-error {
@@ -1227,6 +1228,264 @@ h3 {
   background: color-mix(in oklab, var(--primary) 88%, black);
 }
 
+.admin-jobs-activity {
+  display: grid;
+  gap: 14px;
+  border: 1px solid color-mix(in oklab, var(--foreground) 8%, transparent);
+  border-radius: 10px;
+  padding: 18px;
+  background: color-mix(in oklab, var(--card) 94%, var(--background) 6%);
+}
+
+.admin-jobs-activity-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: flex-start;
+}
+
+.admin-jobs-activity-head > div:first-child {
+  min-width: 0;
+}
+
+.admin-jobs-activity-head h2 {
+  margin: 0;
+  font-family: var(--font-switzer), "Segoe UI", sans-serif;
+  font-size: 1.02rem;
+  font-weight: 750;
+  line-height: 1.2;
+}
+
+.admin-jobs-activity-head p {
+  margin: 5px 0 0;
+  color: var(--muted-foreground);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.admin-jobs-activity-controls {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: nowrap;
+  align-items: flex-start;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.admin-jobs-activity-tabs {
+  display: inline-flex;
+  min-height: 40px;
+  overflow: hidden;
+  border: 1px solid color-mix(in oklab, var(--foreground) 8%, transparent);
+  border-radius: 8px;
+  background: color-mix(in oklab, var(--foreground) 3%, transparent);
+}
+
+.admin-jobs-activity-tabs button {
+  min-width: 66px;
+  border: 0;
+  border-right: 1px solid color-mix(in oklab, var(--foreground) 8%, transparent);
+  padding: 0 11px;
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.76rem;
+  font-weight: 750;
+}
+
+.admin-jobs-activity-tabs button:last-child {
+  border-right: 0;
+}
+
+.admin-jobs-activity-tabs button:hover,
+.admin-jobs-activity-tabs .admin-jobs-activity-tab-active {
+  background: color-mix(in oklab, var(--primary) 10%, transparent);
+  color: color-mix(in oklab, var(--primary) 78%, var(--foreground));
+}
+
+.admin-jobs-kind-filter {
+  display: grid;
+  flex: 0 0 196px;
+  width: min(196px, 100%);
+  color: var(--muted-foreground);
+  font-size: 0.68rem;
+  font-weight: 750;
+}
+
+.admin-jobs-kind-select-trigger {
+  width: 100%;
+  border-color: color-mix(in oklab, var(--foreground) 8%, transparent);
+  border-radius: 8px;
+  background: color-mix(in oklab, var(--foreground) 3%, transparent);
+  padding: 0 10px;
+  color: var(--foreground);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.admin-jobs-kind-select-trigger[data-size="default"] {
+  height: 40px;
+}
+
+.admin-jobs-kind-select-trigger:hover,
+.admin-jobs-kind-select-trigger[data-popup-open] {
+  background: color-mix(in oklab, var(--foreground) 5%, transparent);
+}
+
+.admin-jobs-kind-select-content {
+  width: max-content;
+  min-width: 196px;
+  max-width: min(260px, calc(100vw - 24px));
+  border-radius: 8px;
+  padding: 4px;
+  font-size: 0.8125rem;
+}
+
+.admin-jobs-kind-select-item {
+  min-height: 34px;
+  border-radius: 5px;
+  padding: 0 32px 0 10px;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.admin-jobs-kind-select-item:hover,
+.admin-jobs-kind-select-item[data-highlighted] {
+  background: color-mix(in oklab, var(--foreground) 15%, transparent);
+  color: var(--foreground);
+}
+
+.admin-jobs-activity-error {
+  margin: 0;
+  border-radius: 9px;
+  padding: 10px 11px;
+  background: color-mix(in oklab, var(--destructive) 10%, transparent);
+  color: color-mix(in oklab, var(--destructive) 84%, var(--foreground));
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.admin-jobs-activity-list {
+  display: grid;
+  overflow: hidden;
+  border: 1px solid color-mix(in oklab, var(--foreground) 6%, transparent);
+  border-radius: 8px;
+  min-height: 54px;
+}
+
+.admin-jobs-activity-updating {
+  margin: 0;
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--foreground) 6%, transparent);
+  padding: 7px 12px;
+  background: color-mix(in oklab, var(--primary) 6%, transparent);
+  color: var(--muted-foreground);
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.admin-jobs-activity-row {
+  display: grid;
+  grid-template-columns: auto minmax(220px, 1.1fr) 88px 72px minmax(180px, 1fr);
+  align-items: center;
+  gap: 12px;
+  min-height: 54px;
+  border: 0;
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--foreground) 6%, transparent);
+  padding: 10px 12px;
+  background: transparent;
+  color: var(--foreground);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.admin-jobs-activity-row:last-child {
+  border-bottom: 0;
+}
+
+.admin-jobs-activity-row:hover {
+  background: color-mix(in oklab, var(--primary) 7%, transparent);
+}
+
+.admin-jobs-activity-main {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.admin-jobs-activity-main strong {
+  overflow: hidden;
+  font-size: 0.82rem;
+  font-weight: 750;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.admin-jobs-activity-main small {
+  overflow: hidden;
+  color: var(--muted-foreground);
+  font-size: 0.74rem;
+  font-weight: 600;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.admin-jobs-activity-status {
+  font-size: 0.76rem;
+  font-weight: 750;
+  text-transform: capitalize;
+}
+
+.admin-jobs-activity-attempt {
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+}
+
+.admin-jobs-activity-detail {
+  overflow: hidden;
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.admin-jobs-activity-empty {
+  margin: 0;
+  padding: 18px;
+  color: var(--muted-foreground);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.admin-jobs-activity-more {
+  justify-self: center;
+  min-height: 40px;
+  border: 0;
+  border-radius: 8px;
+  padding: 0 14px;
+  background: color-mix(in oklab, var(--foreground) 6%, transparent);
+  color: var(--foreground);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 750;
+}
+
+.admin-jobs-activity-more:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 .admin-jobs-modal {
   display: flex;
   flex-direction: column;
@@ -1271,15 +1530,23 @@ h3 {
 }
 
 .admin-jobs-state-failed {
-  color: color-mix(in oklab, var(--destructive) 86%, var(--foreground));
+  color: var(--status-failed);
 }
 
 .admin-jobs-state-running {
-  color: oklch(43% 0.1 145);
+  color: var(--status-running);
 }
 
 .admin-jobs-state-queued {
-  color: color-mix(in oklab, var(--primary) 78%, var(--foreground));
+  color: var(--status-queued);
+}
+
+.admin-jobs-state-succeeded {
+  color: var(--status-succeeded);
+}
+
+.admin-jobs-state-cancelled {
+  color: var(--status-cancelled);
 }
 
 .admin-jobs-modal-layout {
@@ -1491,6 +1758,48 @@ h3 {
   .admin-jobs-summary {
     gap: 8px 12px;
     font-size: 0.8125rem;
+  }
+
+  .admin-jobs-activity {
+    padding: 14px;
+  }
+
+  .admin-jobs-activity-head,
+  .admin-jobs-activity-controls {
+    display: grid;
+    justify-content: stretch;
+  }
+
+  .admin-jobs-activity-tabs {
+    width: 100%;
+  }
+
+  .admin-jobs-activity-tabs button {
+    min-width: 0;
+    flex: 1;
+  }
+
+  .admin-jobs-kind-filter {
+    width: 100%;
+  }
+
+  .admin-jobs-activity-row {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: 8px 10px;
+    min-height: 68px;
+  }
+
+  .admin-jobs-activity-status {
+    justify-self: end;
+  }
+
+  .admin-jobs-activity-attempt {
+    grid-column: 2 / 3;
+  }
+
+  .admin-jobs-activity-detail {
+    grid-column: 2 / 4;
+    white-space: normal;
   }
 
   .admin-jobs-card {
@@ -5766,6 +6075,20 @@ h3 {
   --sidebar-accent-foreground: oklch(0.94 0.008 78);
   --sidebar-border: oklch(0.38 0.014 76 / 0.55);
   --sidebar-ring: oklch(0.82 0.06 80);
+  --status-succeeded: oklch(0.78 0.1 145);
+  --status-succeeded-bg: oklch(0.67 0.12 145 / 0.16);
+  --status-running: oklch(0.78 0.1 210);
+  --status-running-bg: oklch(0.68 0.1 210 / 0.16);
+  --status-queued: oklch(0.82 0.1 78);
+  --status-queued-bg: oklch(0.74 0.1 78 / 0.17);
+  --status-failed: oklch(0.78 0.16 25);
+  --status-failed-bg: oklch(0.62 0.16 25 / 0.16);
+  --status-cancelled: color-mix(
+    in oklab,
+    var(--muted-foreground) 86%,
+    var(--foreground)
+  );
+  --status-cancelled-bg: color-mix(in oklab, var(--foreground) 8%, transparent);
 }
 
 html.dark {
@@ -5811,6 +6134,24 @@ html.light {
     --sidebar-accent-foreground: oklch(0.94 0.008 78);
     --sidebar-border: oklch(0.38 0.014 76 / 0.55);
     --sidebar-ring: oklch(0.82 0.06 80);
+    --status-succeeded: oklch(0.78 0.1 145);
+    --status-succeeded-bg: oklch(0.67 0.12 145 / 0.16);
+    --status-running: oklch(0.78 0.1 210);
+    --status-running-bg: oklch(0.68 0.1 210 / 0.16);
+    --status-queued: oklch(0.82 0.1 78);
+    --status-queued-bg: oklch(0.74 0.1 78 / 0.17);
+    --status-failed: oklch(0.78 0.16 25);
+    --status-failed-bg: oklch(0.62 0.16 25 / 0.16);
+    --status-cancelled: color-mix(
+      in oklab,
+      var(--muted-foreground) 86%,
+      var(--foreground)
+    );
+    --status-cancelled-bg: color-mix(
+      in oklab,
+      var(--foreground) 8%,
+      transparent
+    );
   }
 
   body {
@@ -8641,6 +8982,24 @@ main.share-locked-page {
   --sidebar-accent-foreground: oklch(0.22 0.015 72);
   --sidebar-border: oklch(0.9 0.009 78);
   --sidebar-ring: oklch(0.68 0.06 80);
+  --status-succeeded: oklch(0.46 0.12 145);
+  --status-succeeded-bg: oklch(0.64 0.11 145 / 0.14);
+  --status-running: oklch(0.43 0.1 210);
+  --status-running-bg: oklch(0.65 0.1 210 / 0.14);
+  --status-queued: oklch(0.48 0.1 78);
+  --status-queued-bg: oklch(0.74 0.1 78 / 0.16);
+  --status-failed: color-mix(
+    in oklab,
+    var(--destructive) 86%,
+    var(--foreground)
+  );
+  --status-failed-bg: oklch(0.62 0.16 25 / 0.14);
+  --status-cancelled: color-mix(
+    in oklab,
+    var(--muted-foreground) 88%,
+    var(--foreground)
+  );
+  --status-cancelled-bg: color-mix(in oklab, var(--foreground) 7%, transparent);
 }
 
 .light body {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -460,6 +460,62 @@ h3 {
   padding: 0;
 }
 
+@media (max-width: 720px) {
+  .admin-shell {
+    height: 100dvh;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto minmax(0, 1fr);
+  }
+
+  .admin-sidebar {
+    height: auto;
+    gap: 12px;
+    overflow: hidden;
+    border-right: 0;
+    border-bottom: 1px solid
+      color-mix(in oklab, var(--foreground) 7%, transparent);
+    padding: 14px 14px 10px;
+  }
+
+  .admin-sidebar .workspace-brand {
+    font-size: 20px;
+    white-space: nowrap;
+  }
+
+  .admin-sidebar .workspace-nav {
+    flex: 0 0 auto;
+    flex-direction: row;
+    gap: 6px;
+    overflow-x: auto;
+    padding-bottom: 4px;
+    scrollbar-width: none;
+  }
+
+  .admin-sidebar .workspace-nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  .admin-sidebar .workspace-nav-link {
+    flex: 0 0 auto;
+    min-height: 36px;
+    padding: 0 12px;
+  }
+
+  .admin-main {
+    height: 100%;
+    min-height: 0;
+  }
+
+  .admin-topbar {
+    min-height: 48px;
+    padding: 8px 14px;
+  }
+
+  .admin-main > main.admin-main-content {
+    padding: 28px 14px 52px;
+  }
+}
+
 .admin-kv-link {
   font-size: 0.78rem;
   color: color-mix(in oklab, var(--primary) 80%, var(--foreground) 20%);
@@ -856,6 +912,547 @@ h3 {
 
 .admin-history-row:last-child {
   border-bottom: none;
+}
+
+/* ---- Admin: jobs card grid ---- */
+.admin-jobs-page {
+  display: grid;
+  width: min(1120px, 100%);
+  margin-inline: auto;
+  gap: 24px;
+}
+
+.admin-jobs-header {
+  display: grid;
+  justify-items: center;
+  gap: 16px;
+  text-align: center;
+}
+
+.admin-jobs-header h1 {
+  margin: 0;
+  font-size: 1.95rem;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.admin-jobs-summary {
+  display: flex;
+  justify-content: center;
+  gap: 10px 18px;
+  flex-wrap: wrap;
+  color: var(--muted-foreground);
+  font-size: 0.875rem;
+  line-height: 1.35;
+}
+
+.admin-jobs-summary strong {
+  color: var(--foreground);
+  font-weight: 750;
+}
+
+.admin-jobs-summary-danger,
+.admin-jobs-summary-danger strong {
+  color: color-mix(in oklab, var(--destructive) 84%, var(--foreground));
+}
+
+.admin-jobs-schedule-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  border-radius: 8px;
+  padding: 0 14px;
+  background: color-mix(in oklab, var(--foreground) 5%, transparent);
+  color: var(--foreground);
+  font-size: 0.82rem;
+  font-weight: 750;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease;
+}
+
+.admin-jobs-schedule-link:hover {
+  background: color-mix(in oklab, var(--primary) 10%, transparent);
+  color: color-mix(in oklab, var(--primary) 78%, var(--foreground));
+}
+
+.admin-jobs-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  align-items: stretch;
+}
+
+.admin-jobs-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 92px;
+  min-height: 126px;
+  overflow: hidden;
+  border: 1px solid color-mix(in oklab, var(--foreground) 8%, transparent);
+  border-radius: 10px;
+  background: color-mix(in oklab, var(--card) 96%, var(--background) 4%);
+  transition:
+    border-color 140ms ease,
+    background-color 140ms ease;
+}
+
+.admin-jobs-card:hover {
+  border-color: color-mix(in oklab, var(--primary) 24%, var(--border));
+}
+
+.admin-jobs-card-failed {
+  background: color-mix(in oklab, var(--destructive) 5%, var(--card));
+}
+
+.admin-jobs-card-running {
+  background: oklch(64% 0.11 145 / 0.055);
+}
+
+.admin-jobs-card-queued {
+  background: color-mix(in oklab, var(--primary) 5%, var(--card));
+}
+
+.admin-jobs-card-cancelled {
+  background: color-mix(in oklab, var(--foreground) 4%, var(--card));
+}
+
+.admin-jobs-card-body {
+  display: grid;
+  min-width: 0;
+  align-content: center;
+  justify-items: center;
+  gap: 12px;
+  padding: 22px 24px;
+}
+
+.admin-jobs-card-head {
+  display: grid;
+  justify-items: center;
+  gap: 9px;
+  text-align: center;
+}
+
+.admin-jobs-card-head h2 {
+  margin: 0;
+  overflow-wrap: anywhere;
+  font-family: var(--font-switzer), "Segoe UI", sans-serif;
+  font-size: 1.02rem;
+  font-weight: 750;
+  line-height: 1.2;
+}
+
+.admin-jobs-card-state {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: 0.86rem;
+  font-weight: 650;
+  line-height: 1.35;
+  text-wrap: pretty;
+}
+
+.admin-jobs-card-state-failed {
+  color: color-mix(in oklab, var(--destructive) 86%, var(--foreground));
+}
+
+.admin-jobs-card-state-running {
+  color: oklch(43% 0.1 145);
+}
+
+.admin-jobs-card-state-queued {
+  color: color-mix(in oklab, var(--primary) 78%, var(--foreground));
+}
+
+.admin-jobs-card-dot,
+.admin-jobs-state-dot,
+.admin-jobs-run-dot {
+  display: inline-flex;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--muted-foreground);
+}
+
+.admin-jobs-card-dot-failed,
+.admin-jobs-state-failed .admin-jobs-state-dot,
+.admin-jobs-run-dot-failed {
+  background: color-mix(in oklab, var(--destructive) 86%, var(--foreground));
+}
+
+.admin-jobs-card-dot-running,
+.admin-jobs-state-running .admin-jobs-state-dot,
+.admin-jobs-run-dot-running {
+  background: oklch(43% 0.1 145);
+}
+
+.admin-jobs-card-dot-queued,
+.admin-jobs-state-queued .admin-jobs-state-dot,
+.admin-jobs-run-dot-queued {
+  background: color-mix(in oklab, var(--primary) 78%, var(--foreground));
+}
+
+.admin-jobs-card-error {
+  margin: 0;
+  color: color-mix(in oklab, var(--destructive) 84%, var(--foreground));
+  font-size: 0.78rem;
+  line-height: 1.35;
+  text-align: center;
+}
+
+.admin-jobs-card-actions {
+  display: grid;
+  border-left: 1px solid color-mix(in oklab, var(--foreground) 7%, transparent);
+  background: color-mix(in oklab, var(--foreground) 4%, transparent);
+}
+
+.admin-jobs-rail-action {
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--foreground) 7%, transparent);
+  background: transparent;
+  color: var(--foreground);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.76rem;
+  font-weight: 750;
+  text-align: center;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    opacity 140ms ease;
+}
+
+.admin-jobs-rail-action:last-child {
+  border-bottom: 0;
+}
+
+.admin-jobs-rail-action:hover:not(:disabled) {
+  background: color-mix(in oklab, var(--foreground) 5%, transparent);
+}
+
+.admin-jobs-rail-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.admin-jobs-rail-action-primary {
+  background: var(--primary);
+  color: var(--primary-foreground);
+}
+
+.admin-jobs-rail-action-primary:hover:not(:disabled) {
+  background: color-mix(in oklab, var(--primary) 88%, black);
+}
+
+.admin-jobs-modal {
+  width: min(920px, calc(100vw - 32px));
+  max-width: none;
+  max-height: min(760px, calc(100dvh - 48px));
+  overflow: hidden;
+  border-radius: 14px;
+  padding: 0;
+}
+
+.admin-jobs-modal-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: flex-start;
+  border-bottom: 1px solid var(--border);
+  padding: 22px 24px 18px;
+}
+
+.admin-jobs-modal-head p {
+  margin: 6px 0 0;
+  color: var(--muted-foreground);
+  font-size: 0.84rem;
+}
+
+.admin-jobs-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--muted-foreground);
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.admin-jobs-state-failed {
+  color: color-mix(in oklab, var(--destructive) 86%, var(--foreground));
+}
+
+.admin-jobs-state-running {
+  color: oklch(43% 0.1 145);
+}
+
+.admin-jobs-state-queued {
+  color: color-mix(in oklab, var(--primary) 78%, var(--foreground));
+}
+
+.admin-jobs-modal-layout {
+  display: grid;
+  grid-template-columns: minmax(210px, 0.38fr) minmax(0, 1fr);
+  min-height: 0;
+  overflow: hidden;
+}
+
+.admin-jobs-run-list,
+.admin-jobs-run-detail {
+  min-height: 0;
+  overflow-y: auto;
+  padding: 18px 20px 22px;
+}
+
+.admin-jobs-run-list {
+  border-right: 1px solid var(--border);
+  background: color-mix(in oklab, var(--foreground) 3%, transparent);
+}
+
+.admin-jobs-run-list h3,
+.admin-jobs-modal-section h3 {
+  margin: 0 0 10px;
+  color: var(--muted-foreground);
+  font-family: var(--font-switzer), "Segoe UI", sans-serif;
+  font-size: 0.7rem;
+  font-weight: 750;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.admin-jobs-run-buttons {
+  display: grid;
+  gap: 4px;
+}
+
+.admin-jobs-run-button {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 42px;
+  border: 0;
+  border-radius: 8px;
+  padding: 8px 9px;
+  background: transparent;
+  color: var(--foreground);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.admin-jobs-run-button:hover,
+.admin-jobs-run-button-selected {
+  background: color-mix(in oklab, var(--primary) 9%, transparent);
+}
+
+.admin-jobs-run-button strong,
+.admin-jobs-run-button small {
+  display: block;
+}
+
+.admin-jobs-run-button strong {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.admin-jobs-run-button small {
+  color: var(--muted-foreground);
+  font-size: 0.72rem;
+  line-height: 1.3;
+}
+
+.admin-jobs-run-detail {
+  display: grid;
+  align-content: start;
+  gap: 18px;
+}
+
+.admin-jobs-modal-section {
+  display: grid;
+  gap: 8px;
+}
+
+.admin-jobs-modal-error {
+  margin: 0;
+  border-radius: 9px;
+  padding: 10px 11px;
+  background: color-mix(in oklab, var(--destructive) 10%, transparent);
+  color: color-mix(in oklab, var(--destructive) 84%, var(--foreground));
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.admin-jobs-modal-empty {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.admin-jobs-event-list {
+  display: grid;
+}
+
+.admin-jobs-event-row {
+  display: grid;
+  grid-template-columns: 140px minmax(0, 1fr);
+  gap: 14px;
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--foreground) 5%, transparent);
+  padding: 8px 0;
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.admin-jobs-event-row:last-child {
+  border-bottom: 0;
+}
+
+.admin-jobs-event-time {
+  color: var(--muted-foreground);
+  font-variant-numeric: tabular-nums;
+}
+
+.admin-jobs-event-main {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.admin-jobs-event-main strong {
+  text-transform: capitalize;
+}
+
+.admin-jobs-event-main span {
+  color: var(--muted-foreground);
+  overflow-wrap: anywhere;
+}
+
+.admin-jobs-payload {
+  max-height: 180px;
+  overflow: auto;
+  margin: 0;
+  border-radius: 8px;
+  padding: 10px;
+  background: color-mix(in oklab, var(--foreground) 5%, transparent);
+  color: var(--foreground);
+  font-family: var(--font-jetbrains-mono), monospace;
+  font-size: 0.72rem;
+  line-height: 1.45;
+}
+
+.admin-jobs-modal-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.admin-jobs-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 36px;
+  border: 0;
+  border-radius: 8px;
+  padding: 0 12px;
+  background: color-mix(in oklab, var(--foreground) 6%, transparent);
+  color: var(--foreground);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+
+.admin-jobs-button-primary {
+  background: var(--primary);
+  color: var(--primary-foreground);
+}
+
+.admin-jobs-button-danger {
+  background: color-mix(in oklab, var(--destructive) 12%, transparent);
+  color: color-mix(in oklab, var(--destructive) 84%, var(--foreground));
+}
+
+@media (max-width: 1180px) {
+  .admin-jobs-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .admin-main > main.admin-main-content:has(.admin-jobs-page) {
+    padding: 28px 18px 60px;
+  }
+
+  .admin-jobs-page {
+    width: 100%;
+  }
+
+  .admin-jobs-header {
+    gap: 14px;
+  }
+
+  .admin-jobs-summary {
+    gap: 8px 12px;
+    font-size: 0.8125rem;
+  }
+
+  .admin-jobs-card {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .admin-jobs-card-actions {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    min-height: 44px;
+    border-top: 1px solid color-mix(in oklab, var(--foreground) 7%, transparent);
+    border-left: 0;
+  }
+
+  .admin-jobs-rail-action {
+    min-height: 44px;
+    border-right: 1px solid
+      color-mix(in oklab, var(--foreground) 7%, transparent);
+    border-bottom: 0;
+  }
+
+  .admin-jobs-rail-action:last-child {
+    border-right: 0;
+  }
+
+  .admin-jobs-modal {
+    width: calc(100vw - 20px);
+    max-height: calc(100dvh - 32px);
+  }
+
+  .admin-jobs-modal-head {
+    flex-direction: column;
+    padding: 20px 18px 16px;
+  }
+
+  .admin-jobs-modal-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-jobs-run-list {
+    max-height: 220px;
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .admin-jobs-run-list,
+  .admin-jobs-run-detail {
+    padding: 16px;
+  }
+
+  .admin-jobs-event-row {
+    grid-template-columns: 1fr;
+    gap: 3px;
+  }
 }
 
 /* ---- Admin: users ---- */

--- a/apps/web/components/ui/select.tsx
+++ b/apps/web/components/ui/select.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import * as React from "react";
+import { Select as SelectPrimitive } from "@base-ui/react/select";
+
+import { cn } from "@/lib/utils";
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react";
+
+const Select = SelectPrimitive.Root;
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1.5 p-1.5", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("flex flex-1 text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-3xl border border-transparent bg-input/50 px-3 py-2 text-sm whitespace-nowrap transition-[color,box-shadow,background-color] outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={
+          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn(
+            "relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-3xl bg-popover text-popover-foreground shadow-lg ring-1 ring-foreground/5 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className,
+          )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-3 py-2.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2.5 rounded-2xl py-2 pr-8 pl-3 text-sm font-medium outline-hidden select-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className,
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn(
+        "pointer-events-none -mx-1.5 my-1.5 h-px bg-border",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronUpIcon />
+    </SelectPrimitive.ScrollUpArrow>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronDownIcon />
+    </SelectPrimitive.ScrollDownArrow>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/apps/web/server/admin/jobs.ts
+++ b/apps/web/server/admin/jobs.ts
@@ -1,4 +1,5 @@
 import {
+  listAdminBackgroundJobItems,
   listAdminBackgroundJobs,
   type AdminBackgroundJobListFilters,
   type AdminBackgroundJobListResult,
@@ -13,6 +14,7 @@ import {
   listBackgroundJobEvents,
   retryBackgroundJob,
   type BackgroundJobRecord,
+  type QueueOperationalSummary,
 } from "@staaash/db/jobs";
 
 import type { JsonAdminJobListResponse } from "./types";
@@ -65,6 +67,15 @@ export const getAdminJobList = async (
 
 export const getAdminJobSummary = async () => getQueueOperationalSummary();
 
+export const getAdminJobStateSnapshot = async () => {
+  const [lastRuns, summary] = await Promise.all([
+    getLastRunPerKind(),
+    getAdminJobSummary(),
+  ]);
+
+  return { lastRuns, summary };
+};
+
 export const getAdminJobEvents = async (jobId: string) =>
   listBackgroundJobEvents({ jobId });
 
@@ -112,8 +123,8 @@ export const getLastRunPerKind = async () => {
   const now = new Date();
   const results = await Promise.all(
     ALL_SUPPORTED_JOB_KINDS.map(async (kind) => {
-      const res = await listAdminBackgroundJobs({ kind, limit: 100 });
-      return { kind, job: selectRepresentativeAdminJob(res.items, now) };
+      const jobs = await listAdminBackgroundJobItems({ kind, limit: 100 });
+      return { kind, job: selectRepresentativeAdminJob(jobs, now) };
     }),
   );
   return Object.fromEntries(
@@ -125,16 +136,44 @@ export const toJsonAdminJobListResponse = (
   response: AdminBackgroundJobListResult,
 ): JsonAdminJobListResponse => ({
   ...response,
-  items: response.items.map((item) => ({
-    ...item,
-    runAt: item.runAt.toISOString(),
-    lockedAt: item.lockedAt?.toISOString() ?? null,
-    leaseExpiresAt: item.leaseExpiresAt?.toISOString() ?? null,
-    timeoutAt: item.timeoutAt?.toISOString() ?? null,
-    startedAt: item.startedAt?.toISOString() ?? null,
-    completedAt: item.completedAt?.toISOString() ?? null,
-    cancelledAt: item.cancelledAt?.toISOString() ?? null,
-    createdAt: item.createdAt.toISOString(),
-    updatedAt: item.updatedAt.toISOString(),
+  items: response.items.map(toJsonAdminJob),
+});
+
+export const toJsonAdminJob = (item: BackgroundJobRecord) => ({
+  ...item,
+  payloadJson: item.payloadJson as Record<string, unknown> | null,
+  runAt: item.runAt.toISOString(),
+  lockedAt: item.lockedAt?.toISOString() ?? null,
+  leaseExpiresAt: item.leaseExpiresAt?.toISOString() ?? null,
+  timeoutAt: item.timeoutAt?.toISOString() ?? null,
+  startedAt: item.startedAt?.toISOString() ?? null,
+  completedAt: item.completedAt?.toISOString() ?? null,
+  cancelledAt: item.cancelledAt?.toISOString() ?? null,
+  createdAt: item.createdAt.toISOString(),
+  updatedAt: item.updatedAt.toISOString(),
+});
+
+export const toJsonAdminJobSummary = (summary: QueueOperationalSummary) => ({
+  ...summary,
+  nextQueuedRunAt: summary.nextQueuedRunAt?.toISOString() ?? null,
+  workers: summary.workers.map((worker) => ({
+    ...worker,
+    startedAt: worker.startedAt.toISOString(),
+    lastHeartbeatAt: worker.lastHeartbeatAt.toISOString(),
+    stoppedAt: worker.stoppedAt?.toISOString() ?? null,
+    createdAt: worker.createdAt.toISOString(),
+    updatedAt: worker.updatedAt.toISOString(),
   })),
+});
+
+export const toJsonAdminJobStateSnapshot = (
+  snapshot: Awaited<ReturnType<typeof getAdminJobStateSnapshot>>,
+) => ({
+  summary: toJsonAdminJobSummary(snapshot.summary),
+  lastRuns: Object.fromEntries(
+    Object.entries(snapshot.lastRuns).map(([kind, job]) => [
+      kind,
+      job ? toJsonAdminJob(job) : null,
+    ]),
+  ),
 });

--- a/packages/db/src/admin.ts
+++ b/packages/db/src/admin.ts
@@ -288,3 +288,17 @@ export const listAdminBackgroundJobs = async (
     statusCounts,
   };
 };
+
+export const listAdminBackgroundJobItems = async (
+  filters: Pick<AdminBackgroundJobListFilters, "kind" | "limit"> = {},
+  client?: AdminClient,
+): Promise<BackgroundJobRecord[]> => {
+  const activeClient = client ?? (getPrisma() as unknown as AdminClient);
+  const limit = normalizeJobListLimit(filters.limit);
+
+  return activeClient.backgroundJob.findMany({
+    where: buildJobWhere({ kind: filters.kind, status: null }),
+    orderBy: [{ updatedAt: "desc" }, { id: "desc" }],
+    take: limit,
+  }) as Promise<BackgroundJobRecord[]>;
+};

--- a/packages/db/src/jobs.ts
+++ b/packages/db/src/jobs.ts
@@ -14,6 +14,7 @@ export const STAGING_CLEANUP_SCHEDULE_WINDOW_MS = 15 * 60 * 1000;
 export const BACKGROUND_JOB_LEASE_MS = 60_000;
 export const BACKGROUND_JOB_RETRY_DELAY_MS = 30_000;
 export const BACKGROUND_JOB_RETRY_DELAY_MAX_MS = 15 * 60 * 1000;
+export const BACKGROUND_JOB_STATE_CHANGED_CHANNEL = "staaash_job_state_changed";
 
 export type SupportedBackgroundJobKind =
   | typeof STAGING_CLEANUP_JOB_KIND
@@ -132,6 +133,7 @@ type BackgroundJobClient = {
       isolationLevel?: Prisma.TransactionIsolationLevel;
     },
   ): Promise<T>;
+  $executeRawUnsafe?(query: string, ...values: unknown[]): Promise<unknown>;
 };
 
 const BACKGROUND_JOB_SCHEDULE_MAX_RETRIES = 3;
@@ -139,6 +141,18 @@ const MAX_STORED_ERROR_LENGTH = 2000;
 
 const getClient = (client?: BackgroundJobClient) =>
   client ?? (getPrisma() as unknown as BackgroundJobClient);
+
+const notifyBackgroundJobStateChanged = async (
+  client: BackgroundJobClient,
+  jobId: string | null = null,
+) => {
+  await client
+    .$executeRawUnsafe?.(
+      `SELECT pg_notify('${BACKGROUND_JOB_STATE_CHANGED_CHANNEL}', $1)`,
+      jobId ?? "",
+    )
+    .catch(() => undefined);
+};
 
 const truncateJobError = (value: string) =>
   value.length > MAX_STORED_ERROR_LENGTH
@@ -304,6 +318,7 @@ export const ensureBackgroundJobScheduled = async ({
               metadataJson: { source: "scheduler" },
             },
           });
+          await notifyBackgroundJobStateChanged(tx, job.id);
 
           return { created: true, job };
         },
@@ -410,6 +425,7 @@ export const claimDueBackgroundJob = async ({
         metadataJson: { leaseExpiresAt: leaseExpiresAt.toISOString() },
       },
     });
+    await notifyBackgroundJobStateChanged(tx, job.id);
 
     return tx.backgroundJob.findUnique({ where: { id: job.id } });
   });
@@ -500,6 +516,7 @@ export const markBackgroundJobSucceeded = async ({
       metadataJson: {},
     },
   });
+  await notifyBackgroundJobStateChanged(activeClient, jobId);
 
   return activeClient.backgroundJob.findUnique({ where: { id: jobId } });
 };
@@ -549,6 +566,7 @@ export const markBackgroundJobTerminal = async ({
       metadataJson: { errorCode, terminal: true },
     },
   });
+  await notifyBackgroundJobStateChanged(activeClient, jobId);
 
   return activeClient.backgroundJob.findUnique({ where: { id: jobId } });
 };
@@ -624,6 +642,7 @@ export const markBackgroundJobFailed = async ({
         },
       },
     });
+    await notifyBackgroundJobStateChanged(tx, jobId);
 
     return updated;
   });
@@ -672,6 +691,7 @@ export const cancelBackgroundJob = async ({
         metadataJson: { actorUserId },
       },
     });
+    await notifyBackgroundJobStateChanged(tx, jobId);
 
     return updated;
   });
@@ -726,6 +746,7 @@ export const retryBackgroundJob = async ({
         metadataJson: { actorUserId },
       },
     });
+    await notifyBackgroundJobStateChanged(tx, jobId);
 
     return updated;
   });
@@ -762,8 +783,9 @@ export const registerWorkerInstance = async ({
   metadataJson?: Record<string, unknown>;
   now?: Date;
   client?: BackgroundJobClient;
-}) =>
-  getClient(client).workerInstance.upsert({
+}) => {
+  const activeClient = getClient(client);
+  const worker = await activeClient.workerInstance.upsert({
     where: { id },
     create: {
       id,
@@ -787,6 +809,9 @@ export const registerWorkerInstance = async ({
       metadataJson,
     },
   });
+  await notifyBackgroundJobStateChanged(activeClient);
+  return worker;
+};
 
 export const heartbeatWorkerInstance = async ({
   id,
@@ -821,8 +846,9 @@ export const markWorkerInstanceStopped = async ({
   id: string;
   now?: Date;
   client?: BackgroundJobClient;
-}) =>
-  getClient(client).workerInstance.update({
+}) => {
+  const activeClient = getClient(client);
+  const worker = await activeClient.workerInstance.update({
     where: { id },
     data: {
       status: "stopped",
@@ -831,6 +857,9 @@ export const markWorkerInstanceStopped = async ({
       lastHeartbeatAt: now,
     },
   });
+  await notifyBackgroundJobStateChanged(activeClient);
+  return worker;
+};
 
 export const listWorkerInstances = async ({
   limit = 25,


### PR DESCRIPTION
## 🚀 Summary

- Add a global Job activity panel to admin jobs for recent queued, running, failed, cancelled, and completed work.
- Replace the native kind filter with a shared shadcn Base Select implementation, with stable width, visible hover/highlight state, and right-aligned popup behavior.
- Standardize job status colors across dots, text, chips, and docs so queued, running, succeeded, failed, and cancelled stay consistent.

## 📊 Impacts and Changes

- Admin jobs now has status filters and a kind filter for scanning recent job activity.
- The kind filter no longer changes width when selecting longer job names and avoids the native Firefox dropdown styling mismatch.
- No schema, auth, storage, or restore behavior changes.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

Manual UI verification: checked `http://localhost:3000/admin/jobs` in the in-app browser at desktop and mobile widths. Confirmed the filters stay aligned, the select trigger keeps a stable width across long labels, menu items are not clipped, and hover/highlight states are visible.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

- Firefox-specific visual behavior was addressed through the custom select and fixed-width control styling; final confirmation in the user's Firefox is still useful because the in-app browser is Chromium-based.

## 🔗 Linked Issues

- None.
