### PR TITLE
Tune workspace comfort scale

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -65,19 +65,19 @@ typography:
     letterSpacing: "0"
   body:
     fontFamily: "var(--font-switzer), Segoe UI, sans-serif"
-    fontSize: "0.875rem"
+    fontSize: "1.0625rem"
     fontWeight: 400
     lineHeight: 1.5
     letterSpacing: "0"
   label:
     fontFamily: "var(--font-switzer), Segoe UI, sans-serif"
-    fontSize: "0.75rem"
+    fontSize: "0.8125rem"
     fontWeight: 600
     lineHeight: 1.25
     letterSpacing: "0.04em"
   mono:
     fontFamily: "var(--font-jetbrains-mono), monospace"
-    fontSize: "0.75rem"
+    fontSize: "0.8125rem"
     fontWeight: 400
     lineHeight: 1.4
     letterSpacing: "0"
@@ -95,35 +95,36 @@ spacing:
   md: "12px"
   lg: "16px"
   xl: "24px"
-  page-x: "32px"
-  page-y: "24px"
+  page-x: "40px"
+  page-y: "34px"
 components:
   button-primary:
     backgroundColor: "{colors.primary}"
     textColor: "{colors.primary-foreground}"
     rounded: "{rounded.xl}"
     padding: "0 18px"
-    height: "44px"
+    height: "48px"
     typography: "{typography.body}"
   button-secondary:
     backgroundColor: "{colors.secondary}"
     textColor: "{colors.foreground}"
     rounded: "{rounded.xl}"
     padding: "0 18px"
-    height: "44px"
+    height: "48px"
     typography: "{typography.body}"
   input-default:
     backgroundColor: "{colors.card}"
     textColor: "{colors.foreground}"
     rounded: "{rounded.xl}"
     padding: "12px 14px"
-    height: "44px"
+    height: "48px"
     typography: "{typography.body}"
   nav-link-active:
     backgroundColor: "{colors.accent}"
     textColor: "{colors.primary}"
     rounded: "{rounded.md}"
-    padding: "7px 10px"
+    padding: "0 14px"
+    height: "48px"
     typography: "{typography.body}"
   panel:
     backgroundColor: "{colors.card}"
@@ -215,13 +216,16 @@ The palette is a warm neutral system with a low-noise bronze primary. OKLCH is c
 - **Display** (400, `clamp(2.6rem, 5.5vw, 5rem)`, 1.06): Entry and onboarding moments only. Not for workspace panels or admin pages.
 - **Headline** (500, `1.45rem`, 1.15): Workspace page titles, breadcrumbs, and primary content headings.
 - **Title** (650, `1.05rem`, 1.2): Bottom sheets, dialogs, compact panel titles, and admin operation names.
-- **Body** (400 to 600, `0.8125rem` to `0.9375rem`, 1.4 to 1.6): File rows, settings, admin content, helper copy, and table-like surfaces.
-- **Label** (600 to 700, `0.625rem` to `0.75rem`, letter-spaced only when short): Section labels, sidebar groups, status metadata, and compact admin labels.
-- **Mono** (400 to 600, `0.6875rem` to `0.75rem`, 1.4): IDs, URLs, checksums, code, archive IDs, and technical values.
+- **Body** (400 to 600, `1.0625rem`, 1.4 to 1.6): File rows, settings, admin content, and other primary task text.
+- **Metadata** (400 to 600, `0.9375rem`, 1.35 to 1.5): timestamps, sizes, helper copy, secondary row values, and compact admin detail.
+- **Label** (600 to 700, `0.8125rem`, letter-spaced only when short): Section labels, sidebar groups, status metadata, and compact admin labels.
+- **Mono** (400 to 600, `0.8125rem` to `0.9375rem`, 1.4): IDs, URLs, checksums, code, archive IDs, and technical values.
 
 ### Named Rules
 
 **The Product Type Rule.** Workspace and admin UI use fixed rem sizes. Fluid type belongs to entry/onboarding moments, not file lists, buttons, or settings.
+
+**The Comfort Baseline Rule.** Workspace and admin should feel like the previous interface at roughly `125%` browser zoom while the browser remains at `100%`. Scale type, chrome, rows, spacing, and icons together. Preserve the existing workspace anchoring; do not globally center Home, Files, Recent, Favorites, Shared, Search, or Trash pages. Center only smaller form/settings-style surfaces.
 
 **The Label Restraint Rule.** Uppercase labels are allowed only for short structural labels. Never use uppercase body copy.
 
@@ -275,11 +279,11 @@ Staaash is flat by default. Depth comes from tonal surfaces, 1px borders, separa
 
 ### Navigation
 
-The workspace shell uses a quiet left sidebar on desktop, a compact topbar search, and a bottom navigation plus bottom sheets on mobile. Active nav is bronze-tinted, inactive nav is muted, hover is tonal. Mobile actions use minimum `44px` touch targets and bottom-sheet grouping.
+The workspace shell uses a quiet `270px` left sidebar on desktop, a compact topbar search, and a bottom navigation plus bottom sheets on mobile. Active nav is bronze-tinted, inactive nav is muted, hover is tonal. Desktop nav links and mobile actions use minimum `48px` targets.
 
 ### File Rows
 
-Rows are the core workspace component. They should feel like file-system rows, not cards: icon, name, metadata, state badges, and actions aligned for scanning. Hover and selected state use tonal fills. Selection and action affordances must not cover file metadata.
+Rows are the core workspace component. They should feel like file-system rows, not cards: icon, name, metadata, state badges, and actions aligned for scanning. Desktop file rows target `50px`; Home dashboard rows target `60px`; mobile rows may be taller for touch. Hover and selected state use tonal fills. Selection and action affordances must not cover file metadata.
 
 ### Share Dialog
 

--- a/apps/web/app/(workspace)/workspace-nav.tsx
+++ b/apps/web/app/(workspace)/workspace-nav.tsx
@@ -106,8 +106,8 @@ export function WorkspaceNav() {
               >
                 <Icon
                   className="workspace-nav-icon"
-                  size={15}
-                  strokeWidth={1.8}
+                  size={20}
+                  strokeWidth={1.9}
                 />
                 <span>{item.label}</span>
               </Link>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -33,6 +33,19 @@
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
   --radius: 0.45rem;
+  --app-sidebar-width: 270px;
+  --app-admin-sidebar-width: 300px;
+  --app-row-height: 50px;
+  --app-home-row-height: 60px;
+  --app-row-height-compact: 46px;
+  --app-control-height: 48px;
+  --app-control-height-compact: 44px;
+  --app-font-body: 1.0625rem;
+  --app-font-control: 1rem;
+  --app-font-meta: 0.9375rem;
+  --app-font-label: 0.8125rem;
+  --app-settings-max-width: 920px;
+  --app-admin-settings-max-width: 980px;
   --sidebar: oklch(0.975 0.006 78);
   --sidebar-foreground: oklch(0.19 0.015 72);
   --sidebar-primary: oklch(0.48 0.09 78);
@@ -422,7 +435,7 @@ h3 {
   height: 100vh;
   overflow: hidden;
   display: grid;
-  grid-template-columns: 216px minmax(0, 1fr);
+  grid-template-columns: var(--app-sidebar-width) minmax(0, 1fr);
   grid-template-rows: 100vh;
   background: var(--background);
 }
@@ -431,7 +444,7 @@ h3 {
   height: 100vh;
   overflow: hidden;
   display: grid;
-  grid-template-columns: 240px minmax(0, 1fr);
+  grid-template-columns: var(--app-admin-sidebar-width) minmax(0, 1fr);
 }
 
 .admin-sidebar {
@@ -2345,7 +2358,9 @@ h3 {
 }
 
 .workspace-nav-icon {
-  flex-shrink: 0;
+  flex: 0 0 20px;
+  width: 20px;
+  height: 20px;
   opacity: 0.7;
 }
 
@@ -3735,7 +3750,7 @@ h3 {
 
 .home-section-head {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 12px;
   min-height: 18px;
@@ -10148,6 +10163,499 @@ main.share-locked-page {
 
 .st-card-list {
   display: none;
+}
+
+/* ---- Workspace/admin comfort scale ---- */
+@media (min-width: 721px) {
+  .admin-sidebar {
+    padding: 30px 18px 22px;
+  }
+
+  .admin-sidebar .workspace-brand {
+    font-size: 32px;
+  }
+
+  .admin-sidebar .workspace-nav-link {
+    min-height: var(--app-control-height);
+    padding: 0 14px;
+    font-size: var(--app-font-control);
+  }
+
+  .admin-sidebar .workspace-nav-icon {
+    width: 20px;
+    height: 20px;
+    stroke-width: 1.9;
+  }
+
+  .admin-topbar {
+    min-height: 62px;
+    padding: 14px 36px;
+  }
+
+  .admin-main-content,
+  .admin-main > main.admin-main-content {
+    padding: 50px 64px 84px;
+  }
+
+  .admin-kv-item {
+    min-width: 200px;
+    padding: 26px 28px;
+  }
+
+  .admin-kv-label,
+  .admin-eyebrow,
+  .admin-job-history-head,
+  .admin-jobs-kind-filter,
+  .admin-jobs-run-list h3,
+  .admin-jobs-modal-section h3,
+  .admin-users-table th,
+  .instance-badge-row dt {
+    font-size: var(--app-font-label);
+    color: color-mix(
+      in oklab,
+      var(--muted-foreground) 88%,
+      var(--foreground) 12%
+    );
+  }
+
+  .admin-kv-link,
+  .admin-kv-sub,
+  .admin-check-msg,
+  .admin-op-desc,
+  .admin-op-last,
+  .admin-worker-archive,
+  .admin-worker-row,
+  .admin-job-detail-error,
+  .admin-job-events-empty,
+  .admin-history-row,
+  .admin-jobs-summary,
+  .admin-jobs-schedule-link,
+  .admin-jobs-card-desc,
+  .admin-jobs-card-state,
+  .admin-jobs-card-error,
+  .admin-jobs-rail-action,
+  .admin-jobs-rail-note,
+  .admin-jobs-activity-head p,
+  .admin-jobs-kind-select-trigger,
+  .admin-jobs-kind-select-content,
+  .admin-jobs-kind-select-item,
+  .admin-jobs-activity-error,
+  .admin-jobs-activity-main small,
+  .admin-jobs-activity-status,
+  .admin-jobs-activity-attempt,
+  .admin-jobs-activity-detail,
+  .admin-jobs-activity-empty,
+  .admin-jobs-activity-more,
+  .admin-jobs-modal-head p,
+  .admin-jobs-state,
+  .admin-jobs-run-button small,
+  .admin-jobs-modal-error,
+  .admin-jobs-modal-empty,
+  .admin-jobs-event-row,
+  .admin-jobs-payload,
+  .admin-jobs-button,
+  .admin-user-row-note,
+  .admin-users-count,
+  .admin-user-menu-panel a,
+  .admin-user-menu-panel button,
+  .admin-user-dialog .field > span:first-child,
+  .admin-user-toggle-row,
+  .admin-user-result-list dt,
+  .admin-user-result-list dd,
+  .admin-inline-link,
+  .settings-panel-description,
+  .settings-row-help,
+  .settings-field-note,
+  .settings-form-status {
+    font-size: var(--app-font-meta);
+  }
+
+  .admin-check-name,
+  .admin-setting-key,
+  .admin-setting-val,
+  .admin-op-name,
+  .admin-job-detail-title,
+  .admin-jobs-activity-main strong,
+  .admin-jobs-run-button strong,
+  .settings-page-head p,
+  .settings-row-label,
+  .settings-row-value,
+  .settings-input,
+  .settings-action {
+    font-size: var(--app-font-body);
+  }
+
+  .admin-worker-row,
+  .admin-job-run-button,
+  .admin-jobs-activity-row,
+  .admin-jobs-kind-select-trigger[data-size="default"],
+  .admin-jobs-activity-more,
+  .admin-jobs-button,
+  .admin-user-toggle-row,
+  .settings-input,
+  .settings-action {
+    min-height: var(--app-control-height);
+  }
+
+  .admin-jobs-kind-select-item,
+  .settings-segment {
+    min-height: var(--app-control-height-compact);
+  }
+
+  .admin-jobs-page {
+    width: min(1240px, 100%);
+  }
+
+  .admin-settings-page {
+    --settings-max-width: var(--app-admin-settings-max-width);
+  }
+
+  .settings-page {
+    --settings-max-width: var(--app-settings-max-width);
+  }
+
+  .settings-panel-summary {
+    min-height: 76px;
+    padding: 18px 20px;
+  }
+
+  .settings-panel-body {
+    gap: 18px;
+    padding: 0 20px 20px;
+  }
+
+  .settings-row {
+    min-height: 70px;
+    padding: 18px 0;
+  }
+
+  .settings-segment {
+    padding: 0 16px;
+    font-size: var(--app-font-meta);
+  }
+}
+
+@media (min-width: 1024px) {
+  .workspace-sidebar {
+    padding: 30px 18px 22px;
+  }
+
+  .workspace-brand-area {
+    padding: 0 8px 28px;
+  }
+
+  .workspace-brand {
+    font-size: 32px;
+  }
+
+  .workspace-nav {
+    gap: 4px;
+  }
+
+  .workspace-nav-group {
+    gap: 3px;
+    margin-bottom: 18px;
+  }
+
+  .workspace-nav-link {
+    min-height: var(--app-control-height);
+    gap: 12px;
+    padding: 0 14px;
+    font-size: var(--app-font-control);
+  }
+
+  .workspace-nav-icon {
+    width: 20px;
+    height: 20px;
+    stroke-width: 1.9;
+  }
+
+  .workspace-nav-label,
+  .workspace-storage-label,
+  .instance-badge-row dt,
+  .explorer-col-header,
+  .recent-col-head-cell,
+  .recent-group-header span,
+  .recent-grid-group-header span,
+  .favorites-col-head-cell {
+    font-size: var(--app-font-label);
+    color: color-mix(
+      in oklab,
+      var(--muted-foreground) 88%,
+      var(--foreground) 12%
+    );
+  }
+
+  .workspace-nav-label {
+    padding: 6px 12px 8px;
+  }
+
+  .workspace-storage-text,
+  .workspace-user-meta,
+  .workspace-user-action-link,
+  .instance-badge-version,
+  .instance-badge-row dd,
+  .instance-badge-releases-link,
+  .workspace-search input,
+  .topbar-icon-btn,
+  .topbar-notif-title,
+  .topbar-notif-link,
+  .topbar-notif-empty,
+  .topbar-profile-card-email,
+  .topbar-profile-action,
+  .view-toggle button,
+  .home-section-link,
+  .home-empty-copy,
+  .home-recent-meta,
+  .home-folder-meta,
+  .home-shared-meta,
+  .recent-row-location,
+  .recent-row-size,
+  .recent-row-time,
+  .favorites-row-location,
+  .favorites-row-size,
+  .favorites-row-time,
+  .explorer-row-meta {
+    font-size: var(--app-font-meta);
+  }
+
+  .workspace-user-name,
+  .topbar-profile-card-name,
+  .home-action,
+  .home-section-title,
+  .home-pinned-name,
+  .home-recent-name,
+  .home-folder-name,
+  .home-shared-name,
+  .recent-row-name,
+  .favorites-row-name,
+  .favorites-grid-name,
+  .explorer-row-name,
+  .explorer-row-rename {
+    font-size: var(--app-font-body);
+  }
+
+  .workspace-avatar {
+    width: 44px;
+    height: 44px;
+  }
+
+  .workspace-avatar-initials {
+    font-size: var(--app-font-meta);
+  }
+
+  .workspace-user-action-link,
+  .instance-badge-trigger {
+    min-height: 40px;
+  }
+
+  .workspace-topbar {
+    min-height: 66px;
+    padding: 14px 40px;
+  }
+
+  .workspace-search {
+    min-height: var(--app-control-height);
+    gap: 10px;
+    padding: 10px 14px;
+    border-radius: 10px;
+  }
+
+  .workspace-search-icon {
+    width: 18px;
+    height: 18px;
+  }
+
+  .workspace-topbar-tools {
+    gap: 8px;
+  }
+
+  .topbar-icon-btn {
+    height: 42px;
+    padding: 0 14px;
+  }
+
+  .view-toggle button {
+    min-height: 42px;
+    padding: 0 16px;
+  }
+
+  .workspace-content,
+  .workspace-main > main.workspace-content {
+    padding: 34px 40px 72px;
+  }
+
+  .home-page {
+    --home-row-gap: 12px;
+    --home-row-height: var(--app-home-row-height);
+    --home-row-icon-size: 30px;
+    --home-row-inset-x: 9px;
+    --home-row-inset-y: 8px;
+    gap: 30px;
+  }
+
+  .home-page-empty {
+    gap: 38px;
+  }
+
+  .home-hero {
+    gap: 24px;
+    padding-bottom: 8px;
+  }
+
+  .home-greeting h1 {
+    font-size: clamp(2.35rem, 3.45vw, 3.75rem);
+  }
+
+  .home-actions {
+    gap: 10px;
+  }
+
+  .home-action {
+    min-height: var(--app-control-height);
+    gap: 10px;
+    padding: 0 18px;
+  }
+
+  .home-sections-grid {
+    gap: 34px;
+  }
+
+  .home-section-head {
+    align-items: center;
+    min-height: 24px;
+    margin-bottom: 10px;
+    padding-bottom: 10px;
+  }
+
+  .home-section-title,
+  .home-section-link {
+    min-height: 24px;
+    line-height: 24px;
+  }
+
+  .home-empty-copy {
+    line-height: 1.35;
+  }
+
+  .item-type-icon {
+    width: 30px;
+    height: 30px;
+  }
+
+  .home-item-icon svg,
+  .home-empty-icon svg {
+    width: 20px;
+    height: 20px;
+  }
+
+  .explorer-row,
+  .explorer-col-header {
+    grid-template-columns: 36px minmax(0, 1fr) 104px 170px;
+    gap: 0 14px;
+  }
+
+  .explorer-row {
+    height: var(--app-row-height);
+    padding: 0 12px 0 8px;
+  }
+
+  .explorer-col-header {
+    min-height: 48px;
+    padding: 6px 12px 12px 8px;
+  }
+
+  .explorer-row-icon .item-type-icon {
+    width: 30px;
+    height: 30px;
+  }
+
+  .explorer-row-icon svg {
+    width: 20px;
+    height: 20px;
+  }
+
+  .explorer-row-rename {
+    height: 40px;
+    padding: 5px 10px;
+  }
+
+  .recent-col-head,
+  .recent-row {
+    grid-template-columns:
+      36px minmax(225px, 1fr) minmax(175px, 225px) minmax(90px, 104px)
+      minmax(108px, 138px);
+    gap: 0 14px;
+  }
+
+  .favorites-col-head,
+  .favorites-row {
+    grid-template-columns:
+      36px minmax(225px, 1fr) minmax(175px, 235px) minmax(90px, 104px)
+      minmax(108px, 138px);
+    gap: 0 14px;
+  }
+
+  .trash-col-head,
+  .trash-row {
+    grid-template-columns:
+      36px minmax(225px, 1fr) minmax(175px, 225px) minmax(90px, 104px)
+      minmax(108px, 138px) minmax(84px, 104px);
+    gap: 0 14px;
+  }
+
+  .recent-col-head,
+  .favorites-col-head,
+  .trash-col-head {
+    min-height: 48px;
+    padding: 6px 12px 12px 8px;
+  }
+
+  .recent-row,
+  .favorites-row,
+  .trash-row {
+    min-height: var(--app-row-height);
+    padding: 0 12px 0 8px;
+  }
+
+  .recent-group-header,
+  .recent-grid-group-header {
+    gap: 10px;
+    padding: 26px 6px 12px;
+  }
+
+  .recent-group-section:first-of-type .recent-group-header,
+  .recent-grid-group:first-of-type .recent-grid-group-header {
+    padding-top: 10px;
+  }
+
+  .recent-group-header span,
+  .recent-grid-group-header span,
+  .recent-group-header small,
+  .recent-grid-group-header small {
+    font-size: var(--app-font-label);
+    color: color-mix(
+      in oklab,
+      var(--muted-foreground) 82%,
+      var(--foreground) 18%
+    );
+  }
+
+  .recent-action-btn,
+  .favorites-action-btn,
+  .explorer-row-mobile-action {
+    width: 42px;
+    height: 42px;
+  }
+
+  .workspace-selection-bar span,
+  .workspace-selection-bar button {
+    font-size: var(--app-font-meta);
+  }
+
+  .workspace-selection-bar button {
+    min-height: var(--app-control-height-compact);
+  }
 }
 
 @media (max-width: 1023px) {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3818,6 +3818,10 @@ h3 {
   display: contents;
 }
 
+[data-slot="context-menu-trigger"] {
+  user-select: none;
+}
+
 .home-pinned-row,
 .home-recent-row,
 .home-folder-row,

--- a/apps/web/components/time-zone-picker.tsx
+++ b/apps/web/components/time-zone-picker.tsx
@@ -110,7 +110,7 @@ const TIME_ZONE_PICKER_CSS = `
 .time-zone-picker__offset {
   color: var(--muted-foreground);
   flex: 0 0 auto;
-  font-size: 0.78rem;
+  font-size: var(--app-font-meta, 0.9375rem);
   font-variant-numeric: tabular-nums;
 }
 
@@ -158,8 +158,8 @@ const TIME_ZONE_PICKER_CSS = `
   border-radius: 6px;
   color: var(--foreground);
   font: inherit;
-  font-size: 0.86rem;
-  min-height: 36px;
+  font-size: var(--app-font-body, 1.0625rem);
+  min-height: var(--app-control-height-compact, 44px);
   padding: 8px 10px 8px 32px;
   width: 100%;
 }
@@ -187,10 +187,10 @@ const TIME_ZONE_PICKER_CSS = `
   cursor: pointer;
   display: grid;
   font: inherit;
-  font-size: 0.86rem;
+  font-size: var(--app-font-body, 1.0625rem);
   gap: 8px;
   grid-template-columns: minmax(0, 1fr) auto auto;
-  min-height: 34px;
+  min-height: var(--app-control-height-compact, 44px);
   padding: 0 8px;
   text-align: left;
 }
@@ -210,7 +210,7 @@ const TIME_ZONE_PICKER_CSS = `
 
 .time-zone-picker__empty {
   color: var(--muted-foreground);
-  font-size: 0.82rem;
+  font-size: var(--app-font-meta, 0.9375rem);
   margin: 0;
   padding: 12px 8px;
 }

--- a/apps/web/components/ui/context-menu.tsx
+++ b/apps/web/components/ui/context-menu.tsx
@@ -2,7 +2,6 @@
 
 import * as React from "react";
 import { ContextMenu as ContextMenuPrimitive } from "@base-ui/react/context-menu";
-import { mergeProps } from "@base-ui/react/merge-props";
 
 import { cn } from "@/lib/utils";
 import { ChevronRightIcon } from "lucide-react";
@@ -16,39 +15,13 @@ function ContextMenuTrigger({
   render,
   ...props
 }: ContextMenuPrimitive.Trigger.Props) {
-  const triggerClassName = cn("select-none", className);
+  const triggerClassName = render ? className : cn("select-none", className);
 
   return (
     <ContextMenuPrimitive.Trigger
       data-slot="context-menu-trigger"
       className={triggerClassName}
-      render={
-        render
-          ? (triggerProps, state) => {
-              const element =
-                typeof render === "function"
-                  ? render(triggerProps, state)
-                  : render;
-              const elementProps = React.isValidElement<{
-                className?: string;
-              }>(element)
-                ? element.props
-                : null;
-
-              return elementProps
-                ? React.cloneElement(
-                    element,
-                    mergeProps(elementProps, triggerProps, {
-                      className: cn(
-                        elementProps.className,
-                        triggerProps.className,
-                      ),
-                    }),
-                  )
-                : element;
-            }
-          : undefined
-      }
+      render={render}
       {...props}
     />
   );


### PR DESCRIPTION
## 🚀 Summary

- Increases the workspace UI comfort scale so navigation, controls, rows, and common text read larger on 1080p and 2K displays.
- Adjusts Home, Files, Trash, sidebar, and shared workspace spacing/alignment to preserve the existing layout while scaling up.
- Fixes the context menu trigger class merge that caused a Home hydration mismatch without breaking row layout classes.

## 📊 Impacts and Changes

Users get a larger default workspace interface without browser zoom. The Home context-menu trigger should no longer produce the className hydration mismatch. No schema, auth, storage, or restore behavior changes.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

None.

## 🔗 Linked Issues

None.