### PR TITLE
Improve file moves, uploads, and production icons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN npm install -g "prisma@$(node -e "process.stdout.write(JSON.parse(require('f
 # Next.js standalone server
 COPY --from=build /app/apps/web/.next/standalone ./
 COPY --from=build /app/apps/web/.next/static ./apps/web/.next/static
+COPY --from=build /app/apps/web/public ./apps/web/public
 
 # Prisma schema + migrations + config
 COPY --from=build /app/packages/db/prisma ./prisma

--- a/apps/web/app/(workspace)/files/files-move.ts
+++ b/apps/web/app/(workspace)/files/files-move.ts
@@ -1,0 +1,29 @@
+import type { BatchMoveItem, BatchMoveResponse } from "@/server/files/types";
+
+export const getMoveItemsForInteraction = ({
+  allItems,
+  selectedIds,
+  target,
+}: {
+  allItems: BatchMoveItem[];
+  selectedIds: ReadonlySet<string>;
+  target: BatchMoveItem;
+}): BatchMoveItem[] =>
+  selectedIds.has(target.id) && selectedIds.size > 1
+    ? allItems.filter((item) => selectedIds.has(item.id))
+    : [target];
+
+export const buildBatchMoveFailureMessage = ({
+  response,
+  getItemName,
+}: {
+  response: BatchMoveResponse;
+  getItemName: (item: BatchMoveItem) => string;
+}) => {
+  const detail = response.results
+    .filter((result) => result.status === "failed")
+    .map((failure) => `${getItemName(failure)}: ${failure.error}`)
+    .join("; ");
+
+  return `${response.movedCount} moved. ${response.failedCount} failed — ${detail}`;
+};

--- a/apps/web/app/(workspace)/files/files-row.tsx
+++ b/apps/web/app/(workspace)/files/files-row.tsx
@@ -66,6 +66,7 @@ type BaseFolderRowProps = {
   onRenameSubmit: () => void;
   onRenameCancel: () => void;
   onClick: (e: React.MouseEvent) => void;
+  onContextMenu: () => void;
   onLongPress: () => void;
   onOpen: () => void;
   onStartRename: () => void;
@@ -101,6 +102,7 @@ type BaseFileRowProps = {
   onRenameSubmit: () => void;
   onRenameCancel: () => void;
   onClick: (e: React.MouseEvent) => void;
+  onContextMenu: () => void;
   onLongPress: () => void;
   onOpen: () => void;
   onStartRename: () => void;
@@ -136,6 +138,7 @@ export function FilesRow(props: FilesRowProps) {
     onRenameSubmit,
     onRenameCancel,
     onClick,
+    onContextMenu,
     onLongPress,
     onOpen,
     onStartRename,
@@ -355,6 +358,7 @@ export function FilesRow(props: FilesRowProps) {
           className={rowClasses}
           draggable={!touchMode && !isRenaming}
           onClick={handleRowClick}
+          onContextMenu={onContextMenu}
           onDoubleClick={touchMode ? undefined : onOpen}
           onDragStart={onDragStart}
           onDragEnd={onDragEnd}
@@ -443,6 +447,7 @@ export function FilesRow(props: FilesRowProps) {
             type="button"
             onClick={(event) => {
               event.stopPropagation();
+              onContextMenu();
               setActionSheetOpen(true);
             }}
           >

--- a/apps/web/app/(workspace)/files/files-row.tsx
+++ b/apps/web/app/(workspace)/files/files-row.tsx
@@ -75,6 +75,12 @@ type BaseFolderRowProps = {
   onCut: () => void;
   onMoveTo: (destinationId: string) => void;
   onDownload: () => void;
+  onDragStart: (event: React.DragEvent<HTMLDivElement>) => void;
+  onDragEnd: () => void;
+  isDropTarget: boolean;
+  onMoveDragOver: (event: React.DragEvent<HTMLDivElement>) => void;
+  onMoveDragLeave: (event: React.DragEvent<HTMLDivElement>) => void;
+  onMoveDrop: (event: React.DragEvent<HTMLDivElement>) => void;
   rowRef: (el: HTMLDivElement | null) => void;
   touchMode: boolean;
 };
@@ -104,6 +110,8 @@ type BaseFileRowProps = {
   onCut: () => void;
   onMoveTo: (destinationId: string) => void;
   onDownload: () => void;
+  onDragStart: (event: React.DragEvent<HTMLDivElement>) => void;
+  onDragEnd: () => void;
   rowRef: (el: HTMLDivElement | null) => void;
   touchMode: boolean;
 };
@@ -136,6 +144,8 @@ export function FilesRow(props: FilesRowProps) {
     onProperties,
     onCut,
     onMoveTo,
+    onDragStart,
+    onDragEnd,
     rowRef,
   } = props;
 
@@ -159,6 +169,7 @@ export function FilesRow(props: FilesRowProps) {
     isSelected ? "is-selected" : "",
     isCut ? "is-cut" : "",
     isJustMoved ? "just-moved" : "",
+    props.kind === "folder" && props.isDropTarget ? "is-drop-target" : "",
   ]
     .filter(Boolean)
     .join(" ");
@@ -342,8 +353,18 @@ export function FilesRow(props: FilesRowProps) {
           ref={rowRef}
           data-file-row={props.data.id}
           className={rowClasses}
+          draggable={!touchMode && !isRenaming}
           onClick={handleRowClick}
           onDoubleClick={touchMode ? undefined : onOpen}
+          onDragStart={onDragStart}
+          onDragEnd={onDragEnd}
+          onDragOver={
+            props.kind === "folder" ? props.onMoveDragOver : undefined
+          }
+          onDragLeave={
+            props.kind === "folder" ? props.onMoveDragLeave : undefined
+          }
+          onDrop={props.kind === "folder" ? props.onMoveDrop : undefined}
           onPointerCancel={clearLongPressTimer}
           onPointerDown={handlePointerDown}
           onPointerLeave={clearLongPressTimer}

--- a/apps/web/app/(workspace)/files/files-view.tsx
+++ b/apps/web/app/(workspace)/files/files-view.tsx
@@ -166,6 +166,7 @@ export function FilesView({
   const dragCounterRef = useRef(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const draggedItemsRef = useRef<BatchMoveItem[]>([]);
+  const contextMoveItemsRef = useRef<BatchMoveItem[]>([]);
   const dragPreviewRef = useRef<HTMLDivElement | null>(null);
   const [dropTargetId, setDropTargetId] = useState<string | null>(null);
 
@@ -264,6 +265,20 @@ export function FilesView({
       selectedIds: selectedIdsRef.current,
       target: { id, kind },
     });
+
+  const handleItemContextMenu = (id: string, kind: BatchMoveItem["kind"]) => {
+    const current = selectedIdsRef.current;
+    contextMoveItemsRef.current = getMoveItemsForInteraction({
+      allItems,
+      selectedIds: current,
+      target: { id, kind },
+    });
+    if (current.has(id)) return;
+    const next = new Set([id]);
+    selectedIdsRef.current = next;
+    setSelectedIds(next);
+    setLastSelectedId(id);
+  };
 
   // ---- Load persisted state ----
   useEffect(() => {
@@ -752,9 +767,30 @@ export function FilesView({
     draggedItemsRef.current.length > 0 ||
     event.dataTransfer.types.includes(INTERNAL_ITEM_DRAG_TYPE);
 
+  const positionDragPreview = (clientX: number, clientY: number) => {
+    const preview = dragPreviewRef.current;
+    if (!preview || (clientX === 0 && clientY === 0)) return;
+    const left = Math.min(
+      clientX + 18,
+      window.innerWidth - preview.offsetWidth - 12,
+    );
+    const top = Math.min(
+      clientY + 18,
+      window.innerHeight - preview.offsetHeight - 12,
+    );
+    preview.style.left = `${Math.max(12, left)}px`;
+    preview.style.top = `${Math.max(12, top)}px`;
+  };
+
+  const clearDragPreview = () => {
+    dragPreviewRef.current?.remove();
+    dragPreviewRef.current = null;
+  };
+
   const handleDragEnter = (e: React.DragEvent) => {
     if (isInternalItemDrag(e)) {
       e.preventDefault();
+      positionDragPreview(e.clientX, e.clientY);
       return;
     }
     e.preventDefault();
@@ -774,6 +810,7 @@ export function FilesView({
   const handleDragOver = (e: React.DragEvent) => {
     if (isInternalItemDrag(e)) {
       e.preventDefault();
+      positionDragPreview(e.clientX, e.clientY);
       e.dataTransfer.dropEffect = "none";
       return;
     }
@@ -784,6 +821,7 @@ export function FilesView({
     if (isInternalItemDrag(e)) {
       e.preventDefault();
       draggedItemsRef.current = [];
+      clearDragPreview();
       setDropTargetId(null);
       return;
     }
@@ -810,47 +848,63 @@ export function FilesView({
     event.dataTransfer.setData(INTERNAL_ITEM_DRAG_TYPE, JSON.stringify(items));
     event.dataTransfer.setData("text/plain", `${items.length} Staaash item(s)`);
 
-    dragPreviewRef.current?.remove();
-    dragPreviewRef.current = null;
+    clearDragPreview();
+    const preview = document.createElement("div");
+    preview.className = "explorer-drag-preview";
+    preview.dataset.stackDepth = String(Math.min(items.length, 3));
+    preview.setAttribute("aria-hidden", "true");
+
+    const stackDepth = Math.min(items.length, 3);
+    for (let layerIndex = stackDepth - 1; layerIndex >= 1; layerIndex--) {
+      const layer = document.createElement("div");
+      layer.className = "explorer-drag-preview-layer";
+      layer.dataset.layer = String(layerIndex);
+      preview.append(layer);
+    }
+
+    const row = document.createElement("div");
+    row.className = "explorer-drag-preview-row";
+    const icon = event.currentTarget
+      .querySelector(".explorer-row-icon")
+      ?.cloneNode(true);
+    const name = event.currentTarget
+      .querySelector(".explorer-row-name-cell")
+      ?.cloneNode(true);
+    if (icon) row.append(icon);
+    if (name) row.append(name);
+
+    preview.append(row);
     if (items.length > 1) {
-      const preview = document.createElement("div");
-      preview.className = "explorer-drag-preview";
-      preview.setAttribute("aria-hidden", "true");
-
-      const row = document.createElement("div");
-      row.className = "explorer-drag-preview-row";
-      const icon = event.currentTarget
-        .querySelector(".explorer-row-icon")
-        ?.cloneNode(true);
-      const name = event.currentTarget
-        .querySelector(".explorer-row-name-cell")
-        ?.cloneNode(true);
-      if (icon) row.append(icon);
-      if (name) row.append(name);
-
+      preview.classList.add("has-count");
       const count = document.createElement("span");
       count.className = "explorer-drag-preview-count";
-      count.textContent = String(items.length);
-
-      preview.append(row, count);
-      preview.style.left = `${event.clientX}px`;
-      preview.style.top = `${event.clientY}px`;
-      preview.style.transform = "none";
-      document.body.append(preview);
-      dragPreviewRef.current = preview;
-      event.dataTransfer.setDragImage(preview, 22, 22);
-      requestAnimationFrame(() => {
-        if (dragPreviewRef.current !== preview) return;
-        preview.remove();
-        dragPreviewRef.current = null;
-      });
+      count.textContent = `${items.length} items`;
+      preview.append(count);
     }
+
+    preview.style.transform = "none";
+    document.body.append(preview);
+    dragPreviewRef.current = preview;
+
+    positionDragPreview(event.clientX, event.clientY);
+
+    const transparentDragImage = document.createElement("canvas");
+    transparentDragImage.width = 1;
+    transparentDragImage.height = 1;
+    transparentDragImage.style.position = "fixed";
+    transparentDragImage.style.top = "0";
+    transparentDragImage.style.left = "0";
+    transparentDragImage.style.opacity = "0";
+    document.body.append(transparentDragImage);
+    event.dataTransfer.setDragImage(transparentDragImage, 0, 0);
+    requestAnimationFrame(() => {
+      transparentDragImage.remove();
+    });
   };
 
   const handleItemDragEnd = () => {
     draggedItemsRef.current = [];
-    dragPreviewRef.current?.remove();
-    dragPreviewRef.current = null;
+    clearDragPreview();
     setDropTargetId(null);
   };
 
@@ -861,6 +915,7 @@ export function FilesView({
     if (!isInternalItemDrag(event)) return;
     event.preventDefault();
     event.stopPropagation();
+    positionDragPreview(event.clientX, event.clientY);
     event.dataTransfer.dropEffect = "move";
     setDropTargetId(destinationFolderId);
   };
@@ -883,6 +938,7 @@ export function FilesView({
     event.stopPropagation();
     const items = draggedItemsRef.current;
     draggedItemsRef.current = [];
+    clearDragPreview();
     setDropTargetId(null);
     if (
       items.length === 0 ||
@@ -1081,6 +1137,10 @@ export function FilesView({
     persistCutItems(cut);
   };
 
+  const backgroundMoveTargets = listing.moveTargets.filter(
+    (target) => target.id !== listing.currentFolder.id,
+  );
+
   const backgroundMenuGroups = [
     {
       actions: [
@@ -1129,6 +1189,19 @@ export function FilesView({
           label: `Cut ${selectedIds.size} item${selectedIds.size !== 1 ? "s" : ""}`,
           shortcut: "⌘X",
           onSelect: cutSelectedItems,
+        },
+        {
+          disabled: backgroundMoveTargets.length === 0,
+          hidden: selectedIds.size === 0,
+          label: `Move ${selectedIds.size} item${selectedIds.size !== 1 ? "s" : ""} to…`,
+          subActions: backgroundMoveTargets.map((target) => ({
+            label: target.pathLabel,
+            onSelect: () =>
+              void moveItems(
+                allItems.filter((item) => selectedIdsRef.current.has(item.id)),
+                target.id,
+              ),
+          })),
         },
         {
           destructive: true,
@@ -1199,7 +1272,9 @@ export function FilesView({
                         }
                         onDrop={(event) => handleMoveDrop(crumb.id, event)}
                       >
-                        {label}
+                        <span className="workspace-breadcrumb-label">
+                          {label}
+                        </span>
                       </Link>
                     );
                   })}
@@ -1327,6 +1402,9 @@ export function FilesView({
                   onRenameSubmit={() => submitRename(folder.id, "folder")}
                   onRenameCancel={cancelRename}
                   onClick={(e) => handleRowClick(folder.id, e)}
+                  onContextMenu={() =>
+                    handleItemContextMenu(folder.id, "folder")
+                  }
                   onLongPress={() => selectSingleItem(folder.id)}
                   onOpen={() => openItem(folder.id)}
                   onStartRename={() => beginRename(folder.id, folder.name)}
@@ -1373,10 +1451,12 @@ export function FilesView({
                     }
                   }}
                   onMoveTo={(dest) => {
-                    void moveItems(
-                      getInteractionItems(folder.id, "folder"),
-                      dest,
-                    );
+                    const items =
+                      contextMoveItemsRef.current.length > 0
+                        ? [...contextMoveItemsRef.current]
+                        : getInteractionItems(folder.id, "folder");
+                    contextMoveItemsRef.current = [];
+                    void moveItems(items, dest);
                   }}
                   onDownload={() => {
                     const current = selectedIdsRef.current;
@@ -1513,6 +1593,7 @@ export function FilesView({
                   onRenameSubmit={() => submitRename(file.id, "file")}
                   onRenameCancel={cancelRename}
                   onClick={(e) => handleRowClick(file.id, e)}
+                  onContextMenu={() => handleItemContextMenu(file.id, "file")}
                   onLongPress={() => selectSingleItem(file.id)}
                   onOpen={() => openItem(file.id)}
                   onStartRename={() => beginRename(file.id, file.name)}
@@ -1559,7 +1640,12 @@ export function FilesView({
                     }
                   }}
                   onMoveTo={(dest) => {
-                    void moveItems(getInteractionItems(file.id, "file"), dest);
+                    const items =
+                      contextMoveItemsRef.current.length > 0
+                        ? [...contextMoveItemsRef.current]
+                        : getInteractionItems(file.id, "file");
+                    contextMoveItemsRef.current = [];
+                    void moveItems(items, dest);
                   }}
                   onDownload={() => {
                     const current = selectedIdsRef.current;

--- a/apps/web/app/(workspace)/files/files-view.tsx
+++ b/apps/web/app/(workspace)/files/files-view.tsx
@@ -166,6 +166,7 @@ export function FilesView({
   const dragCounterRef = useRef(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const draggedItemsRef = useRef<BatchMoveItem[]>([]);
+  const dragPreviewRef = useRef<HTMLDivElement | null>(null);
   const [dropTargetId, setDropTargetId] = useState<string | null>(null);
 
   // Register fileInputRef + current folder ID with TransferProvider so the
@@ -174,6 +175,10 @@ export function FilesView({
     registerFileInput(fileInputRef.current, listing.currentFolder.id);
     return () => registerFileInput(null);
   }, [listing.currentFolder.id, registerFileInput]);
+
+  useEffect(() => {
+    return () => dragPreviewRef.current?.remove();
+  }, []);
 
   // Auto-open file picker when navigated here via Upload button from another route.
   useEffect(() => {
@@ -804,10 +809,48 @@ export function FilesView({
     event.dataTransfer.effectAllowed = "move";
     event.dataTransfer.setData(INTERNAL_ITEM_DRAG_TYPE, JSON.stringify(items));
     event.dataTransfer.setData("text/plain", `${items.length} Staaash item(s)`);
+
+    dragPreviewRef.current?.remove();
+    dragPreviewRef.current = null;
+    if (items.length > 1) {
+      const preview = document.createElement("div");
+      preview.className = "explorer-drag-preview";
+      preview.setAttribute("aria-hidden", "true");
+
+      const row = document.createElement("div");
+      row.className = "explorer-drag-preview-row";
+      const icon = event.currentTarget
+        .querySelector(".explorer-row-icon")
+        ?.cloneNode(true);
+      const name = event.currentTarget
+        .querySelector(".explorer-row-name-cell")
+        ?.cloneNode(true);
+      if (icon) row.append(icon);
+      if (name) row.append(name);
+
+      const count = document.createElement("span");
+      count.className = "explorer-drag-preview-count";
+      count.textContent = String(items.length);
+
+      preview.append(row, count);
+      preview.style.left = `${event.clientX}px`;
+      preview.style.top = `${event.clientY}px`;
+      preview.style.transform = "none";
+      document.body.append(preview);
+      dragPreviewRef.current = preview;
+      event.dataTransfer.setDragImage(preview, 22, 22);
+      requestAnimationFrame(() => {
+        if (dragPreviewRef.current !== preview) return;
+        preview.remove();
+        dragPreviewRef.current = null;
+      });
+    }
   };
 
   const handleItemDragEnd = () => {
     draggedItemsRef.current = [];
+    dragPreviewRef.current?.remove();
+    dragPreviewRef.current = null;
     setDropTargetId(null);
   };
 

--- a/apps/web/app/(workspace)/files/files-view.tsx
+++ b/apps/web/app/(workspace)/files/files-view.tsx
@@ -15,11 +15,19 @@ import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { FlashMessage } from "@/app/auth-ui";
 import { DashboardPageContextMenu } from "@/app/dashboard-context-menu";
 import { startValidatedDownload } from "@/lib/transfers/download";
-import type { FilesListing } from "@/server/files/types";
+import type {
+  BatchMoveItem,
+  BatchMoveResponse,
+  FilesListing,
+} from "@/server/files/types";
 import type { ShareFilesLookup } from "@/server/sharing";
 
 import { RubberBandRect, type RubberBand } from "../rubber-band-rect";
 import { FilesRow } from "./files-row";
+import {
+  buildBatchMoveFailureMessage,
+  getMoveItemsForInteraction,
+} from "./files-move";
 import { FilesPropertiesPanel } from "./files-properties-panel";
 import { ShareDialog } from "./share-dialog";
 import { CreateFolderDialog } from "../create-folder-dialog";
@@ -40,6 +48,7 @@ import type { ShareLinkSummary } from "@/server/sharing";
 const FOLDER_ICON_KEY = "staaash:folder-icons";
 const CUT_STATE_KEY = "staaash:cut-items";
 const UPLOAD_SESSION_KEY_PREFIX = "staaash:upload-session";
+const INTERNAL_ITEM_DRAG_TYPE = "application/x-staaash-items";
 
 type CutItem = { id: string; kind: "folder" | "file"; name: string };
 
@@ -123,6 +132,7 @@ export function FilesView({
   // the new listing arrives (the server response no longer contains them).
   const [trashedIds, setTrashedIds] = useState<Set<string>>(new Set());
   const [trashError, setTrashError] = useState<string | null>(null);
+  const [moveError, setMoveError] = useState<string | null>(null);
   useEffect(() => {
     setTrashedIds(new Set());
   }, [listing]);
@@ -152,6 +162,8 @@ export function FilesView({
   >([]);
   const dragCounterRef = useRef(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const draggedItemsRef = useRef<BatchMoveItem[]>([]);
+  const [dropTargetId, setDropTargetId] = useState<string | null>(null);
 
   // Register fileInputRef + current folder ID with TransferProvider so the
   // topbar Upload button can trigger it and the panel can scope uploads by folder.
@@ -178,13 +190,6 @@ export function FilesView({
   const rubberBandStart = useRef<{ startX: number; startY: number } | null>(
     null,
   );
-  // Tracks where a mousedown originated so we can convert to rubber-band
-  // after the drag threshold when the drag started on a row.
-  const dragOrigin = useRef<{
-    x: number;
-    y: number;
-    onRow: boolean;
-  } | null>(null);
   // True from the moment rubber-band is committed until after the next click
   // event fires, so we can suppress spurious row-click / deselect callbacks.
   const didRubberBand = useRef(false);
@@ -231,12 +236,26 @@ export function FilesView({
   const visibleFiles = listing.files.filter((f) => !trashedIds.has(f.id));
 
   // Flat ordered list of all items (folders first, then files)
-  type AnyItem = { kind: "folder"; id: string } | { kind: "file"; id: string };
-
-  const allItems: AnyItem[] = [
+  const allItems: BatchMoveItem[] = [
     ...visibleFolders.map((f) => ({ kind: "folder" as const, id: f.id })),
     ...visibleFiles.map((f) => ({ kind: "file" as const, id: f.id })),
   ];
+
+  const getItemName = (item: BatchMoveItem) =>
+    item.kind === "folder"
+      ? (listing.childFolders.find((folder) => folder.id === item.id)?.name ??
+        item.id)
+      : (listing.files.find((file) => file.id === item.id)?.name ?? item.id);
+
+  const getInteractionItems = (
+    id: string,
+    kind: BatchMoveItem["kind"],
+  ): BatchMoveItem[] =>
+    getMoveItemsForInteraction({
+      allItems,
+      selectedIds: selectedIdsRef.current,
+      target: { id, kind },
+    });
 
   // ---- Load persisted state ----
   useEffect(() => {
@@ -613,36 +632,91 @@ export function FilesView({
     if (succeeded) startTransition(() => router.refresh());
   };
 
-  const moveItem = async (
-    id: string,
-    kind: "folder" | "file",
+  const moveItems = async (
+    items: BatchMoveItem[],
     destinationFolderId: string,
-  ) => {
-    const endpoint =
-      kind === "folder"
-        ? `/api/files/folders/${id}/move`
-        : `/api/files/files/${id}/move`;
-    await fetch(endpoint, {
-      method: "POST",
-      body: new URLSearchParams({
-        destinationFolderId,
-        redirectTo: currentPath,
-      }),
-    });
+  ): Promise<BatchMoveResponse | null> => {
+    if (items.length === 0) return null;
+    setMoveError(null);
+
+    try {
+      const response = await fetch("/api/files/move", {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          items,
+          destinationFolderId,
+        }),
+      });
+      const data = (await response.json().catch(() => ({}))) as
+        BatchMoveResponse | { error?: string };
+
+      if (!response.ok || !("results" in data)) {
+        throw new Error(
+          "error" in data && data.error
+            ? data.error
+            : `Move failed (${response.status})`,
+        );
+      }
+
+      const failures = data.results.filter(
+        (result) => result.status === "failed",
+      );
+      setSelectedIds(new Set(failures.map((result) => result.id)));
+      setLastSelectedId(failures.at(-1)?.id ?? null);
+
+      if (failures.length > 0) {
+        setMoveError(
+          buildBatchMoveFailureMessage({
+            response: data,
+            getItemName,
+          }),
+        );
+      }
+
+      if (data.movedCount > 0) {
+        startTransition(() => router.refresh());
+      }
+
+      return data;
+    } catch (error) {
+      setSelectedIds(new Set(items.map((item) => item.id)));
+      setMoveError(
+        error instanceof Error ? error.message : "Items could not be moved.",
+      );
+      return null;
+    }
   };
 
   const handlePaste = async () => {
     if (cutItems.length === 0) return;
     const dest = listing.currentFolder.id;
-    await Promise.all(
-      cutItems.map((item) => moveItem(item.id, item.kind, dest)),
+    const result = await moveItems(
+      cutItems.map(({ id, kind }) => ({ id, kind })),
+      dest,
     );
-    const moved = new Set(cutItems.map((i) => i.id));
-    setCutItems([]);
-    clearCutItems();
+    if (!result) return;
+
+    const failedIds = new Set(
+      result.results
+        .filter((item) => item.status === "failed")
+        .map((item) => item.id),
+    );
+    const remainingCutItems = cutItems.filter((item) => failedIds.has(item.id));
+    setCutItems(remainingCutItems);
+    if (remainingCutItems.length > 0) persistCutItems(remainingCutItems);
+    else clearCutItems();
+
+    const moved = new Set(
+      result.results
+        .filter((item) => item.status === "moved")
+        .map((item) => item.id),
+    );
     setJustMovedIds(moved);
     setTimeout(() => setJustMovedIds(new Set()), 800);
-    startTransition(() => router.refresh());
   };
 
   // ---------------------------------------------------------------------------
@@ -666,13 +740,22 @@ export function FilesView({
   // Upload
   // ---------------------------------------------------------------------------
 
+  const isInternalItemDrag = (event: React.DragEvent) =>
+    draggedItemsRef.current.length > 0 ||
+    event.dataTransfer.types.includes(INTERNAL_ITEM_DRAG_TYPE);
+
   const handleDragEnter = (e: React.DragEvent) => {
+    if (isInternalItemDrag(e)) {
+      e.preventDefault();
+      return;
+    }
     e.preventDefault();
     dragCounterRef.current++;
     if (e.dataTransfer.types.includes("Files")) setIsDragOver(true);
   };
 
-  const handleDragLeave = () => {
+  const handleDragLeave = (event: React.DragEvent) => {
+    if (isInternalItemDrag(event)) return;
     dragCounterRef.current--;
     if (dragCounterRef.current <= 0) {
       dragCounterRef.current = 0;
@@ -680,15 +763,88 @@ export function FilesView({
     }
   };
 
-  const handleDragOver = (e: React.DragEvent) => e.preventDefault();
+  const handleDragOver = (e: React.DragEvent) => {
+    if (isInternalItemDrag(e)) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "none";
+      return;
+    }
+    e.preventDefault();
+  };
 
   const handleDrop = (e: React.DragEvent) => {
+    if (isInternalItemDrag(e)) {
+      e.preventDefault();
+      draggedItemsRef.current = [];
+      setDropTargetId(null);
+      return;
+    }
     e.preventDefault();
     dragCounterRef.current = 0;
     setIsDragOver(false);
     const files = Array.from(e.dataTransfer.files);
     if (files.length > 0)
       beginUpload(listing.currentFolder.id, currentPath, files);
+  };
+
+  const handleItemDragStart = (
+    id: string,
+    kind: BatchMoveItem["kind"],
+    event: React.DragEvent<HTMLDivElement>,
+  ) => {
+    const items = getInteractionItems(id, kind);
+    draggedItemsRef.current = items;
+    if (!selectedIdsRef.current.has(id)) {
+      setSelectedIds(new Set([id]));
+      setLastSelectedId(id);
+    }
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData(INTERNAL_ITEM_DRAG_TYPE, JSON.stringify(items));
+    event.dataTransfer.setData("text/plain", `${items.length} Staaash item(s)`);
+  };
+
+  const handleItemDragEnd = () => {
+    draggedItemsRef.current = [];
+    setDropTargetId(null);
+  };
+
+  const handleMoveDragOver = (
+    destinationFolderId: string,
+    event: React.DragEvent,
+  ) => {
+    if (!isInternalItemDrag(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = "move";
+    setDropTargetId(destinationFolderId);
+  };
+
+  const handleMoveDragLeave = (
+    destinationFolderId: string,
+    event: React.DragEvent,
+  ) => {
+    const nextTarget = event.relatedTarget as Node | null;
+    if (nextTarget && event.currentTarget.contains(nextTarget)) return;
+    if (dropTargetId === destinationFolderId) setDropTargetId(null);
+  };
+
+  const handleMoveDrop = (
+    destinationFolderId: string,
+    event: React.DragEvent,
+  ) => {
+    if (!isInternalItemDrag(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const items = draggedItemsRef.current;
+    draggedItemsRef.current = [];
+    setDropTargetId(null);
+    if (
+      items.length === 0 ||
+      destinationFolderId === listing.currentFolder.id
+    ) {
+      return;
+    }
+    void moveItems(items, destinationFolderId);
   };
 
   const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -702,9 +858,6 @@ export function FilesView({
   // Rubber-band
   // ---------------------------------------------------------------------------
 
-  // px of movement required before a row-origin drag becomes a rubber-band
-  const DRAG_THRESHOLD = 5;
-
   const handleListMouseDown = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       if (isCoarsePointer) return;
@@ -715,23 +868,19 @@ export function FilesView({
       // Never start rubber-band from the header toolbar
       if (target.closest(".explorer-header")) return;
 
-      const onRow = !!target.closest("[data-file-row]");
+      if (target.closest("[data-file-row]")) return;
+
       const container = listRef.current!;
       const rect = container.getBoundingClientRect();
       const x = e.clientX - rect.left;
       const y = e.clientY - rect.top;
 
-      dragOrigin.current = { x, y, onRow };
-
-      if (!onRow) {
-        // Empty-space click: activate rubber-band immediately
-        e.preventDefault(); // also suppresses the upcoming click event
-        rubberBandStart.current = { startX: x, startY: y };
-        isRubberBanding.current = true;
-        setRubberBand({ startX: x, startY: y, currentX: x, currentY: y });
-        if (!e.shiftKey && !e.ctrlKey && !e.metaKey) setSelectedIds(new Set());
-      }
-      // Row click: wait for drag threshold in the window mousemove handler
+      // Rubber-band starts from empty list space. Row drags move items.
+      e.preventDefault();
+      rubberBandStart.current = { startX: x, startY: y };
+      isRubberBanding.current = true;
+      setRubberBand({ startX: x, startY: y, currentX: x, currentY: y });
+      if (!e.shiftKey && !e.ctrlKey && !e.metaKey) setSelectedIds(new Set());
     },
     [isCoarsePointer],
   );
@@ -749,26 +898,7 @@ export function FilesView({
       const currentX = e.clientX - rect.left;
       const currentY = e.clientY - rect.top;
 
-      // If not yet rubber-banding, check whether a row-origin drag has
-      // exceeded the threshold and should be promoted to rubber-band mode.
-      if (!isRubberBanding.current) {
-        const origin = dragOrigin.current;
-        if (!origin || !origin.onRow) return;
-        const dist = Math.hypot(currentX - origin.x, currentY - origin.y);
-        if (dist < DRAG_THRESHOLD) return;
-        // Promote to rubber-band
-        isRubberBanding.current = true;
-        didRubberBand.current = true;
-        rubberBandStart.current = { startX: origin.x, startY: origin.y };
-        setRubberBand({
-          startX: origin.x,
-          startY: origin.y,
-          currentX,
-          currentY,
-        });
-        setSelectedIds(new Set());
-        return;
-      }
+      if (!isRubberBanding.current) return;
 
       const start = rubberBandStart.current;
       if (!start) return;
@@ -815,7 +945,6 @@ export function FilesView({
     };
 
     const onUp = () => {
-      dragOrigin.current = null;
       if (!isRubberBanding.current) return;
       isRubberBanding.current = false;
       rubberBandStart.current = null;
@@ -977,6 +1106,7 @@ export function FilesView({
         {error ? <FlashMessage>{error}</FlashMessage> : null}
         {success ? <FlashMessage tone="success">{success}</FlashMessage> : null}
         {trashError ? <FlashMessage>{trashError}</FlashMessage> : null}
+        {moveError ? <FlashMessage>{moveError}</FlashMessage> : null}
 
         <DashboardPageContextMenu
           className="explorer-root"
@@ -1007,7 +1137,22 @@ export function FilesView({
                       );
                     }
                     return (
-                      <Link key={crumb.id} href={crumb.href}>
+                      <Link
+                        key={crumb.id}
+                        className={
+                          dropTargetId === crumb.id
+                            ? "is-drop-target"
+                            : undefined
+                        }
+                        href={crumb.href}
+                        onDragOver={(event) =>
+                          handleMoveDragOver(crumb.id, event)
+                        }
+                        onDragLeave={(event) =>
+                          handleMoveDragLeave(crumb.id, event)
+                        }
+                        onDrop={(event) => handleMoveDrop(crumb.id, event)}
+                      >
                         {label}
                       </Link>
                     );
@@ -1182,8 +1327,9 @@ export function FilesView({
                     }
                   }}
                   onMoveTo={(dest) => {
-                    moveItem(folder.id, "folder", dest).then(() =>
-                      startTransition(() => router.refresh()),
+                    void moveItems(
+                      getInteractionItems(folder.id, "folder"),
+                      dest,
                     );
                   }}
                   onDownload={() => {
@@ -1198,6 +1344,18 @@ export function FilesView({
                     if (el) rowRefs.current.set(folder.id, el);
                     else rowRefs.current.delete(folder.id);
                   }}
+                  onDragStart={(event) =>
+                    handleItemDragStart(folder.id, "folder", event)
+                  }
+                  onDragEnd={handleItemDragEnd}
+                  isDropTarget={dropTargetId === folder.id}
+                  onMoveDragOver={(event) =>
+                    handleMoveDragOver(folder.id, event)
+                  }
+                  onMoveDragLeave={(event) =>
+                    handleMoveDragLeave(folder.id, event)
+                  }
+                  onMoveDrop={(event) => handleMoveDrop(folder.id, event)}
                   touchMode={isCoarsePointer}
                 />
               );
@@ -1354,9 +1512,7 @@ export function FilesView({
                     }
                   }}
                   onMoveTo={(dest) => {
-                    moveItem(file.id, "file", dest).then(() =>
-                      startTransition(() => router.refresh()),
-                    );
+                    void moveItems(getInteractionItems(file.id, "file"), dest);
                   }}
                   onDownload={() => {
                     const current = selectedIdsRef.current;
@@ -1370,6 +1526,10 @@ export function FilesView({
                     if (el) rowRefs.current.set(file.id, el);
                     else rowRefs.current.delete(file.id);
                   }}
+                  onDragStart={(event) =>
+                    handleItemDragStart(file.id, "file", event)
+                  }
+                  onDragEnd={handleItemDragEnd}
                   touchMode={isCoarsePointer}
                 />
               );

--- a/apps/web/app/(workspace)/files/files-view.tsx
+++ b/apps/web/app/(workspace)/files/files-view.tsx
@@ -14,6 +14,8 @@ import { Download, FolderPlus, RefreshCw, Upload } from "lucide-react";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { FlashMessage } from "@/app/auth-ui";
 import { DashboardPageContextMenu } from "@/app/dashboard-context-menu";
+import { ItemTypeIcon } from "@/app/item-type-icon";
+import { getItemVisual } from "@/app/item-visuals";
 import { startValidatedDownload } from "@/lib/transfers/download";
 import type {
   BatchMoveItem,
@@ -1640,9 +1642,8 @@ function UploadingRow({
   onDismiss: () => void;
   onRetry?: () => void;
 }) {
-  const { File: FileIcon } = { File: require("lucide-react").File };
-
   const eta = formatEta(file.size, file.progress, file.speed);
+  const visual = getItemVisual("file", file.fileRef?.type);
   const statusText =
     file.status === "error"
       ? (file.error ?? "Upload failed")
@@ -1655,13 +1656,18 @@ function UploadingRow({
             : `${file.progress}% · ${formatSpeed(file.speed)}${eta ? ` · ${eta}` : ""}`;
 
   return (
-    <div className="uploading-row" role="row">
+    <div className="explorer-row uploading-row" role="row">
       <div className="explorer-row-icon" role="gridcell">
-        <FileIcon size={16} style={{ color: "var(--muted-foreground)" }} />
+        <ItemTypeIcon size={16} tone="plain" visual={visual} />
       </div>
-      <span className="uploading-row-name" role="gridcell" title={file.name}>
-        {file.name}
-      </span>
+      <div className="explorer-row-name-cell" role="gridcell">
+        <span
+          className="explorer-row-name uploading-row-name"
+          title={file.name}
+        >
+          {file.name}
+        </span>
+      </div>
       <span className="uploading-row-size explorer-row-meta" role="gridcell">
         {formatBytes(file.size)}
       </span>
@@ -1718,19 +1724,21 @@ function GhostUploadRow({
   onDismiss: () => void;
   onDoubleClick: () => void;
 }) {
-  const { File: FileIcon } = { File: require("lucide-react").File };
+  const visual = getItemVisual("file");
   return (
     <div
-      className="uploading-row ghost-upload-row"
+      className="explorer-row uploading-row ghost-upload-row"
       onDoubleClick={onDoubleClick}
       role="row"
     >
       <div className="explorer-row-icon" role="gridcell">
-        <FileIcon size={16} style={{ color: "var(--muted-foreground)" }} />
+        <ItemTypeIcon size={16} tone="plain" visual={visual} />
       </div>
-      <span className="uploading-row-name" role="gridcell" title={name}>
-        {name}
-      </span>
+      <div className="explorer-row-name-cell" role="gridcell">
+        <span className="explorer-row-name uploading-row-name" title={name}>
+          {name}
+        </span>
+      </div>
       <span className="uploading-row-size explorer-row-meta" role="gridcell">
         {formatBytes(size)}
       </span>

--- a/apps/web/app/(workspace)/files/files-view.tsx
+++ b/apps/web/app/(workspace)/files/files-view.tsx
@@ -35,6 +35,7 @@ import {
   useTransferContext,
   type UploadingFile,
   CHUNKED_UPLOAD_THRESHOLD,
+  formatBytes,
   formatSpeed,
   formatEta,
 } from "../transfer-context";
@@ -1402,6 +1403,7 @@ export function FilesView({
                   <GhostUploadRow
                     key={entry.storageKey}
                     name={entry.name}
+                    size={entry.size}
                     onDismiss={() => {
                       localStorage.removeItem(entry.storageKey);
                       setResumableSessions((prev) =>
@@ -1653,37 +1655,42 @@ function UploadingRow({
             : `${file.progress}% · ${formatSpeed(file.speed)}${eta ? ` · ${eta}` : ""}`;
 
   return (
-    <div className="uploading-row">
-      <div className="uploading-row-top">
-        <div className="explorer-row-icon">
-          <FileIcon size={16} style={{ color: "var(--muted-foreground)" }} />
-        </div>
-        <span className="uploading-row-name">{file.name}</span>
-        <span
-          className={`uploading-row-status${file.status === "error" ? " is-error" : ""}`}
-        >
-          {statusText}
-          {file.status === "error" && onRetry && (
-            <button
-              type="button"
-              className="uploading-row-retry"
-              onClick={onRetry}
-            >
-              Retry
-            </button>
-          )}
-          {file.status !== "uploading" && (
-            <button
-              type="button"
-              className="uploading-row-dismiss"
-              onClick={onDismiss}
-              aria-label="Dismiss"
-            >
-              ✕
-            </button>
-          )}
-        </span>
+    <div className="uploading-row" role="row">
+      <div className="explorer-row-icon" role="gridcell">
+        <FileIcon size={16} style={{ color: "var(--muted-foreground)" }} />
       </div>
+      <span className="uploading-row-name" role="gridcell" title={file.name}>
+        {file.name}
+      </span>
+      <span className="uploading-row-size explorer-row-meta" role="gridcell">
+        {formatBytes(file.size)}
+      </span>
+      <span
+        className={`uploading-row-status${file.status === "error" ? " is-error" : ""}`}
+        role="gridcell"
+        title={statusText}
+      >
+        <span className="uploading-row-status-text">{statusText}</span>
+        {file.status === "error" && onRetry && (
+          <button
+            type="button"
+            className="uploading-row-retry"
+            onClick={onRetry}
+          >
+            Retry
+          </button>
+        )}
+        {file.status !== "uploading" && (
+          <button
+            type="button"
+            className="uploading-row-dismiss"
+            onClick={onDismiss}
+            aria-label="Dismiss"
+          >
+            ✕
+          </button>
+        )}
+      </span>
       {file.status === "uploading" && (
         <div className="uploading-row-progress-track">
           <div
@@ -1702,10 +1709,12 @@ function UploadingRow({
 
 function GhostUploadRow({
   name,
+  size,
   onDismiss,
   onDoubleClick,
 }: {
   name: string;
+  size: number;
   onDismiss: () => void;
   onDoubleClick: () => void;
 }) {
@@ -1714,37 +1723,44 @@ function GhostUploadRow({
     <div
       className="uploading-row ghost-upload-row"
       onDoubleClick={onDoubleClick}
+      role="row"
     >
-      <div className="uploading-row-top">
-        <div className="explorer-row-icon">
-          <FileIcon size={16} style={{ color: "var(--muted-foreground)" }} />
-        </div>
-        <span className="uploading-row-name">{name}</span>
-        <span className="uploading-row-status ghost-upload-row-status">
-          Incomplete ·
-          <button
-            type="button"
-            className="uploading-row-retry"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDoubleClick();
-            }}
-          >
-            resume
-          </button>
-          <button
-            type="button"
-            className="uploading-row-dismiss"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDismiss();
-            }}
-            aria-label="Dismiss"
-          >
-            ✕
-          </button>
-        </span>
+      <div className="explorer-row-icon" role="gridcell">
+        <FileIcon size={16} style={{ color: "var(--muted-foreground)" }} />
       </div>
+      <span className="uploading-row-name" role="gridcell" title={name}>
+        {name}
+      </span>
+      <span className="uploading-row-size explorer-row-meta" role="gridcell">
+        {formatBytes(size)}
+      </span>
+      <span
+        className="uploading-row-status ghost-upload-row-status"
+        role="gridcell"
+      >
+        <span className="uploading-row-status-text">Incomplete</span>
+        <button
+          type="button"
+          className="uploading-row-retry"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDoubleClick();
+          }}
+        >
+          Resume
+        </button>
+        <button
+          type="button"
+          className="uploading-row-dismiss"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDismiss();
+          }}
+          aria-label="Dismiss"
+        >
+          ✕
+        </button>
+      </span>
       <div className="uploading-row-progress-track ghost-upload-row-track">
         <div className="ghost-upload-row-fill" />
       </div>

--- a/apps/web/app/(workspace)/transfer-context.tsx
+++ b/apps/web/app/(workspace)/transfer-context.tsx
@@ -81,7 +81,7 @@ export function formatSpeed(bytesPerSec: number): string {
   return `${(bytesPerSec / 1024 / 1024).toFixed(1)} MB/s`;
 }
 
-function formatBytes(bytes: number): string {
+export function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / 1024 / 1024).toFixed(1)} MB`;

--- a/apps/web/app/api/files/move/route.ts
+++ b/apps/web/app/api/files/move/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { getRequestSession } from "@/server/auth/guards";
+import {
+  isSameOrigin,
+  jsonErrorResponse,
+  jsonNotSignedInResponse,
+} from "@/server/auth/http";
+import { filesService } from "@/server/files/service";
+import type { BatchMoveResponse, BatchMoveResult } from "@/server/files/types";
+import {
+  recordFileAccessBestEffort,
+  recordFolderAccessBestEffort,
+} from "@/server/retrieval/recent-tracking";
+
+const requestSchema = z.object({
+  destinationFolderId: z.string().trim().min(1),
+  items: z
+    .array(
+      z.object({
+        id: z.string().trim().min(1),
+        kind: z.enum(["file", "folder"]),
+      }),
+    )
+    .min(1)
+    .max(500),
+});
+
+const normalizeMoveFailure = (
+  item: { id: string; kind: "file" | "folder" },
+  error: unknown,
+): BatchMoveResult => {
+  if (
+    error instanceof Error &&
+    typeof (error as { code?: unknown }).code === "string"
+  ) {
+    return {
+      ...item,
+      status: "failed",
+      code: (error as Error & { code: string }).code,
+      error: error.message,
+    };
+  }
+
+  return {
+    ...item,
+    status: "failed",
+    code: "INTERNAL_ERROR",
+    error: "Unexpected server error.",
+  };
+};
+
+export async function POST(request: NextRequest) {
+  if (!isSameOrigin(request)) {
+    return NextResponse.json(
+      { error: "Cross-origin requests are not allowed." },
+      { status: 403 },
+    );
+  }
+
+  const session = await getRequestSession(request);
+  if (!session) return jsonNotSignedInResponse();
+
+  try {
+    const body = requestSchema.parse(await request.json());
+    const results: BatchMoveResult[] = [];
+
+    for (const item of body.items) {
+      try {
+        if (item.kind === "folder") {
+          await filesService.moveFolder({
+            actorUserId: session.user.id,
+            actorRole: session.user.role,
+            folderId: item.id,
+            destinationFolderId: body.destinationFolderId,
+          });
+          await recordFolderAccessBestEffort({
+            actorUserId: session.user.id,
+            actorRole: session.user.role,
+            folderId: item.id,
+            source: "batch-move-route",
+          });
+        } else {
+          await filesService.moveFile({
+            actorUserId: session.user.id,
+            actorRole: session.user.role,
+            fileId: item.id,
+            destinationFolderId: body.destinationFolderId,
+          });
+          await recordFileAccessBestEffort({
+            actorUserId: session.user.id,
+            actorRole: session.user.role,
+            fileId: item.id,
+            source: "batch-move-route",
+          });
+        }
+
+        results.push({ ...item, status: "moved" });
+      } catch (error) {
+        results.push(normalizeMoveFailure(item, error));
+      }
+    }
+
+    const movedCount = results.filter(
+      (result) => result.status === "moved",
+    ).length;
+    const response: BatchMoveResponse = {
+      movedCount,
+      failedCount: results.length - movedCount,
+      results,
+    };
+
+    return NextResponse.json(response);
+  } catch (error) {
+    return jsonErrorResponse(error);
+  }
+}

--- a/apps/web/app/dashboard-context-menu.tsx
+++ b/apps/web/app/dashboard-context-menu.tsx
@@ -109,31 +109,93 @@ function DashboardFloatingMenuItems({
   onActionSelected,
 }: DashboardContextMenuItemsProps) {
   const visibleGroups = getVisibleDashboardMenuGroups(groups);
+  const [openSubmenu, setOpenSubmenu] = useState<string | null>(null);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelSubmenuClose = () => {
+    if (!closeTimerRef.current) return;
+    clearTimeout(closeTimerRef.current);
+    closeTimerRef.current = null;
+  };
+
+  const openSubmenuNow = (label: string) => {
+    cancelSubmenuClose();
+    setOpenSubmenu(label);
+  };
+
+  const scheduleSubmenuClose = () => {
+    cancelSubmenuClose();
+    closeTimerRef.current = setTimeout(() => {
+      setOpenSubmenu(null);
+      closeTimerRef.current = null;
+    }, 180);
+  };
+
+  useEffect(() => {
+    return () => cancelSubmenuClose();
+  }, []);
 
   return (
     <>
       {visibleGroups.map((group, groupIndex) => (
         <div key={groupIndex}>
           {groupIndex > 0 ? <div className="bg-ctx-sep" /> : null}
-          {group.actions.map((action) => (
-            <button
-              className={`bg-ctx-item${action.destructive ? " bg-ctx-item--danger" : ""}`}
-              disabled={action.disabled}
-              key={action.label}
-              type="button"
-              onClick={() => {
-                if (action.disabled) return;
-                action.onSelect?.();
-                onActionSelected?.();
-              }}
-            >
-              {action.icon}
-              {action.label}
-              {action.shortcut ? (
-                <span className="bg-ctx-shortcut">{action.shortcut}</span>
-              ) : null}
-            </button>
-          ))}
+          {group.actions.map((action) =>
+            action.subActions && action.subActions.length > 0 ? (
+              <div
+                className="bg-ctx-sub"
+                key={action.label}
+                onPointerEnter={() => openSubmenuNow(action.label)}
+                onPointerLeave={scheduleSubmenuClose}
+              >
+                <button
+                  className="bg-ctx-item bg-ctx-sub-trigger"
+                  disabled={action.disabled}
+                  onFocus={() => openSubmenuNow(action.label)}
+                  onPointerDown={(event) => {
+                    event.stopPropagation();
+                    openSubmenuNow(action.label);
+                  }}
+                  type="button"
+                >
+                  {action.icon}
+                  {action.label}
+                  <span className="bg-ctx-sub-arrow" aria-hidden="true">
+                    ›
+                  </span>
+                </button>
+                <div
+                  className={`bg-ctx-menu bg-ctx-sub-content${openSubmenu === action.label ? " is-open" : ""}`}
+                  onPointerEnter={cancelSubmenuClose}
+                  onPointerLeave={scheduleSubmenuClose}
+                  onPointerDown={(event) => event.stopPropagation()}
+                >
+                  <DashboardFloatingMenuItems
+                    groups={[{ actions: action.subActions }]}
+                    onActionSelected={onActionSelected}
+                  />
+                </div>
+              </div>
+            ) : (
+              <button
+                className={`bg-ctx-item${action.destructive ? " bg-ctx-item--danger" : ""}`}
+                disabled={action.disabled}
+                key={action.label}
+                type="button"
+                onClick={() => {
+                  if (action.disabled) return;
+                  action.onSelect?.();
+                  onActionSelected?.();
+                }}
+              >
+                {action.icon}
+                {action.label}
+                {action.shortcut ? (
+                  <span className="bg-ctx-shortcut">{action.shortcut}</span>
+                ) : null}
+              </button>
+            ),
+          )}
         </div>
       ))}
     </>
@@ -199,9 +261,13 @@ export function DashboardPageContextMenu({
 
   useEffect(() => {
     if (!position) return;
-    const close = () => setPosition(null);
+    const close = (event: PointerEvent) => {
+      const target = event.target instanceof Element ? event.target : null;
+      if (target?.closest(".bg-ctx-menu")) return;
+      setPosition(null);
+    };
     const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") close();
+      if (event.key === "Escape") setPosition(null);
     };
     window.addEventListener("pointerdown", close);
     window.addEventListener("keydown", onKey);

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3904,10 +3904,17 @@ h3 {
 
 .workspace-breadcrumbs a.is-drop-target {
   color: var(--foreground);
-  background: color-mix(in oklab, var(--primary) 12%, transparent);
+}
+
+.workspace-breadcrumb-label {
   border-radius: 5px;
-  outline: 1px solid color-mix(in oklab, var(--primary) 45%, transparent);
-  outline-offset: 3px;
+}
+
+.workspace-breadcrumbs a.is-drop-target .workspace-breadcrumb-label {
+  background: color-mix(in oklab, var(--primary) 12%, transparent);
+  box-shadow:
+    0 0 0 3px color-mix(in oklab, var(--primary) 12%, transparent),
+    0 0 0 4px color-mix(in oklab, var(--primary) 45%, transparent);
 }
 
 .workspace-breadcrumbs a::after {
@@ -7127,48 +7134,40 @@ html.light {
   background: color-mix(in oklab, var(--primary) 10%, var(--card));
 }
 
-.explorer-row[draggable="true"] {
-  cursor: grab;
-}
-
-.explorer-row[draggable="true"]:active {
-  cursor: grabbing;
-}
-
 .explorer-drag-preview {
   position: fixed;
   top: 0;
   left: 0;
   z-index: 100;
-  width: min(320px, calc(100vw - 48px));
-  height: 56px;
+  width: min(300px, calc(100vw - 48px));
+  height: 64px;
   pointer-events: none;
   transform: translate(-200%, -200%);
   isolation: isolate;
+  opacity: 1;
 }
 
-.explorer-drag-preview::before,
-.explorer-drag-preview::after {
+.explorer-drag-preview-layer {
   position: absolute;
-  top: 8px;
-  right: 8px;
-  bottom: 8px;
+  top: 10px;
   left: 0;
-  z-index: -1;
-  content: "";
-  border: 1px solid color-mix(in oklab, var(--foreground) 10%, var(--border));
+  width: calc(100% - 10px);
+  height: 44px;
+  border: 2px solid color-mix(in oklab, var(--primary) 45%, transparent);
   border-radius: 8px;
-  background: color-mix(in oklab, var(--card) 94%, var(--accent));
+  background: color-mix(in oklab, var(--primary) 18%, transparent);
 }
 
-.explorer-drag-preview::before {
-  transform: translate(8px, 8px);
+.explorer-drag-preview-layer[data-layer="1"] {
+  z-index: -1;
+  transform: translate(5px, 5px);
+  opacity: 0.72;
+}
+
+.explorer-drag-preview-layer[data-layer="2"] {
+  z-index: -2;
+  transform: translate(10px, 10px);
   opacity: 0.55;
-}
-
-.explorer-drag-preview::after {
-  transform: translate(4px, 4px);
-  opacity: 0.78;
 }
 
 .explorer-drag-preview-row {
@@ -7176,32 +7175,51 @@ html.light {
   grid-template-columns: 28px minmax(0, 1fr);
   align-items: center;
   gap: 10px;
-  width: calc(100% - 8px);
-  height: 40px;
-  margin-top: 8px;
-  padding: 0 36px 0 4px;
+  width: 100%;
+  height: 44px;
+  margin-top: 10px;
+  padding: 0 12px 0 6px;
   overflow: hidden;
-  border: 1px solid color-mix(in oklab, var(--foreground) 14%, var(--border));
+  border: 2px solid color-mix(in oklab, var(--primary) 55%, transparent);
   border-radius: 8px;
-  background: var(--card);
+  background: color-mix(in oklab, var(--card) 36%, transparent);
   color: var(--foreground);
+}
+
+.explorer-drag-preview[data-stack-depth="2"] .explorer-drag-preview-layer,
+.explorer-drag-preview[data-stack-depth="2"] .explorer-drag-preview-row {
+  width: calc(100% - 5px);
+}
+
+.explorer-drag-preview[data-stack-depth="3"] .explorer-drag-preview-row {
+  width: calc(100% - 10px);
+}
+
+.explorer-drag-preview.has-count .explorer-drag-preview-row {
+  padding-right: 94px;
+}
+
+.explorer-drag-preview .explorer-row-name {
+  color: color-mix(in oklab, var(--foreground) 78%, transparent);
+  font-weight: 300;
+  opacity: 1;
 }
 
 .explorer-drag-preview-count {
   position: absolute;
-  top: 0;
-  right: 0;
+  top: 16px;
+  right: 18px;
   display: grid;
-  min-width: 24px;
-  height: 24px;
-  padding: 0 6px;
+  min-width: 68px;
+  height: 30px;
+  padding: 0 10px;
   place-items: center;
-  border: 2px solid var(--card);
+  border: 2px solid color-mix(in oklab, var(--background) 58%, transparent);
   border-radius: 999px;
-  background: var(--primary);
-  color: var(--primary-foreground);
-  font-size: 12px;
-  font-weight: 700;
+  background: color-mix(in oklab, var(--foreground) 58%, transparent);
+  color: color-mix(in oklab, var(--background) 92%, transparent);
+  font-size: 13px;
+  font-weight: 750;
   line-height: 1;
 }
 
@@ -7382,6 +7400,34 @@ html.light {
   font-size: 11px;
   color: var(--muted-foreground);
   pointer-events: none;
+}
+
+.bg-ctx-sub {
+  position: relative;
+}
+
+.bg-ctx-sub-trigger {
+  padding-right: 6px;
+}
+
+.bg-ctx-sub-arrow {
+  margin-left: auto;
+  color: var(--muted-foreground);
+  font-size: 18px;
+  line-height: 1;
+}
+
+.bg-ctx-sub-content {
+  position: absolute;
+  top: -4px;
+  left: calc(100% - 1px);
+  display: none;
+}
+
+.bg-ctx-sub:hover > .bg-ctx-sub-content,
+.bg-ctx-sub:focus-within > .bg-ctx-sub-content,
+.bg-ctx-sub-content.is-open {
+  display: block;
 }
 
 /* ---- Drag-to-upload overlay ---- */

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -7364,18 +7364,15 @@ html.light {
 
 .uploading-row {
   display: grid;
-  gap: 6px;
-  padding: 8px 12px 8px 4px;
+  grid-template-columns: 28px 1fr 76px 132px;
+  align-items: center;
+  gap: 0 10px;
+  height: 40px;
+  padding: 0 8px 0 4px;
   border-radius: 8px;
   background: color-mix(in oklab, var(--foreground) 3%, var(--card));
   margin-bottom: 2px;
-}
-
-.uploading-row-top {
-  display: grid;
-  grid-template-columns: 28px 1fr auto;
-  align-items: center;
-  gap: 0 10px;
+  position: relative;
 }
 
 .uploading-row-name {
@@ -7385,12 +7382,26 @@ html.light {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  min-width: 0;
 }
 
 .uploading-row-status {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 0;
   font-size: 12px;
   color: var(--muted-foreground);
   white-space: nowrap;
+  overflow: hidden;
+  text-align: right;
+}
+
+.uploading-row-status-text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .uploading-row-status.is-error {
@@ -7402,7 +7413,10 @@ html.light {
   background: color-mix(in oklab, var(--foreground) 10%, transparent);
   border-radius: 999px;
   overflow: hidden;
-  margin-left: 38px;
+  position: absolute;
+  right: 8px;
+  bottom: 1px;
+  left: 4px;
 }
 
 .uploading-row-progress-fill {
@@ -7737,6 +7751,7 @@ html.light {
 /* ---- Upload row — error / retry / dismiss ---- */
 
 .uploading-row-dismiss {
+  flex-shrink: 0;
   margin-left: 8px;
   background: none;
   border: none;
@@ -7755,6 +7770,7 @@ html.light {
 }
 
 .uploading-row-retry {
+  flex-shrink: 0;
   margin-left: 8px;
   background: none;
   border: 1px solid color-mix(in oklab, var(--primary) 40%, transparent);
@@ -11032,12 +11048,14 @@ main.share-locked-page {
   }
 
   .explorer-row,
+  .uploading-row,
   .explorer-col-header {
     grid-template-columns: 36px minmax(0, 1fr) 104px 170px;
     gap: 0 14px;
   }
 
-  .explorer-row {
+  .explorer-row,
+  .uploading-row {
     height: var(--app-row-height);
     padding: 0 12px 0 8px;
   }
@@ -11375,6 +11393,36 @@ main.share-locked-page {
     min-height: 56px;
     padding: 7px 4px;
     touch-action: manipulation;
+  }
+
+  .uploading-row {
+    grid-template-columns: 34px minmax(0, 1fr);
+    grid-template-rows: auto auto;
+    min-height: 56px;
+    height: auto;
+    gap: 2px 0;
+    padding: 7px 4px;
+  }
+
+  .uploading-row .explorer-row-icon {
+    grid-row: 1 / 3;
+  }
+
+  .uploading-row-name {
+    grid-column: 2;
+    align-self: end;
+    font-size: 15px;
+  }
+
+  .uploading-row-size {
+    display: none;
+  }
+
+  .uploading-row-status {
+    grid-column: 2;
+    align-self: start;
+    justify-content: flex-start;
+    text-align: left;
   }
 
   .explorer-row-name-cell {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -7135,6 +7135,76 @@ html.light {
   cursor: grabbing;
 }
 
+.explorer-drag-preview {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  width: min(320px, calc(100vw - 48px));
+  height: 56px;
+  pointer-events: none;
+  transform: translate(-200%, -200%);
+  isolation: isolate;
+}
+
+.explorer-drag-preview::before,
+.explorer-drag-preview::after {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  bottom: 8px;
+  left: 0;
+  z-index: -1;
+  content: "";
+  border: 1px solid color-mix(in oklab, var(--foreground) 10%, var(--border));
+  border-radius: 8px;
+  background: color-mix(in oklab, var(--card) 94%, var(--accent));
+}
+
+.explorer-drag-preview::before {
+  transform: translate(8px, 8px);
+  opacity: 0.55;
+}
+
+.explorer-drag-preview::after {
+  transform: translate(4px, 4px);
+  opacity: 0.78;
+}
+
+.explorer-drag-preview-row {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  width: calc(100% - 8px);
+  height: 40px;
+  margin-top: 8px;
+  padding: 0 36px 0 4px;
+  overflow: hidden;
+  border: 1px solid color-mix(in oklab, var(--foreground) 14%, var(--border));
+  border-radius: 8px;
+  background: var(--card);
+  color: var(--foreground);
+}
+
+.explorer-drag-preview-count {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: grid;
+  min-width: 24px;
+  height: 24px;
+  padding: 0 6px;
+  place-items: center;
+  border: 2px solid var(--card);
+  border-radius: 999px;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+}
+
 .explorer-row.is-drop-target {
   background: color-mix(in oklab, var(--primary) 13%, var(--card));
   outline: 1px solid color-mix(in oklab, var(--primary) 50%, transparent);

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -7363,26 +7363,7 @@ html.light {
 /* ---- Uploading rows (optimistic) ---- */
 
 .uploading-row {
-  display: grid;
-  grid-template-columns: 28px 1fr 76px 132px;
-  align-items: center;
-  gap: 0 10px;
-  height: 40px;
-  padding: 0 8px 0 4px;
-  border-radius: 8px;
   background: color-mix(in oklab, var(--foreground) 3%, var(--card));
-  margin-bottom: 2px;
-  position: relative;
-}
-
-.uploading-row-name {
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--muted-foreground);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
 }
 
 .uploading-row-status {
@@ -11048,14 +11029,12 @@ main.share-locked-page {
   }
 
   .explorer-row,
-  .uploading-row,
   .explorer-col-header {
     grid-template-columns: 36px minmax(0, 1fr) 104px 170px;
     gap: 0 14px;
   }
 
-  .explorer-row,
-  .uploading-row {
+  .explorer-row {
     height: var(--app-row-height);
     padding: 0 12px 0 8px;
   }
@@ -11395,42 +11374,19 @@ main.share-locked-page {
     touch-action: manipulation;
   }
 
-  .uploading-row {
-    grid-template-columns: 34px minmax(0, 1fr);
-    grid-template-rows: auto auto;
-    min-height: 56px;
-    height: auto;
-    gap: 2px 0;
-    padding: 7px 4px;
-  }
-
-  .uploading-row .explorer-row-icon {
-    grid-row: 1 / 3;
-  }
-
-  .uploading-row-name {
-    grid-column: 2;
-    align-self: end;
-    font-size: 15px;
-  }
-
-  .uploading-row-size {
-    display: none;
-  }
-
-  .uploading-row-status {
-    grid-column: 2;
-    align-self: start;
-    justify-content: flex-start;
-    text-align: left;
-  }
-
   .explorer-row-name-cell {
     grid-column: 2;
   }
 
   .explorer-row-meta {
     display: none;
+  }
+
+  .uploading-row .uploading-row-status {
+    display: flex;
+    grid-column: 3;
+    justify-content: flex-end;
+    text-align: right;
   }
 
   .explorer-row-mobile-action {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3902,6 +3902,14 @@ h3 {
   text-decoration: none;
 }
 
+.workspace-breadcrumbs a.is-drop-target {
+  color: var(--foreground);
+  background: color-mix(in oklab, var(--primary) 12%, transparent);
+  border-radius: 5px;
+  outline: 1px solid color-mix(in oklab, var(--primary) 45%, transparent);
+  outline-offset: 3px;
+}
+
 .workspace-breadcrumbs a::after {
   content: "/";
   padding: 0 7px;
@@ -7117,6 +7125,20 @@ html.light {
 
 .explorer-row.is-selected:hover {
   background: color-mix(in oklab, var(--primary) 10%, var(--card));
+}
+
+.explorer-row[draggable="true"] {
+  cursor: grab;
+}
+
+.explorer-row[draggable="true"]:active {
+  cursor: grabbing;
+}
+
+.explorer-row.is-drop-target {
+  background: color-mix(in oklab, var(--primary) 13%, var(--card));
+  outline: 1px solid color-mix(in oklab, var(--primary) 50%, transparent);
+  outline-offset: -1px;
 }
 
 .explorer-row:focus-visible {

--- a/apps/web/server/batch-move-route.test.ts
+++ b/apps/web/server/batch-move-route.test.ts
@@ -1,0 +1,135 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST } from "@/app/api/files/move/route";
+import { getRequestSession } from "@/server/auth/guards";
+import { FilesError } from "@/server/files/errors";
+import { filesService } from "@/server/files/service";
+
+vi.mock("@/server/auth/guards", () => ({
+  getRequestSession: vi.fn(),
+}));
+
+vi.mock("@/server/files/service", () => ({
+  filesService: {
+    moveFile: vi.fn(),
+    moveFolder: vi.fn(),
+  },
+}));
+
+vi.mock("@/server/retrieval/recent-tracking", () => ({
+  recordFileAccessBestEffort: vi.fn(),
+  recordFolderAccessBestEffort: vi.fn(),
+}));
+
+const request = (body: unknown, origin = "http://localhost:3000") =>
+  new NextRequest("http://localhost:3000/api/files/move", {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+      host: "localhost:3000",
+      origin,
+    },
+    body: JSON.stringify(body),
+  });
+
+describe("batch move route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getRequestSession).mockResolvedValue({
+      user: { id: "user-1", role: "owner" },
+    } as Awaited<ReturnType<typeof getRequestSession>>);
+    vi.mocked(filesService.moveFile).mockResolvedValue({ file: undefined });
+    vi.mocked(filesService.moveFolder).mockResolvedValue({
+      folder: {} as never,
+    });
+  });
+
+  it("moves mixed items and reports per-item success", async () => {
+    const response = await POST(
+      request({
+        destinationFolderId: "folder-destination",
+        items: [
+          { id: "folder-1", kind: "folder" },
+          { id: "file-1", kind: "file" },
+        ],
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      movedCount: 2,
+      failedCount: 0,
+      results: [
+        { id: "folder-1", kind: "folder", status: "moved" },
+        { id: "file-1", kind: "file", status: "moved" },
+      ],
+    });
+    expect(filesService.moveFolder).toHaveBeenCalledWith({
+      actorUserId: "user-1",
+      actorRole: "owner",
+      folderId: "folder-1",
+      destinationFolderId: "folder-destination",
+    });
+    expect(filesService.moveFile).toHaveBeenCalledWith({
+      actorUserId: "user-1",
+      actorRole: "owner",
+      fileId: "file-1",
+      destinationFolderId: "folder-destination",
+    });
+  });
+
+  it("keeps processing after an item fails", async () => {
+    vi.mocked(filesService.moveFolder).mockRejectedValueOnce(
+      new FilesError("FOLDER_MOVE_CYCLE"),
+    );
+
+    const response = await POST(
+      request({
+        destinationFolderId: "folder-destination",
+        items: [
+          { id: "folder-1", kind: "folder" },
+          { id: "file-1", kind: "file" },
+        ],
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      movedCount: 1,
+      failedCount: 1,
+      results: [
+        {
+          id: "folder-1",
+          kind: "folder",
+          status: "failed",
+          code: "FOLDER_MOVE_CYCLE",
+          error:
+            "A folder cannot be moved into itself or one of its descendants.",
+        },
+        { id: "file-1", kind: "file", status: "moved" },
+      ],
+    });
+    expect(filesService.moveFile).toHaveBeenCalledOnce();
+  });
+
+  it("rejects malformed and cross-origin requests", async () => {
+    const malformed = await POST(
+      request({ destinationFolderId: "", items: [] }),
+    );
+    expect(malformed.status).toBe(400);
+
+    const crossOrigin = await POST(
+      request(
+        {
+          destinationFolderId: "folder-destination",
+          items: [{ id: "file-1", kind: "file" }],
+        },
+        "https://evil.example",
+      ),
+    );
+    expect(crossOrigin.status).toBe(403);
+    expect(filesService.moveFile).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/server/files-move-ui.test.ts
+++ b/apps/web/server/files-move-ui.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildBatchMoveFailureMessage,
+  getMoveItemsForInteraction,
+} from "@/app/(workspace)/files/files-move";
+
+const allItems = [
+  { id: "folder-1", kind: "folder" as const },
+  { id: "file-1", kind: "file" as const },
+  { id: "file-2", kind: "file" as const },
+];
+
+describe("file move interactions", () => {
+  it("moves the whole selection when the action starts on a selected row", () => {
+    expect(
+      getMoveItemsForInteraction({
+        allItems,
+        selectedIds: new Set(["folder-1", "file-2"]),
+        target: { id: "folder-1", kind: "folder" },
+      }),
+    ).toEqual([
+      { id: "folder-1", kind: "folder" },
+      { id: "file-2", kind: "file" },
+    ]);
+  });
+
+  it("moves only the target when the action starts outside the selection", () => {
+    expect(
+      getMoveItemsForInteraction({
+        allItems,
+        selectedIds: new Set(["folder-1", "file-2"]),
+        target: { id: "file-1", kind: "file" },
+      }),
+    ).toEqual([{ id: "file-1", kind: "file" }]);
+  });
+
+  it("builds an exact per-item partial-failure summary", () => {
+    expect(
+      buildBatchMoveFailureMessage({
+        response: {
+          movedCount: 1,
+          failedCount: 1,
+          results: [
+            { id: "file-1", kind: "file", status: "moved" },
+            {
+              id: "folder-1",
+              kind: "folder",
+              status: "failed",
+              code: "FOLDER_MOVE_CYCLE",
+              error:
+                "A folder cannot be moved into itself or one of its descendants.",
+            },
+          ],
+        },
+        getItemName: (item) => (item.id === "folder-1" ? "Photos" : item.id),
+      }),
+    ).toBe(
+      "1 moved. 1 failed — Photos: A folder cannot be moved into itself or one of its descendants.",
+    );
+  });
+});

--- a/apps/web/server/files/types.ts
+++ b/apps/web/server/files/types.ts
@@ -53,6 +53,27 @@ export type MoveTarget = {
   isFilesRoot: boolean;
 };
 
+export type BatchMoveItem = {
+  id: string;
+  kind: "file" | "folder";
+};
+
+export type BatchMoveResult =
+  | (BatchMoveItem & {
+      status: "moved";
+    })
+  | (BatchMoveItem & {
+      status: "failed";
+      code: string;
+      error: string;
+    });
+
+export type BatchMoveResponse = {
+  movedCount: number;
+  failedCount: number;
+  results: BatchMoveResult[];
+};
+
 export type FilesListing = {
   ownerUserId: string;
   currentFolder: FolderSummary;


### PR DESCRIPTION
## 🚀 Summary

Fix production favicon packaging, make multi-item moves reliable, add desktop item drag-and-drop, and align upload rows with normal file rows.

## 📊 Impacts and Changes

- Copies `apps/web/public` into the standalone Docker runner so favicon and apple-icon assets are served in production.
- Adds an authenticated, same-origin `POST /api/files/move` batch endpoint with best-effort per-item results.
- Makes Move to, paste, and row drag operations selection-aware; failed items remain selected with exact errors.
- Supports desktop drops onto visible folder rows and ancestor breadcrumbs; rubber-band selection now begins from empty space only.
- Aligns active and resumable upload rows with file-list columns and responsive row geometry.
- No database schema, auth, restore, or migration changes. Storage mutations continue through the existing file and folder move services.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

Manual browser and CasaOS verification is deferred to the merged release-candidate image gate. The local Docker daemon and browser-control runtime were unavailable; automated workspace validation passed.

## 🔗 Linked Issues

None.
