### PR TITLE
Polish home dashboard

### DIFF
--- a/apps/web/app/(workspace)/create-folder-dialog.tsx
+++ b/apps/web/app/(workspace)/create-folder-dialog.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { startTransition, useId, useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+import { FolderPlus } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+
+type CreateFolderDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  parentId?: string | null;
+  redirectTo: string;
+};
+
+export function CreateFolderDialog({
+  open,
+  onOpenChange,
+  parentId = null,
+  redirectTo,
+}: CreateFolderDialogProps) {
+  const inputId = useId();
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const reset = () => {
+    setName("");
+    setError(null);
+    setIsSubmitting(false);
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (isSubmitting) return;
+    if (!nextOpen) reset();
+    onOpenChange(nextOpen);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedName = name.trim();
+
+    if (!trimmedName) {
+      setError("Enter a folder name.");
+      return;
+    }
+
+    setError(null);
+    setIsSubmitting(true);
+
+    const body = new URLSearchParams({
+      name: trimmedName,
+      redirectTo,
+    });
+    if (parentId) body.set("parentId", parentId);
+
+    try {
+      const response = await fetch("/api/files/folders", {
+        method: "POST",
+        headers: { Accept: "application/json" },
+        body,
+      });
+      const data = (await response.json().catch(() => ({}))) as {
+        error?: string;
+        folder?: { name?: string };
+      };
+
+      if (!response.ok) {
+        setError(data.error ?? "Folder could not be created.");
+        return;
+      }
+
+      const folderName = data.folder?.name ?? trimmedName;
+      reset();
+      onOpenChange(false);
+      toast.success(`Created folder ${folderName}.`);
+      startTransition(() => router.refresh());
+    } catch (caughtError) {
+      setError(
+        caughtError instanceof Error
+          ? caughtError.message
+          : "Folder could not be created.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="create-folder-dialog">
+        <div className="create-folder-dialog-head">
+          <span className="create-folder-dialog-icon" aria-hidden>
+            <FolderPlus size={18} strokeWidth={1.9} />
+          </span>
+          <div>
+            <DialogTitle>Create folder</DialogTitle>
+            <p>Folders are created at the current level.</p>
+          </div>
+        </div>
+
+        <form className="create-folder-form" onSubmit={handleSubmit}>
+          <div className="create-folder-field">
+            <label htmlFor={inputId}>Folder name</label>
+            <Input
+              id={inputId}
+              autoFocus
+              value={name}
+              aria-invalid={error ? true : undefined}
+              aria-describedby={error ? `${inputId}-error` : undefined}
+              disabled={isSubmitting}
+              onChange={(event) => {
+                setName(event.target.value);
+                if (error) setError(null);
+              }}
+            />
+            {error ? (
+              <p className="create-folder-error" id={`${inputId}-error`}>
+                {error}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="create-folder-actions">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => handleOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!name.trim() || isSubmitting}>
+              {isSubmitting ? "Creating" : "Create"}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/app/(workspace)/favorites/favorites-view.tsx
+++ b/apps/web/app/(workspace)/favorites/favorites-view.tsx
@@ -101,13 +101,16 @@ function SortIcon({
 function FavoriteIcon({
   item,
   size = 14,
+  tone = "filled",
 }: {
   item: FavoriteClientItem;
   size?: number;
+  tone?: "filled" | "plain";
 }) {
   return (
     <ItemTypeIcon
       size={size}
+      tone={tone}
       visual={getItemVisual(
         item.kind,
         item.kind === "file" ? item.mimeType : null,
@@ -1082,7 +1085,7 @@ export function FavoritesView({ error, items, success }: FavoritesViewProps) {
                     onPointerUp={clearLongPressTimer}
                   >
                     <span className="favorites-row-thumb">
-                      <FavoriteIcon item={item} />
+                      <FavoriteIcon item={item} tone="plain" />
                     </span>
                     <span className="favorites-row-name" title={item.name}>
                       {item.name}

--- a/apps/web/app/(workspace)/files/files-row.tsx
+++ b/apps/web/app/(workspace)/files/files-row.tsx
@@ -357,6 +357,7 @@ export function FilesRow(props: FilesRowProps) {
             <ItemTypeIcon
               icon={props.kind === "folder" ? IconComponent : undefined}
               size={16}
+              tone="plain"
               visual={visual}
             />
           </div>

--- a/apps/web/app/(workspace)/files/files-view.tsx
+++ b/apps/web/app/(workspace)/files/files-view.tsx
@@ -11,13 +11,6 @@ import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { Download, FolderPlus, RefreshCw, Upload } from "lucide-react";
 
-import { Button, buttonVariants } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { FlashMessage } from "@/app/auth-ui";
 import { DashboardPageContextMenu } from "@/app/dashboard-context-menu";
@@ -28,6 +21,7 @@ import type { ShareFilesLookup } from "@/server/sharing";
 import { FilesRow } from "./files-row";
 import { FilesPropertiesPanel } from "./files-properties-panel";
 import { ShareDialog } from "./share-dialog";
+import { CreateFolderDialog } from "../create-folder-dialog";
 import {
   useTransferContext,
   type UploadingFile,
@@ -229,9 +223,8 @@ export function FilesView({
     share: ShareLinkSummary | null;
   } | null>(null);
 
-  // ---- New folder popover ----
+  // ---- New folder dialog ----
   const [newFolderOpen, setNewFolderOpen] = useState(false);
-  const [newFolderName, setNewFolderName] = useState("");
 
   // ---- Flash messages ----
   const error =
@@ -662,22 +655,6 @@ export function FilesView({
     startTransition(() => router.refresh());
   };
 
-  const handleCreateFolder = async () => {
-    const name = newFolderName.trim();
-    if (!name) return;
-    setNewFolderOpen(false);
-    setNewFolderName("");
-    await fetch("/api/files/folders", {
-      method: "POST",
-      body: new URLSearchParams({
-        name,
-        parentId: listing.currentFolder.id,
-        redirectTo: currentPath,
-      }),
-    });
-    startTransition(() => router.refresh());
-  };
-
   // ---------------------------------------------------------------------------
   // Folder icons
   // ---------------------------------------------------------------------------
@@ -1088,38 +1065,14 @@ export function FilesView({
             </div>
 
             <div className="explorer-header-actions">
-              {/* New folder */}
-              <Popover open={newFolderOpen} onOpenChange={setNewFolderOpen}>
-                <PopoverTrigger
-                  className={buttonVariants({ variant: "outline", size: "sm" })}
-                >
-                  <FolderPlus />
-                  New folder
-                </PopoverTrigger>
-                <PopoverContent side="bottom" align="end" className="w-64">
-                  <form
-                    className="new-folder-form"
-                    onSubmit={(e) => {
-                      e.preventDefault();
-                      handleCreateFolder();
-                    }}
-                  >
-                    <Input
-                      autoFocus
-                      placeholder="Folder name"
-                      value={newFolderName}
-                      onChange={(e) => setNewFolderName(e.target.value)}
-                    />
-                    <Button
-                      type="submit"
-                      size="sm"
-                      disabled={!newFolderName.trim()}
-                    >
-                      Create
-                    </Button>
-                  </form>
-                </PopoverContent>
-              </Popover>
+              <button
+                className="button button-secondary"
+                type="button"
+                onClick={() => setNewFolderOpen(true)}
+              >
+                <FolderPlus size={15} aria-hidden />
+                New folder
+              </button>
 
               <input
                 ref={fileInputRef}
@@ -1518,6 +1471,13 @@ export function FilesView({
             }}
           />
         )}
+
+        <CreateFolderDialog
+          open={newFolderOpen}
+          onOpenChange={setNewFolderOpen}
+          parentId={listing.currentFolder.id}
+          redirectTo={currentPath}
+        />
 
         {/* ---- Keyboard shortcut legend ---- */}
         {showShortcutLegend && (

--- a/apps/web/app/(workspace)/home/home-actions.tsx
+++ b/apps/web/app/(workspace)/home/home-actions.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState } from "react";
+import { FolderPlus, Upload } from "lucide-react";
+
+import { CreateFolderDialog } from "../create-folder-dialog";
+
+export function HomePrimaryActions() {
+  const [createFolderOpen, setCreateFolderOpen] = useState(false);
+
+  return (
+    <>
+      <div className="home-actions">
+        <button
+          className="home-action home-action-primary"
+          type="button"
+          onClick={() =>
+            window.dispatchEvent(new Event("staaash:upload-click"))
+          }
+        >
+          <Upload size={15} strokeWidth={1.9} aria-hidden />
+          <span>Upload files</span>
+        </button>
+        <button
+          className="home-action home-action-secondary"
+          type="button"
+          onClick={() => setCreateFolderOpen(true)}
+        >
+          <FolderPlus size={15} strokeWidth={1.9} aria-hidden />
+          <span>New folder</span>
+        </button>
+      </div>
+
+      <CreateFolderDialog
+        open={createFolderOpen}
+        onOpenChange={setCreateFolderOpen}
+        parentId={null}
+        redirectTo="/home"
+      />
+    </>
+  );
+}

--- a/apps/web/app/(workspace)/home/home-helpers.ts
+++ b/apps/web/app/(workspace)/home/home-helpers.ts
@@ -83,6 +83,25 @@ export function formatHomeChildCount(count: number): string {
   return `${count} items`;
 }
 
+export function isHomeDashboardEmpty({
+  favoriteCount,
+  folderCount,
+  recentCount,
+  shareCount,
+}: {
+  favoriteCount: number;
+  folderCount: number;
+  recentCount: number;
+  shareCount: number;
+}): boolean {
+  return (
+    favoriteCount === 0 &&
+    folderCount === 0 &&
+    recentCount === 0 &&
+    shareCount === 0
+  );
+}
+
 export function getHomeItemVisual(
   kind: "file" | "folder",
   mimeType?: string | null,

--- a/apps/web/app/(workspace)/home/page.tsx
+++ b/apps/web/app/(workspace)/home/page.tsx
@@ -5,6 +5,7 @@ import {
   Clock,
   FolderPlus,
   Heart,
+  Link2 as LinkIcon,
   Share2,
   type LucideIcon,
 } from "lucide-react";
@@ -67,24 +68,31 @@ function SectionHeader({
 }
 
 function HomeIcon({ visual }: { visual: HomeItemVisual }) {
-  return <ItemTypeIcon className="home-item-icon" size={16} visual={visual} />;
+  return (
+    <ItemTypeIcon
+      className="home-item-icon"
+      size={16}
+      tone="plain"
+      visual={visual}
+    />
+  );
 }
 
 function HomeEmptyBlock({
   icon: Icon,
+  tone = "neutral",
   title,
 }: {
   icon: LucideIcon;
+  tone?: "favorite" | "folder" | "recent" | "share" | "neutral";
   title: string;
 }) {
   return (
     <div className="home-empty-block">
-      <span className="home-empty-icon" aria-hidden>
+      <span className={`home-empty-icon home-empty-icon-${tone}`} aria-hidden>
         <Icon size={17} strokeWidth={1.8} />
       </span>
-      <span className="home-empty-copy">
-        <strong>{title}</strong>
-      </span>
+      <span className="home-empty-copy">{title}</span>
     </div>
   );
 }
@@ -112,7 +120,9 @@ function PinnedList({
   redirectTo: string;
 }) {
   if (items.length === 0) {
-    return <HomeEmptyBlock icon={Heart} title="Nothing pinned" />;
+    return (
+      <HomeEmptyBlock icon={Heart} title="Nothing pinned yet" tone="favorite" />
+    );
   }
 
   return (
@@ -163,7 +173,9 @@ function RecentList({
   redirectTo: string;
 }) {
   if (items.length === 0) {
-    return <HomeEmptyBlock icon={Clock} title="Nothing recent" />;
+    return (
+      <HomeEmptyBlock icon={Clock} title="Nothing recent yet" tone="recent" />
+    );
   }
 
   return (
@@ -221,7 +233,9 @@ function FolderList({
   redirectTo: string;
 }) {
   if (folders.length === 0) {
-    return <HomeEmptyBlock icon={FolderPlus} title="No folders" />;
+    return (
+      <HomeEmptyBlock icon={FolderPlus} title="No folders yet" tone="folder" />
+    );
   }
 
   return (
@@ -254,7 +268,9 @@ function FolderList({
 
 function SharedList({ shares }: { shares: ShareLinkSummary[] }) {
   if (shares.length === 0) {
-    return <HomeEmptyBlock icon={Share2} title="No links" />;
+    return (
+      <HomeEmptyBlock icon={LinkIcon} title="No shared links" tone="share" />
+    );
   }
 
   return (
@@ -279,7 +295,7 @@ function SharedList({ shares }: { shares: ShareLinkSummary[] }) {
                 <span className="home-shared-name">{share.target.name}</span>
                 <span className="home-shared-meta">
                   {share.downloadDisabled ? "Downloads off" : "Downloads on"}
-                  {" · expires "}
+                  {", expires "}
                   {formatHomeExpiryTime(share.expiresAt)}
                 </span>
               </span>

--- a/apps/web/app/(workspace)/home/page.tsx
+++ b/apps/web/app/(workspace)/home/page.tsx
@@ -1,13 +1,20 @@
 import Link from "next/link";
 import { headers } from "next/headers";
-import { ArrowRight, Share2, Video } from "lucide-react";
+import {
+  ArrowRight,
+  Clock,
+  FolderPlus,
+  Heart,
+  Share2,
+  type LucideIcon,
+} from "lucide-react";
 
 import { requireSignedInPageSession } from "@/server/auth/guards";
 import { filesService } from "@/server/files/service";
 import type { FolderSummary } from "@/server/files/types";
 import { ItemContextMenu } from "@/app/item-context-menu";
 import { WorkspacePresetPageContextMenu } from "@/app/dashboard-context-menu";
-import { ItemTypeIcon, itemVisualIconMap } from "@/app/item-type-icon";
+import { ItemTypeIcon } from "@/app/item-type-icon";
 import { retrievalService } from "@/server/retrieval/service";
 import type { RetrievalItem } from "@/server/retrieval/types";
 import { getShareBaseUrl } from "@/server/request";
@@ -21,8 +28,10 @@ import {
   formatHomeRelativeTime,
   getHomeGreeting,
   getHomeItemVisual,
+  isHomeDashboardEmpty,
   type HomeItemVisual,
 } from "./home-helpers";
+import { HomePrimaryActions } from "./home-actions";
 
 export const dynamic = "force-dynamic";
 
@@ -58,11 +67,41 @@ function SectionHeader({
 }
 
 function HomeIcon({ visual }: { visual: HomeItemVisual }) {
-  return <ItemTypeIcon className="home-item-icon" visual={visual} />;
+  return <ItemTypeIcon className="home-item-icon" size={16} visual={visual} />;
 }
 
-function EmptyLine({ children }: { children: React.ReactNode }) {
-  return <p className="home-empty-line">{children}</p>;
+function HomeEmptyBlock({
+  icon: Icon,
+  title,
+}: {
+  icon: LucideIcon;
+  title: string;
+}) {
+  return (
+    <div className="home-empty-block">
+      <span className="home-empty-icon" aria-hidden>
+        <Icon size={17} strokeWidth={1.8} />
+      </span>
+      <span className="home-empty-copy">
+        <strong>{title}</strong>
+      </span>
+    </div>
+  );
+}
+
+function HomeFirstRunState() {
+  return (
+    <section className="home-first-run" aria-label="Start your drive">
+      <span className="home-first-run-icon" aria-hidden>
+        <FolderPlus size={24} strokeWidth={1.7} />
+      </span>
+      <div className="home-first-run-copy">
+        <h2>Add your first file</h2>
+        <p>Upload something now, or create a folder first.</p>
+      </div>
+      <HomePrimaryActions />
+    </section>
+  );
 }
 
 function PinnedList({
@@ -73,7 +112,7 @@ function PinnedList({
   redirectTo: string;
 }) {
   if (items.length === 0) {
-    return <EmptyLine>No pinned files yet</EmptyLine>;
+    return <HomeEmptyBlock icon={Heart} title="Nothing pinned" />;
   }
 
   return (
@@ -116,93 +155,7 @@ function PinnedList({
   );
 }
 
-function PreviewLines() {
-  return (
-    <span className="home-doc-preview-lines" aria-hidden>
-      {[82, 65, 90, 50, 76, 60].map((width, index) => (
-        <span
-          key={`${width}-${index}`}
-          style={{
-            width: `${width}%`,
-          }}
-        />
-      ))}
-    </span>
-  );
-}
-
-function AudioBars({ color }: { color: string }) {
-  const bars = [5, 9, 14, 10, 18, 22, 16, 12, 20, 24, 18, 14, 10, 16, 20, 14];
-
-  return (
-    <span className="home-audio-bars" aria-hidden>
-      {bars.map((height, index) => (
-        <span
-          key={`${height}-${index}`}
-          style={{
-            background: color,
-            height: `${height}px`,
-          }}
-        />
-      ))}
-    </span>
-  );
-}
-
-function RecentPreview({ item }: { item: RetrievalItem }) {
-  const visual = getHomeItemVisual(
-    item.kind,
-    item.kind === "file" ? item.mimeType : null,
-  );
-  const Icon = itemVisualIconMap[visual.kind];
-
-  if (visual.kind === "video") {
-    return (
-      <span className="home-recent-preview home-recent-preview-video">
-        <span className="home-video-strips" aria-hidden />
-        <span className="home-video-play" aria-hidden>
-          <Video size={14} strokeWidth={1.8} />
-        </span>
-      </span>
-    );
-  }
-
-  if (visual.kind === "audio") {
-    return (
-      <span
-        className="home-recent-preview"
-        style={{ background: visual.background }}
-      >
-        <AudioBars color={visual.color} />
-      </span>
-    );
-  }
-
-  if (visual.kind === "pdf" || visual.kind === "text") {
-    return (
-      <span
-        className="home-recent-preview home-recent-preview-document"
-        style={{ background: visual.background }}
-      >
-        <PreviewLines />
-        <span className="home-preview-type" style={{ color: visual.color }}>
-          {visual.kind === "pdf" ? "PDF" : "TXT"}
-        </span>
-      </span>
-    );
-  }
-
-  return (
-    <span
-      className="home-recent-preview"
-      style={{ background: visual.background }}
-    >
-      <Icon size={24} strokeWidth={1.7} color={visual.color} aria-hidden />
-    </span>
-  );
-}
-
-function RecentGrid({
+function RecentList({
   items,
   redirectTo,
 }: {
@@ -210,16 +163,20 @@ function RecentGrid({
   redirectTo: string;
 }) {
   if (items.length === 0) {
-    return <EmptyLine>Nothing recent yet</EmptyLine>;
+    return <HomeEmptyBlock icon={Clock} title="Nothing recent" />;
   }
 
   return (
-    <div className="home-recent-grid">
+    <div className="home-recent-list">
       {items.map((item) => {
+        const visual = getHomeItemVisual(
+          item.kind,
+          item.kind === "file" ? item.mimeType : null,
+        );
         const content = (
           <>
-            <RecentPreview item={item} />
-            <span className="home-recent-body">
+            <HomeIcon visual={visual} />
+            <span className="home-recent-main">
               <span className="home-recent-name" title={item.name}>
                 {item.name}
               </span>
@@ -241,11 +198,11 @@ function RecentGrid({
             redirectTo={redirectTo}
           >
             {item.kind === "folder" ? (
-              <Link className="home-recent-card" href={item.href}>
+              <Link className="home-recent-row" href={item.href}>
                 {content}
               </Link>
             ) : (
-              <a className="home-recent-card" href={item.href}>
+              <a className="home-recent-row" href={item.href}>
                 {content}
               </a>
             )}
@@ -264,7 +221,7 @@ function FolderList({
   redirectTo: string;
 }) {
   if (folders.length === 0) {
-    return <EmptyLine>No folders yet</EmptyLine>;
+    return <HomeEmptyBlock icon={FolderPlus} title="No folders" />;
   }
 
   return (
@@ -297,7 +254,7 @@ function FolderList({
 
 function SharedList({ shares }: { shares: ShareLinkSummary[] }) {
   if (shares.length === 0) {
-    return <EmptyLine>No active links yet</EmptyLine>;
+    return <HomeEmptyBlock icon={Share2} title="No links" />;
   }
 
   return (
@@ -388,60 +345,71 @@ export default async function HomePage() {
     session.user.displayName ?? session.user.email.split("@")[0] ?? "there";
   const greeting = getHomeGreeting(new Date().getHours());
   const currentPath = "/home";
+  const pinnedItems = favoriteItems.slice(0, 6);
+  const recentHomeItems = recentItems.slice(0, 6);
+  const activeShares = shares.active.slice(0, 3);
+  const dashboardEmpty = isHomeDashboardEmpty({
+    favoriteCount: favoriteItems.length,
+    recentCount: recentItems.length,
+    folderCount: folders.length,
+    shareCount: shares.active.length,
+  });
 
   return (
     <WorkspacePresetPageContextMenu
-      className="workspace-page home-page"
+      className={`workspace-page home-page${dashboardEmpty ? " home-page-empty" : ""}`}
       preset="home"
     >
-      <header className="home-greeting">
-        <h1>{`${greeting}, ${displayName}.`}</h1>
+      <header className="home-hero">
+        <div className="home-greeting">
+          <h1>{`${greeting}, ${displayName}.`}</h1>
+        </div>
+        {dashboardEmpty ? null : <HomePrimaryActions />}
       </header>
 
-      <div className="home-top-grid">
-        <section className="home-section" aria-labelledby="home-pinned-title">
-          <SectionHeader title="Pinned" titleId="home-pinned-title" />
-          <PinnedList
-            items={favoriteItems.slice(0, 6)}
-            redirectTo={currentPath}
-          />
-        </section>
+      {dashboardEmpty ? (
+        <HomeFirstRunState />
+      ) : (
+        <div className="home-sections-grid">
+          <section className="home-section" aria-labelledby="home-pinned-title">
+            <SectionHeader title="Pinned" titleId="home-pinned-title" />
+            <PinnedList items={pinnedItems} redirectTo={currentPath} />
+          </section>
 
-        <section className="home-section" aria-labelledby="home-recent-title">
-          <SectionHeader
-            actionHref="/files"
-            actionLabel="All files"
-            title="Recent"
-            titleId="home-recent-title"
-          />
-          <RecentGrid
-            items={recentItems.slice(0, 6)}
-            redirectTo={currentPath}
-          />
-        </section>
-      </div>
+          <section className="home-section" aria-labelledby="home-recent-title">
+            <SectionHeader
+              actionHref="/files"
+              actionLabel="All files"
+              title="Recent"
+              titleId="home-recent-title"
+            />
+            <RecentList items={recentHomeItems} redirectTo={currentPath} />
+          </section>
 
-      <div className="home-bottom-grid">
-        <section className="home-section" aria-labelledby="home-folders-title">
-          <SectionHeader
-            actionHref="/files"
-            actionLabel="View all"
-            title="Folders"
-            titleId="home-folders-title"
-          />
-          <FolderList folders={folders} redirectTo={currentPath} />
-        </section>
+          <section
+            className="home-section"
+            aria-labelledby="home-folders-title"
+          >
+            <SectionHeader
+              actionHref="/files"
+              actionLabel="View all"
+              title="Folders"
+              titleId="home-folders-title"
+            />
+            <FolderList folders={folders} redirectTo={currentPath} />
+          </section>
 
-        <section className="home-section" aria-labelledby="home-shared-title">
-          <SectionHeader
-            actionHref="/shared"
-            actionLabel="Manage"
-            title="Shared links"
-            titleId="home-shared-title"
-          />
-          <SharedList shares={shares.active.slice(0, 3)} />
-        </section>
-      </div>
+          <section className="home-section" aria-labelledby="home-shared-title">
+            <SectionHeader
+              actionHref="/shared"
+              actionLabel="Manage"
+              title="Shared links"
+              titleId="home-shared-title"
+            />
+            <SharedList shares={activeShares} />
+          </section>
+        </div>
+      )}
     </WorkspacePresetPageContextMenu>
   );
 }

--- a/apps/web/app/(workspace)/recent/recent-view.tsx
+++ b/apps/web/app/(workspace)/recent/recent-view.tsx
@@ -108,13 +108,16 @@ function SortIcon({
 function ItemIcon({
   item,
   size = 14,
+  tone = "filled",
 }: {
   item: RecentClientItem;
   size?: number;
+  tone?: "filled" | "plain";
 }) {
   return (
     <ItemTypeIcon
       size={size}
+      tone={tone}
       visual={getItemVisual(
         item.kind,
         item.kind === "file" ? item.mimeType : null,
@@ -972,7 +975,7 @@ export function RecentView({ error, items, success }: RecentViewProps) {
                       onPointerUp={clearLongPressTimer}
                     >
                       <span className="recent-row-thumb">
-                        <ItemIcon item={item} />
+                        <ItemIcon item={item} tone="plain" />
                       </span>
                       <span className="recent-row-name" title={item.name}>
                         {item.name}

--- a/apps/web/app/(workspace)/retrieval-item-list.tsx
+++ b/apps/web/app/(workspace)/retrieval-item-list.tsx
@@ -57,6 +57,7 @@ export function RetrievalItemList({
           <article className="retrieval-row">
             <div className="retrieval-row-main">
               <ItemTypeIcon
+                tone="plain"
                 visual={getItemVisual(
                   item.kind,
                   item.kind === "file" ? item.mimeType : null,

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3575,10 +3575,11 @@ h3 {
 /* ---- Home dashboard ---- */
 
 .home-page {
-  --home-row-gap: 12px;
-  --home-row-icon-size: 30px;
-  --home-row-inset: 8px;
-  --home-section-title-inset: 2px;
+  --home-row-gap: 9px;
+  --home-row-height: 48px;
+  --home-row-icon-size: 24px;
+  --home-row-inset-x: 7px;
+  --home-row-inset-y: 5px;
   width: 100%;
   margin-inline: 0;
   gap: 24px;
@@ -3724,7 +3725,7 @@ h3 {
 .home-sections-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 30px 28px;
+  gap: 28px;
   align-items: start;
 }
 
@@ -3738,34 +3739,33 @@ h3 {
   justify-content: space-between;
   gap: 12px;
   min-height: 18px;
-  margin-bottom: 10px;
-  padding-bottom: 10px;
+  margin-bottom: 8px;
+  padding-bottom: 8px;
   border-bottom: 1px solid
-    color-mix(in oklab, var(--foreground) 7%, transparent);
+    color-mix(in oklab, var(--foreground) 6%, transparent);
 }
 
 .home-section-title {
   display: flex;
   align-items: center;
-  color: color-mix(in oklab, var(--muted-foreground) 86%, var(--foreground));
-  font-size: 12px;
-  font-weight: 800;
-  letter-spacing: 0.04em;
-  line-height: 16px;
-  min-height: 16px;
-  padding-left: var(--home-section-title-inset);
-  text-transform: uppercase;
+  color: color-mix(in oklab, var(--foreground) 74%, var(--muted-foreground));
+  font-family: var(--font-switzer), "Segoe UI", sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 18px;
+  min-height: 18px;
 }
 
 .home-section-link {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  color: var(--muted-foreground);
+  color: color-mix(in oklab, var(--muted-foreground) 88%, var(--foreground));
   font-size: 12px;
-  font-weight: 650;
-  line-height: 16px;
-  min-height: 16px;
+  font-weight: 500;
+  line-height: 18px;
+  min-height: 18px;
   transition:
     color 120ms ease,
     transform 120ms ease;
@@ -3777,36 +3777,12 @@ h3 {
   transform: translateX(1px);
 }
 
-.home-empty-block {
-  min-height: 38px;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 2px 0 8px;
-}
-
-.home-empty-icon {
-  width: 24px;
-  height: 24px;
-  border-radius: 8px;
-  flex: 0 0 auto;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: transparent;
-  color: color-mix(in oklab, var(--muted-foreground) 72%, var(--primary));
-}
-
 .home-empty-copy {
   min-width: 0;
-  display: grid;
-}
-
-.home-empty-copy strong {
-  color: var(--foreground);
-  font-size: 14px;
-  font-weight: 700;
-  line-height: 1.25;
+  color: color-mix(in oklab, var(--muted-foreground) 88%, var(--foreground));
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 18px;
 }
 
 .home-pinned-list,
@@ -3830,13 +3806,20 @@ h3 {
 .home-pinned-row,
 .home-recent-row,
 .home-folder-row,
-.home-shared-row {
-  display: flex;
+.home-shared-row,
+.home-empty-block {
+  display: grid;
+  grid-template-columns: var(--home-row-icon-size) minmax(0, 1fr) auto;
   align-items: center;
-  border-radius: 9px;
+  column-gap: var(--home-row-gap);
+  border: 1px solid transparent;
+  border-radius: 8px;
   color: var(--foreground);
+  min-height: var(--home-row-height);
+  padding: var(--home-row-inset-y) var(--home-row-inset-x);
   transition:
     background 120ms ease,
+    border-color 120ms ease,
     color 120ms ease;
 }
 
@@ -3844,20 +3827,15 @@ h3 {
 .home-recent-row:hover,
 .home-folder-row:hover,
 .home-shared-row:hover {
-  background: color-mix(in oklab, var(--foreground) 2.5%, transparent);
-}
-
-.home-pinned-row,
-.home-recent-row {
-  gap: var(--home-row-gap);
-  min-height: 46px;
-  padding: var(--home-row-inset);
+  border-color: transparent;
+  background: color-mix(in oklab, var(--foreground) 1.2%, transparent);
 }
 
 .item-type-icon {
   width: 26px;
   height: 26px;
   border-radius: 6px;
+  color: var(--item-type-icon-color, currentColor);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -3867,11 +3845,47 @@ h3 {
 .home-item-icon {
   width: var(--home-row-icon-size);
   height: var(--home-row-icon-size);
-  border-radius: 8px;
+  border-radius: 6px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+  justify-self: center;
+  color: var(--item-type-icon-color, currentColor);
+}
+
+.home-empty-icon {
+  width: var(--home-row-icon-size);
+  height: var(--home-row-icon-size);
+  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  justify-self: center;
+  background: transparent;
+  color: color-mix(in oklab, var(--muted-foreground) 88%, var(--foreground));
+}
+
+.home-empty-icon-favorite {
+  color: color-mix(in oklab, oklch(0.68 0.16 22) 82%, var(--foreground));
+}
+
+.home-empty-icon-folder {
+  color: color-mix(in oklab, var(--primary) 78%, var(--foreground));
+}
+
+.home-empty-icon-recent {
+  color: color-mix(in oklab, var(--status-running) 78%, var(--foreground));
+}
+
+.home-empty-icon-share {
+  color: color-mix(in oklab, var(--status-succeeded) 74%, var(--foreground));
+}
+
+.home-item-icon svg,
+.home-empty-icon svg {
+  color: inherit;
+  stroke: currentColor;
 }
 
 .item-row-title {
@@ -3897,64 +3911,68 @@ h3 {
 
 .home-pinned-name {
   font-size: 14px;
-  font-weight: 600;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.25;
 }
 
 .home-recent-main {
   display: grid;
-  gap: 2px;
+  gap: 1px;
   min-width: 0;
-  flex: 1;
 }
 
 .home-recent-name {
   display: block;
   font-size: 14px;
-  font-weight: 600;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.25;
 }
 
 .home-recent-meta {
   color: var(--muted-foreground);
   font-size: 12px;
-}
-
-.home-folder-row,
-.home-shared-row {
-  gap: var(--home-row-gap);
-  min-height: 46px;
-  padding: var(--home-row-inset);
+  font-weight: 400;
+  line-height: 1.25;
 }
 
 .home-folder-name {
-  flex: 1;
   font-size: 14px;
-  font-weight: 600;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.25;
 }
 
 .home-folder-meta {
-  flex-shrink: 0;
   color: var(--muted-foreground);
-  font-size: 12px;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 18px;
   text-align: right;
   white-space: nowrap;
+  padding: 0 4px;
 }
 
 .home-shared-main {
   display: grid;
-  gap: 2px;
+  gap: 1px;
   min-width: 0;
-  flex: 1;
 }
 
 .home-shared-name {
   display: block;
   font-size: 14px;
-  font-weight: 600;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.25;
 }
 
 .home-shared-meta {
   color: var(--muted-foreground);
   font-size: 12px;
+  font-weight: 400;
+  line-height: 1.25;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -4347,6 +4365,11 @@ h3 {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.recent-row-thumb .item-type-icon,
+.favorites-row-thumb .item-type-icon {
+  background: transparent !important;
 }
 
 .recent-row-name {
@@ -6653,8 +6676,9 @@ html.light {
 }
 
 .explorer-row-icon .item-type-icon {
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
+  background: transparent !important;
 }
 
 .explorer-row-icon svg {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3575,34 +3575,157 @@ h3 {
 /* ---- Home dashboard ---- */
 
 .home-page {
-  gap: 28px;
+  --home-row-gap: 12px;
+  --home-row-icon-size: 30px;
+  --home-row-inset: 8px;
+  --home-section-title-inset: 2px;
+  width: 100%;
+  margin-inline: 0;
+  gap: 24px;
+  align-content: start;
+}
+
+.home-page-empty {
+  gap: 30px;
+}
+
+.home-page-empty .home-hero {
+  padding-bottom: 0;
+}
+
+.home-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 18px;
+  align-items: end;
+  padding-bottom: 4px;
 }
 
 .home-greeting {
   display: grid;
-  gap: 4px;
+  gap: 8px;
+  min-width: 0;
 }
 
 .home-greeting h1 {
-  font-size: 2rem;
+  color: var(--foreground);
+  font-family: var(--font-cabinet), sans-serif;
+  font-size: clamp(2rem, 4vw, 3.35rem);
   font-weight: 700;
-  letter-spacing: -0.03em;
-  line-height: 1.1;
+  letter-spacing: -0.035em;
+  line-height: 0.98;
+  text-wrap: balance;
 }
 
-.home-top-grid,
-.home-bottom-grid {
+.home-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.home-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 38px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  padding: 0 14px;
+  color: var(--foreground);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 650;
+  cursor: pointer;
+  transition:
+    transform 120ms ease,
+    border-color 140ms ease,
+    background 140ms ease,
+    color 140ms ease;
+  white-space: nowrap;
+}
+
+.home-action:hover {
+  transform: translateY(-1px);
+}
+
+.home-action:active {
+  transform: translateY(1px);
+}
+
+.home-action-primary {
+  background: var(--primary);
+  color: var(--primary-foreground);
+  box-shadow: 0 10px 22px color-mix(in oklab, var(--primary) 14%, transparent);
+}
+
+.home-action-primary:hover {
+  background: color-mix(in oklab, var(--primary) 88%, var(--foreground) 12%);
+}
+
+.home-action-secondary {
+  border-color: color-mix(in oklab, var(--foreground) 9%, transparent);
+  background: color-mix(in oklab, var(--card) 84%, var(--background) 16%);
+  color: color-mix(in oklab, var(--foreground) 82%, var(--primary) 18%);
+}
+
+.home-action-secondary:hover {
+  border-color: color-mix(in oklab, var(--primary) 24%, transparent);
+  background: color-mix(in oklab, var(--primary) 9%, var(--card));
+  color: color-mix(in oklab, var(--foreground) 72%, var(--primary) 28%);
+}
+
+.home-first-run {
+  min-height: min(52vh, 520px);
   display: grid;
-  gap: 20px;
+  place-items: center;
+  align-content: center;
+  justify-items: center;
+  gap: 18px;
+  padding: 32px 0 72px;
+  text-align: center;
+}
+
+.home-first-run .home-actions {
+  justify-content: center;
+}
+
+.home-first-run-icon {
+  width: 54px;
+  height: 54px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 16px;
+  color: color-mix(in oklab, var(--primary) 72%, var(--foreground));
+  background: color-mix(in oklab, var(--primary) 9%, transparent);
+}
+
+.home-first-run-copy {
+  display: grid;
+  gap: 7px;
+  max-width: 34ch;
+}
+
+.home-first-run-copy h2 {
+  color: var(--foreground);
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.home-first-run-copy p {
+  color: var(--muted-foreground);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.home-sections-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 30px 28px;
   align-items: start;
-}
-
-.home-top-grid {
-  grid-template-columns: minmax(180px, 1fr) minmax(0, 1.8fr);
-}
-
-.home-bottom-grid {
-  grid-template-columns: minmax(0, 1.2fr) minmax(220px, 1fr);
 }
 
 .home-section {
@@ -3611,19 +3734,27 @@ h3 {
 
 .home-section-head {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
-  margin-bottom: 12px;
+  min-height: 18px;
+  margin-bottom: 10px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--foreground) 7%, transparent);
 }
 
 .home-section-title {
-  font-size: 13px;
+  display: flex;
+  align-items: center;
+  color: color-mix(in oklab, var(--muted-foreground) 86%, var(--foreground));
+  font-size: 12px;
   font-weight: 800;
   letter-spacing: 0.04em;
-  line-height: 1.2;
+  line-height: 16px;
+  min-height: 16px;
+  padding-left: var(--home-section-title-inset);
   text-transform: uppercase;
-  color: color-mix(in oklab, var(--muted-foreground) 80%, transparent);
 }
 
 .home-section-link {
@@ -3632,43 +3763,77 @@ h3 {
   gap: 4px;
   color: var(--muted-foreground);
   font-size: 12px;
-  font-weight: 600;
-  transition: color 120ms ease;
+  font-weight: 650;
+  line-height: 16px;
+  min-height: 16px;
+  transition:
+    color 120ms ease,
+    transform 120ms ease;
   white-space: nowrap;
 }
 
 .home-section-link:hover {
   color: var(--foreground);
+  transform: translateX(1px);
 }
 
-.home-empty-line {
-  color: var(--muted-foreground);
-  font-size: 13px;
-  padding: 8px 6px;
+.home-empty-block {
+  min-height: 38px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 2px 0 8px;
+}
+
+.home-empty-icon {
+  width: 24px;
+  height: 24px;
+  border-radius: 8px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  color: color-mix(in oklab, var(--muted-foreground) 72%, var(--primary));
+}
+
+.home-empty-copy {
+  min-width: 0;
+  display: grid;
+}
+
+.home-empty-copy strong {
+  color: var(--foreground);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.25;
 }
 
 .home-pinned-list,
+.home-recent-list,
 .home-folder-list,
 .home-shared-list {
   display: grid;
   gap: 0;
+  min-height: 48px;
 }
 
 .home-pinned-list > [data-slot="context-menu"],
+.home-recent-list > [data-slot="context-menu"],
 .home-folder-list > [data-slot="context-menu"],
 .home-shared-list > [data-slot="context-menu"],
-.home-recent-grid > [data-slot="context-menu"],
 .retrieval-list > [data-slot="context-menu"],
 .sl-list > [data-slot="context-menu"] {
   display: contents;
 }
 
 .home-pinned-row,
+.home-recent-row,
 .home-folder-row,
 .home-shared-row {
   display: flex;
   align-items: center;
-  border-radius: 7px;
+  border-radius: 9px;
   color: var(--foreground);
   transition:
     background 120ms ease,
@@ -3676,21 +3841,33 @@ h3 {
 }
 
 .home-pinned-row:hover,
+.home-recent-row:hover,
 .home-folder-row:hover,
 .home-shared-row:hover {
-  background: color-mix(in oklab, var(--foreground) 5%, transparent);
+  background: color-mix(in oklab, var(--foreground) 2.5%, transparent);
 }
 
-.home-pinned-row {
-  gap: 9px;
-  padding: 7px 6px;
+.home-pinned-row,
+.home-recent-row {
+  gap: var(--home-row-gap);
+  min-height: 46px;
+  padding: var(--home-row-inset);
 }
 
-.item-type-icon,
-.home-item-icon {
+.item-type-icon {
   width: 26px;
   height: 26px;
   border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.home-item-icon {
+  width: var(--home-row-icon-size);
+  height: var(--home-row-icon-size);
+  border-radius: 8px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -3719,153 +3896,45 @@ h3 {
 }
 
 .home-pinned-name {
-  font-size: 13px;
-  font-weight: 500;
+  font-size: 14px;
+  font-weight: 600;
 }
 
-.home-recent-grid {
+.home-recent-main {
   display: grid;
-  gap: 10px;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.home-recent-card {
-  border: 1px solid color-mix(in oklab, var(--foreground) 7%, transparent);
-  border-radius: 12px;
-  background: var(--card);
-  color: var(--foreground);
-  overflow: hidden;
-  min-width: 0;
-  transition:
-    border-color 150ms ease,
-    box-shadow 150ms ease;
-}
-
-.home-recent-card:hover {
-  border-color: color-mix(in oklab, var(--foreground) 13%, transparent);
-  box-shadow: 0 4px 14px color-mix(in oklab, var(--foreground) 8%, transparent);
-}
-
-.home-recent-preview {
-  height: 80px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-  position: relative;
-}
-
-.home-recent-preview-video {
-  background: oklch(13% 0.008 72);
-  color: oklch(92% 0.008 78);
-}
-
-.home-video-strips {
-  position: absolute;
-  inset: 0;
-  background: repeating-linear-gradient(
-    90deg,
-    transparent 0,
-    transparent 10%,
-    oklch(100% 0 0 / 0.04) 10%,
-    oklch(100% 0 0 / 0.04) 18%
-  );
-}
-
-.home-video-play {
-  position: relative;
-  z-index: 1;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  background: oklch(100% 0 0 / 0.14);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.home-recent-preview-document {
-  align-items: flex-start;
-  justify-content: flex-start;
-  padding: 10px 12px;
-}
-
-.home-doc-preview-lines {
-  width: 100%;
-  display: grid;
-  gap: 3px;
-  padding: 7px;
-  border-radius: 4px;
-  background: var(--card);
-  box-shadow: 0 1px 4px color-mix(in oklab, var(--foreground) 10%, transparent);
-}
-
-.home-doc-preview-lines span {
-  display: block;
-  height: 3px;
-  border-radius: 2px;
-  background: color-mix(in oklab, var(--foreground) 10%, transparent);
-}
-
-.home-doc-preview-lines span:first-child {
-  background: color-mix(in oklab, var(--foreground) 16%, transparent);
-}
-
-.home-preview-type {
-  position: absolute;
-  right: 8px;
-  bottom: 6px;
-  font-size: 9px;
-  font-weight: 800;
-  letter-spacing: 0.06em;
-}
-
-.home-audio-bars {
-  display: flex;
-  align-items: center;
   gap: 2px;
-}
-
-.home-audio-bars span {
-  width: 3px;
-  border-radius: 2px;
-  opacity: 0.72;
-}
-
-.home-recent-body {
-  display: grid;
-  gap: 3px;
-  padding: 10px 12px 12px;
-  border-top: 1px solid color-mix(in oklab, var(--foreground) 5%, transparent);
+  min-width: 0;
+  flex: 1;
 }
 
 .home-recent-name {
   display: block;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 600;
 }
 
 .home-recent-meta {
   color: var(--muted-foreground);
-  font-size: 11px;
+  font-size: 12px;
 }
 
 .home-folder-row,
 .home-shared-row {
-  gap: 10px;
-  padding: 9px 6px;
+  gap: var(--home-row-gap);
+  min-height: 46px;
+  padding: var(--home-row-inset);
 }
 
 .home-folder-name {
   flex: 1;
-  font-size: 13.5px;
-  font-weight: 500;
+  font-size: 14px;
+  font-weight: 600;
 }
 
 .home-folder-meta {
   flex-shrink: 0;
   color: var(--muted-foreground);
-  font-size: 11px;
+  font-size: 12px;
   text-align: right;
   white-space: nowrap;
 }
@@ -3879,38 +3948,41 @@ h3 {
 
 .home-shared-name {
   display: block;
-  font-size: 13px;
-  font-weight: 500;
+  font-size: 14px;
+  font-weight: 600;
 }
 
 .home-shared-meta {
   color: var(--muted-foreground);
-  font-size: 11px;
+  font-size: 12px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 @media (max-width: 980px) {
-  .home-top-grid,
-  .home-bottom-grid {
+  .home-hero {
     grid-template-columns: 1fr;
+    align-items: start;
   }
-}
 
-@media (max-width: 720px) {
-  .home-recent-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .home-actions {
+    justify-content: flex-start;
+  }
+
+  .home-sections-grid {
+    grid-template-columns: 1fr;
   }
 }
 
 @media (max-width: 520px) {
   .home-greeting h1 {
-    font-size: 1.6rem;
+    font-size: 1.78rem;
   }
 
-  .home-recent-grid {
-    grid-template-columns: 1fr;
+  .home-action {
+    flex: 1 1 150px;
+    min-height: 42px;
   }
 }
 
@@ -7048,11 +7120,64 @@ html.light {
   color: color-mix(in oklab, var(--primary) 72%, var(--foreground) 28%);
 }
 
-/* ---- New folder popover ---- */
+/* ---- Create folder dialog ---- */
 
-.new-folder-form {
+.create-folder-dialog {
+  max-width: min(420px, calc(100vw - 32px));
+}
+
+.create-folder-dialog-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding-right: 34px;
+}
+
+.create-folder-dialog-head p {
+  margin-top: 6px;
+  color: var(--muted-foreground);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.create-folder-dialog-icon {
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in oklab, var(--primary) 10%, transparent);
+  color: color-mix(in oklab, var(--primary) 78%, var(--foreground));
+}
+
+.create-folder-form {
   display: grid;
-  gap: 10px;
+  gap: 16px;
+}
+
+.create-folder-field {
+  display: grid;
+  gap: 7px;
+}
+
+.create-folder-field label {
+  color: color-mix(in oklab, var(--foreground) 78%, transparent);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.create-folder-error {
+  color: var(--destructive);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.create-folder-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
 }
 
 /* ---- Move picker popover ---- */
@@ -10412,8 +10537,6 @@ main.share-locked-page {
     font-size: 1.28rem;
   }
 
-  .home-top-grid,
-  .home-bottom-grid,
   .grid {
     grid-template-columns: 1fr;
   }

--- a/apps/web/app/item-type-icon.tsx
+++ b/apps/web/app/item-type-icon.tsx
@@ -8,6 +8,7 @@ import {
   Video,
   type LucideIcon,
 } from "lucide-react";
+import type { CSSProperties } from "react";
 
 import type { ItemVisual, ItemVisualKind } from "@/app/item-visuals";
 
@@ -26,23 +27,31 @@ export function ItemTypeIcon({
   className = "item-type-icon",
   icon,
   size = 14,
+  tone = "filled",
   visual,
 }: {
   className?: string;
   icon?: LucideIcon;
   size?: number;
+  tone?: "filled" | "plain";
   visual: ItemVisual;
 }) {
   const Icon = icon ?? itemVisualIconMap[visual.kind];
+  const filled = tone === "filled";
+  const style = {
+    "--item-type-icon-color": visual.color,
+    color: visual.color,
+    ...(filled ? { background: visual.background } : {}),
+  } as CSSProperties & { "--item-type-icon-color": string };
 
   return (
     <span
       aria-label={visual.label}
       className={className}
-      style={{ background: visual.background }}
+      style={style}
       title={visual.label}
     >
-      <Icon size={size} strokeWidth={1.8} color={visual.color} aria-hidden />
+      <Icon size={size} strokeWidth={1.8} color="currentColor" aria-hidden />
     </span>
   );
 }

--- a/apps/web/server/home-dashboard-helpers.test.ts
+++ b/apps/web/server/home-dashboard-helpers.test.ts
@@ -7,6 +7,7 @@ import {
   formatHomeRelativeTime,
   getHomeGreeting,
   getHomeItemVisual,
+  isHomeDashboardEmpty,
 } from "@/app/(workspace)/home/home-helpers";
 
 describe("home dashboard helpers", () => {
@@ -76,5 +77,25 @@ describe("home dashboard helpers", () => {
     expect(getHomeItemVisual("file", "application/octet-stream").kind).toBe(
       "file",
     );
+  });
+
+  it("detects the first-run empty dashboard", () => {
+    expect(
+      isHomeDashboardEmpty({
+        favoriteCount: 0,
+        folderCount: 0,
+        recentCount: 0,
+        shareCount: 0,
+      }),
+    ).toBe(true);
+
+    expect(
+      isHomeDashboardEmpty({
+        favoriteCount: 0,
+        folderCount: 1,
+        recentCount: 0,
+        shareCount: 0,
+      }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## 🚀 Summary

Refreshes the home dashboard into a more useful workspace overview with clearer primary actions, richer empty states, and consistent item icon presentation across related workspace lists.

## 📊 Impacts and Changes

- Updates `/home` with Pinned, Recent, Folders, and Shared links sections plus dashboard-specific actions.
- Adds a reusable create-folder dialog flow for workspace actions.
- Standardizes item row icons across home, files, favorites, recent, and retrieval list surfaces.
- Adds coverage for home dashboard helper behavior.
- Schema/auth/storage/restore behavior changes: None.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

Manual UI verification: loaded `http://localhost:3000/home` in Chrome using the running local dev server; verified the greeting, primary actions, and Pinned/Recent/Folders/Shared links dashboard sections rendered.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

None.

## 🔗 Linked Issues

None.
