### PR TITLE
fix: show live parallel upload progress

### DIFF
--- a/apps/web/app/(workspace)/transfer-context.tsx
+++ b/apps/web/app/(workspace)/transfer-context.tsx
@@ -21,6 +21,7 @@ import {
   queuedXhrUpload,
 } from "@/lib/transfers/request-queue";
 import {
+  calculateLiveUploadedBytes,
   calculateUploadProgress,
   UploadRateTracker,
 } from "@/lib/transfers/upload-progress";
@@ -152,6 +153,7 @@ const uploadResumableChunk = async ({
   totalSizeBytes,
   buffer,
   signal,
+  onProgress,
 }: {
   sessionId: string;
   startByte: number;
@@ -159,25 +161,31 @@ const uploadResumableChunk = async ({
   totalSizeBytes: number;
   buffer: ArrayBuffer;
   signal: AbortSignal;
+  onProgress?: (loaded: number, total: number) => void;
 }): Promise<{ receivedBytes: number }> => {
-  const response = await queuedFetch(
-    "upload",
-    `/api/uploads/sessions/${sessionId}`,
-    {
-      method: "PATCH",
-      headers: {
-        "Content-Type": "application/octet-stream",
-        "Content-Range": `bytes ${startByte}-${endByte - 1}/${totalSizeBytes}`,
-        Accept: "application/json",
-      },
-      body: buffer,
+  const result = await queuedXhrUpload({
+    url: `/api/uploads/sessions/${sessionId}`,
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/octet-stream",
+      "Content-Range": `bytes ${startByte}-${endByte - 1}/${totalSizeBytes}`,
     },
-    { retries: 3, backoffMs: 500, signal },
-  );
-  if (!response.ok) {
-    throw new Error(await readResponseError(response, "Chunk upload failed"));
+    body: buffer,
+    signal,
+    onProgress,
+    retries: 3,
+    backoffMs: 500,
+  });
+  if (result.status < 200 || result.status >= 300) {
+    let message = "Chunk upload failed";
+    try {
+      message = JSON.parse(result.responseText)?.error ?? message;
+    } catch {
+      /* ignore */
+    }
+    throw new Error(message);
   }
-  return (await response.json()) as { receivedBytes: number };
+  return JSON.parse(result.responseText) as { receivedBytes: number };
 };
 
 const completeResumableUploadSession = async ({
@@ -788,12 +796,37 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
       (total, chunk) => total + chunk.sizeBytes,
       0,
     );
-    let uploadedThisRun = 0;
+    const initialAcknowledgedBytes = acknowledgedBytes;
+    const inFlightChunkBytes = new Map<number, number>();
     const rateTracker = new UploadRateTracker();
     const pipelineController = new AbortController();
     const abortPipeline = () => pipelineController.abort();
     signal.addEventListener("abort", abortPipeline, { once: true });
     const taskPool = new UploadTaskPool(PARALLEL_UPLOAD_CHUNKS, abortPipeline);
+    const publishParallelProgress = () => {
+      const transferredBytes = calculateLiveUploadedBytes(
+        acknowledgedBytes,
+        inFlightChunkBytes.values(),
+        file.size,
+      );
+      const speed = rateTracker.record(
+        transferredBytes - initialAcknowledgedBytes,
+      );
+      setUploadingFiles((prev) =>
+        prev.map((f) =>
+          f.clientKey === clientKey
+            ? {
+                ...f,
+                progress: calculateUploadProgress(transferredBytes, file.size),
+                transferredBytes,
+                speed,
+                resumeHint: undefined,
+                statusLabel: undefined,
+              }
+            : f,
+        ),
+      );
+    };
 
     try {
       const hasher = await createFileSha256Hasher();
@@ -813,35 +846,27 @@ export function TransferProvider({ children }: { children: React.ReactNode }) {
         if (completedIndexes.has(chunkIndex)) continue;
 
         taskPool.start(async () => {
-          await uploadResumableChunk({
-            sessionId,
-            startByte,
-            endByte,
-            totalSizeBytes: file.size,
-            buffer,
-            signal: pipelineController.signal,
-          });
+          try {
+            await uploadResumableChunk({
+              sessionId,
+              startByte,
+              endByte,
+              totalSizeBytes: file.size,
+              buffer,
+              signal: pipelineController.signal,
+              onProgress: (loaded) => {
+                inFlightChunkBytes.set(chunkIndex, loaded);
+                publishParallelProgress();
+              },
+            });
 
-          acknowledgedBytes += buffer.byteLength;
-          uploadedThisRun += buffer.byteLength;
-          const speed = rateTracker.record(uploadedThisRun);
-          setUploadingFiles((prev) =>
-            prev.map((f) =>
-              f.clientKey === clientKey
-                ? {
-                    ...f,
-                    progress: calculateUploadProgress(
-                      acknowledgedBytes,
-                      file.size,
-                    ),
-                    transferredBytes: acknowledgedBytes,
-                    speed,
-                    resumeHint: undefined,
-                    statusLabel: undefined,
-                  }
-                : f,
-            ),
-          );
+            inFlightChunkBytes.delete(chunkIndex);
+            acknowledgedBytes += buffer.byteLength;
+            publishParallelProgress();
+          } catch (error) {
+            inFlightChunkBytes.delete(chunkIndex);
+            throw error;
+          }
         });
       }
       await taskPool.drain();

--- a/apps/web/lib/transfers/request-queue.ts
+++ b/apps/web/lib/transfers/request-queue.ts
@@ -191,38 +191,47 @@ export function queuedXhrUpload(
 ): Promise<XhrUploadResult> {
   return withTransferSlot(
     "upload",
-    async () => {
-      const retries = opts.retries ?? 0;
-      const backoffMs = opts.backoffMs ?? DEFAULT_BACKOFF_MS;
-      let attempt = 0;
-
-      for (;;) {
-        throwIfAborted(opts.signal);
-
-        let result: XhrUploadResult;
-        try {
-          result = await runXhrUpload(opts);
-        } catch (error) {
-          if (opts.signal?.aborted) throw error;
-          if (!(error instanceof TypeError) || attempt >= retries) {
-            throw error;
-          }
-          await delay(backoffFor(backoffMs, attempt), opts.signal);
-          attempt++;
-          continue;
-        }
-
-        const retryable = result.status >= 500 && result.status < 600;
-        if (retryable && attempt < retries) {
-          await delay(backoffFor(backoffMs, attempt), opts.signal);
-          attempt++;
-          continue;
-        }
-        return result;
-      }
-    },
+    () => runXhrUploadWithRetry(opts),
     opts.signal,
   );
+}
+
+async function runXhrUploadWithRetry(
+  opts: XhrUploadOptions,
+  attempt = 0,
+): Promise<XhrUploadResult> {
+  throwIfAborted(opts.signal);
+  const retries = opts.retries ?? 0;
+
+  try {
+    const result = await runXhrUpload(opts);
+    if (!shouldRetryXhrStatus(result.status, attempt, retries)) return result;
+  } catch (error) {
+    if (!shouldRetryXhrError(error, opts.signal, attempt, retries)) throw error;
+  }
+
+  await delay(
+    backoffFor(opts.backoffMs ?? DEFAULT_BACKOFF_MS, attempt),
+    opts.signal,
+  );
+  return runXhrUploadWithRetry(opts, attempt + 1);
+}
+
+function shouldRetryXhrStatus(
+  status: number,
+  attempt: number,
+  retries: number,
+) {
+  return status >= 500 && status < 600 && attempt < retries;
+}
+
+function shouldRetryXhrError(
+  error: unknown,
+  signal: AbortSignal | undefined,
+  attempt: number,
+  retries: number,
+) {
+  return !signal?.aborted && error instanceof TypeError && attempt < retries;
 }
 
 function runXhrUpload(opts: XhrUploadOptions): Promise<XhrUploadResult> {

--- a/apps/web/lib/transfers/request-queue.ts
+++ b/apps/web/lib/transfers/request-queue.ts
@@ -172,10 +172,13 @@ export function queuedFetch(
 
 export type XhrUploadOptions = {
   url: string;
+  method?: string;
   body: XMLHttpRequestBodyInit | Document;
   signal?: AbortSignal;
   onProgress?: (loaded: number, total: number) => void;
   headers?: Record<string, string>;
+  retries?: number;
+  backoffMs?: number;
 };
 
 export type XhrUploadResult = {
@@ -188,45 +191,77 @@ export function queuedXhrUpload(
 ): Promise<XhrUploadResult> {
   return withTransferSlot(
     "upload",
-    () =>
-      new Promise<XhrUploadResult>((resolve, reject) => {
-        if (opts.signal?.aborted) {
-          reject(abortError());
-          return;
-        }
-        const xhr = new XMLHttpRequest();
-        const onAbort = () => xhr.abort();
-        opts.signal?.addEventListener("abort", onAbort, { once: true });
+    async () => {
+      const retries = opts.retries ?? 0;
+      const backoffMs = opts.backoffMs ?? DEFAULT_BACKOFF_MS;
+      let attempt = 0;
 
-        xhr.upload.onprogress = (ev) => {
-          if (ev.lengthComputable && opts.onProgress) {
-            opts.onProgress(ev.loaded, ev.total);
-          }
-        };
-        xhr.onload = () => {
-          opts.signal?.removeEventListener("abort", onAbort);
-          resolve({ status: xhr.status, responseText: xhr.responseText });
-        };
-        xhr.onerror = () => {
-          opts.signal?.removeEventListener("abort", onAbort);
-          reject(new TypeError("Network request failed"));
-        };
-        xhr.onabort = () => {
-          opts.signal?.removeEventListener("abort", onAbort);
-          reject(abortError());
-        };
+      for (;;) {
+        throwIfAborted(opts.signal);
 
-        xhr.open("POST", opts.url);
-        xhr.setRequestHeader("Accept", "application/json");
-        if (opts.headers) {
-          for (const [k, v] of Object.entries(opts.headers)) {
-            xhr.setRequestHeader(k, v);
+        let result: XhrUploadResult;
+        try {
+          result = await runXhrUpload(opts);
+        } catch (error) {
+          if (opts.signal?.aborted) throw error;
+          if (!(error instanceof TypeError) || attempt >= retries) {
+            throw error;
           }
+          await delay(backoffFor(backoffMs, attempt), opts.signal);
+          attempt++;
+          continue;
         }
-        xhr.send(opts.body);
-      }),
+
+        const retryable = result.status >= 500 && result.status < 600;
+        if (retryable && attempt < retries) {
+          await delay(backoffFor(backoffMs, attempt), opts.signal);
+          attempt++;
+          continue;
+        }
+        return result;
+      }
+    },
     opts.signal,
   );
+}
+
+function runXhrUpload(opts: XhrUploadOptions): Promise<XhrUploadResult> {
+  return new Promise<XhrUploadResult>((resolve, reject) => {
+    if (opts.signal?.aborted) {
+      reject(abortError());
+      return;
+    }
+    const xhr = new XMLHttpRequest();
+    const onAbort = () => xhr.abort();
+    opts.signal?.addEventListener("abort", onAbort, { once: true });
+
+    xhr.upload.onprogress = (ev) => {
+      if (ev.lengthComputable && opts.onProgress) {
+        opts.onProgress(ev.loaded, ev.total);
+      }
+    };
+    xhr.onload = () => {
+      opts.signal?.removeEventListener("abort", onAbort);
+      resolve({ status: xhr.status, responseText: xhr.responseText });
+    };
+    xhr.onerror = () => {
+      opts.signal?.removeEventListener("abort", onAbort);
+      reject(new TypeError("Network request failed"));
+    };
+    xhr.onabort = () => {
+      opts.signal?.removeEventListener("abort", onAbort);
+      reject(abortError());
+    };
+
+    xhr.open(opts.method ?? "POST", opts.url);
+    xhr.setRequestHeader("Accept", "application/json");
+    if (opts.headers) {
+      for (const [k, v] of Object.entries(opts.headers)) {
+        xhr.setRequestHeader(k, v);
+      }
+    }
+    xhr.send(opts.body);
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/lib/transfers/upload-progress.ts
+++ b/apps/web/lib/transfers/upload-progress.ts
@@ -43,3 +43,17 @@ export const calculateUploadProgress = (
   totalBytes > 0
     ? Math.min(100, Math.round((acknowledgedBytes / totalBytes) * 100))
     : 100;
+
+export const calculateLiveUploadedBytes = (
+  acknowledgedBytes: number,
+  inFlightChunkBytes: Iterable<number>,
+  totalBytes: number,
+) =>
+  Math.min(
+    totalBytes,
+    acknowledgedBytes +
+      Array.from(inFlightChunkBytes).reduce(
+        (total, chunkBytes) => total + chunkBytes,
+        0,
+      ),
+  );

--- a/apps/web/server/request-queue.test.ts
+++ b/apps/web/server/request-queue.test.ts
@@ -4,6 +4,7 @@ import { queuedXhrUpload } from "@/lib/transfers/request-queue";
 
 class MockXMLHttpRequest {
   static instances: MockXMLHttpRequest[] = [];
+  static responses: Array<{ status: number; responseText: string }> = [];
 
   upload: Pick<XMLHttpRequestUpload, "onprogress"> = { onprogress: null };
   onload: XMLHttpRequest["onload"] = null;
@@ -29,6 +30,11 @@ class MockXMLHttpRequest {
   }
 
   send() {
+    const response = MockXMLHttpRequest.responses.shift();
+    if (response) {
+      this.status = response.status;
+      this.responseText = response.responseText;
+    }
     const onProgress = this.upload.onprogress as
       ((event: ProgressEvent) => void) | null;
     const onLoad = this.onload as ((event: ProgressEvent) => void) | null;
@@ -50,7 +56,9 @@ const originalXMLHttpRequest = globalThis.XMLHttpRequest;
 
 afterEach(() => {
   MockXMLHttpRequest.instances = [];
+  MockXMLHttpRequest.responses = [];
   globalThis.XMLHttpRequest = originalXMLHttpRequest;
+  vi.restoreAllMocks();
 });
 
 describe("queuedXhrUpload", () => {
@@ -76,5 +84,26 @@ describe("queuedXhrUpload", () => {
       status: 200,
       responseText: '{"receivedBytes":10}',
     });
+  });
+
+  it("retries server failures without leaving the upload lane", async () => {
+    globalThis.XMLHttpRequest =
+      MockXMLHttpRequest as unknown as typeof XMLHttpRequest;
+    MockXMLHttpRequest.responses = [
+      { status: 503, responseText: '{"error":"unavailable"}' },
+      { status: 200, responseText: '{"receivedBytes":10}' },
+    ];
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    const result = await queuedXhrUpload({
+      url: "/api/uploads/sessions/session-1",
+      method: "PATCH",
+      body: new ArrayBuffer(10),
+      retries: 1,
+      backoffMs: 0,
+    });
+
+    expect(MockXMLHttpRequest.instances).toHaveLength(2);
+    expect(result.status).toBe(200);
   });
 });

--- a/apps/web/server/request-queue.test.ts
+++ b/apps/web/server/request-queue.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { queuedXhrUpload } from "@/lib/transfers/request-queue";
+
+class MockXMLHttpRequest {
+  static instances: MockXMLHttpRequest[] = [];
+
+  upload: Pick<XMLHttpRequestUpload, "onprogress"> = { onprogress: null };
+  onload: XMLHttpRequest["onload"] = null;
+  onerror: XMLHttpRequest["onerror"] = null;
+  onabort: XMLHttpRequest["onabort"] = null;
+  status = 200;
+  responseText = '{"receivedBytes":10}';
+  method = "";
+  url = "";
+  headers = new Map<string, string>();
+
+  constructor() {
+    MockXMLHttpRequest.instances.push(this);
+  }
+
+  open(method: string, url: string) {
+    this.method = method;
+    this.url = url;
+  }
+
+  setRequestHeader(name: string, value: string) {
+    this.headers.set(name, value);
+  }
+
+  send() {
+    const onProgress = this.upload.onprogress as
+      ((event: ProgressEvent) => void) | null;
+    const onLoad = this.onload as ((event: ProgressEvent) => void) | null;
+    onProgress?.({
+      lengthComputable: true,
+      loaded: 5,
+      total: 10,
+    } as ProgressEvent);
+    onLoad?.({} as ProgressEvent);
+  }
+
+  abort() {
+    const onAbort = this.onabort as ((event: ProgressEvent) => void) | null;
+    onAbort?.({} as ProgressEvent);
+  }
+}
+
+const originalXMLHttpRequest = globalThis.XMLHttpRequest;
+
+afterEach(() => {
+  MockXMLHttpRequest.instances = [];
+  globalThis.XMLHttpRequest = originalXMLHttpRequest;
+});
+
+describe("queuedXhrUpload", () => {
+  it("supports PATCH requests and reports live upload progress", async () => {
+    globalThis.XMLHttpRequest =
+      MockXMLHttpRequest as unknown as typeof XMLHttpRequest;
+    const onProgress = vi.fn();
+
+    const result = await queuedXhrUpload({
+      url: "/api/uploads/sessions/session-1",
+      method: "PATCH",
+      body: new ArrayBuffer(10),
+      headers: { "Content-Range": "bytes 0-9/10" },
+      onProgress,
+    });
+
+    const xhr = MockXMLHttpRequest.instances[0];
+    expect(xhr.method).toBe("PATCH");
+    expect(xhr.url).toBe("/api/uploads/sessions/session-1");
+    expect(xhr.headers.get("Content-Range")).toBe("bytes 0-9/10");
+    expect(onProgress).toHaveBeenCalledWith(5, 10);
+    expect(result).toEqual({
+      status: 200,
+      responseText: '{"receivedBytes":10}',
+    });
+  });
+});

--- a/apps/web/server/upload-progress.test.ts
+++ b/apps/web/server/upload-progress.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  calculateLiveUploadedBytes,
   calculateUploadProgress,
   UploadRateTracker,
 } from "@/lib/transfers/upload-progress";
@@ -18,5 +19,10 @@ describe("upload progress", () => {
     expect(tracker.record(10_000, 1_000)).toBe(10_000);
     expect(tracker.record(30_000, 3_000)).toBe(10_000);
     expect(tracker.record(90_000, 9_000)).toBe(10_000);
+  });
+
+  it("includes live bytes from parallel chunks without exceeding file size", () => {
+    expect(calculateLiveUploadedBytes(20, [10, 15, 5], 100)).toBe(50);
+    expect(calculateLiveUploadedBytes(90, [10, 15], 100)).toBe(100);
   });
 });


### PR DESCRIPTION
## 🚀 Summary

Show live progress and transfer speed while parallel upload chunks are still being sent, instead of updating only after each 10 MiB chunk receives a server acknowledgment.

## 📊 Impacts and Changes

- Parallel chunk PATCH requests now use the existing queued XHR transport so browser upload progress events are available.
- Progress combines acknowledged bytes with bytes currently being transmitted across all three active chunks.
- Speed updates continuously during each chunk instead of appearing frozen between acknowledgments.
- Existing three-request concurrency, abort handling, and retry backoff remain intact.
- No schema, auth, storage format, or restore behavior changes.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [ ] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

Manual verification requires a real large-file browser upload and is deferred to the release-candidate CasaOS test.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

Verify a file larger than 100 MiB through the CasaOS release candidate and confirm the progress bar and speed text update continuously while each three-chunk batch is in flight.

## 🔗 Linked Issues

None.
