### PR TITLE
chore(release): bump to 1.0.0-rc.1

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.3.0-beta.1",
+  "version": "1.0.0-rc.1",
   "private": true,
   "scripts": {
     "build:deps": "pnpm --filter @staaash/config build && pnpm --filter @staaash/db build",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worker",
-  "version": "0.3.0-beta.1",
+  "version": "1.0.0-rc.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "staaash",
-  "version": "0.3.0-beta.1",
+  "version": "1.0.0-rc.1",
   "description": "Self-hosted personal cloud drive monorepo.",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@staaash/config",
-  "version": "0.3.0-beta.1",
+  "version": "1.0.0-rc.1",
   "private": true,
   "type": "module",
   "files": [

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@staaash/db",
-  "version": "0.3.0-beta.1",
+  "version": "1.0.0-rc.1",
   "private": true,
   "type": "module",
   "files": [


### PR DESCRIPTION
## 🚀 Summary

Bumps the Staaash workspace packages to `1.0.0-rc.1` for the first v1 release candidate.

## 📊 Impacts and Changes

- Updates the root, web, worker, config, and database package versions to `1.0.0-rc.1`.
- Leaves Docker Compose and example environment defaults on `STAAASH_VERSION=latest`; the RC will be opt-in and must not move the `latest` image tag.
- No schema, auth, storage, restore, API, or runtime behavior changes.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment. N/A: version metadata only.

Additional verification: `pnpm format:check` and `pnpm quality:fallow` passed.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply. None.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

- Parallel chunk uploads (#65) are not included.
- The inherited Fallow clone groups remain outside the RC release scope.

## 🔗 Linked Issues

None.