### PR TITLE
Fix app version and update checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,33 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Verify release versions
+        shell: bash
+        run: |
+          node <<'NODE'
+          const fs = require("node:fs");
+
+          const tagVersion = process.env.GITHUB_REF_NAME.replace(/^v/, "");
+          const packageFiles = [
+            "package.json",
+            "apps/web/package.json",
+            "apps/worker/package.json",
+            "packages/config/package.json",
+            "packages/db/package.json",
+          ];
+          const mismatches = packageFiles.flatMap((file) => {
+            const version = JSON.parse(fs.readFileSync(file, "utf8")).version;
+            return version === tagVersion
+              ? []
+              : [`${file} has ${version}; expected ${tagVersion}`];
+          });
+
+          if (mismatches.length > 0) {
+            console.error(mismatches.join("\n"));
+            process.exit(1);
+          }
+          NODE
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 

--- a/apps/web/app/(workspace)/instance-badge.tsx
+++ b/apps/web/app/(workspace)/instance-badge.tsx
@@ -1,15 +1,19 @@
 "use client";
 
 import { ExternalLink } from "lucide-react";
+import { formatVersionLabel } from "@staaash/config/version";
+
 import {
   Dialog,
   DialogContent,
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-
-type UpdateStatus =
-  "up-to-date" | "update-available" | "unavailable" | "error" | null;
+import {
+  getUpdateStatusDotClassName,
+  getUpdateStatusLabel,
+  type UpdateStatus,
+} from "@/lib/update-status";
 
 type InstanceBadgeProps = {
   appVersion: string;
@@ -20,13 +24,7 @@ type InstanceBadgeProps = {
 };
 
 function StatusDot({ status }: { status: UpdateStatus }) {
-  const cls =
-    status === "update-available"
-      ? "instance-dot instance-dot--update"
-      : status === "error"
-        ? "instance-dot instance-dot--error"
-        : "instance-dot instance-dot--online";
-  return <span className={cls} aria-hidden />;
+  return <span className={getUpdateStatusDotClassName(status)} aria-hidden />;
 }
 
 export function InstanceBadge({
@@ -36,14 +34,8 @@ export function InstanceBadge({
   latestVersion,
   repository,
 }: InstanceBadgeProps) {
-  const updateLabel =
-    updateStatus === "up-to-date"
-      ? "Up to date"
-      : updateStatus === "update-available"
-        ? `v${latestVersion} available`
-        : updateStatus === "error"
-          ? "Check failed"
-          : "Not checked";
+  const updateLabel = getUpdateStatusLabel(updateStatus, latestVersion);
+  const versionLabel = formatVersionLabel(appVersion);
 
   const releaseUrl = repository
     ? `https://github.com/${repository}/releases`
@@ -53,7 +45,7 @@ export function InstanceBadge({
     <Dialog>
       <DialogTrigger className="instance-badge-trigger">
         <StatusDot status={updateStatus} />
-        <span className="instance-badge-version">v{appVersion}</span>
+        <span className="instance-badge-version">{versionLabel}</span>
       </DialogTrigger>
       <DialogContent className="instance-about-dialog">
         <div className="instance-dialog-header">
@@ -66,7 +58,7 @@ export function InstanceBadge({
         <dl className="instance-badge-dl">
           <div className="instance-badge-row">
             <dt>Version</dt>
-            <dd>v{appVersion}</dd>
+            <dd>{versionLabel}</dd>
           </div>
           <div className="instance-badge-row">
             <dt>Runtime</dt>

--- a/apps/web/app/(workspace)/topbar-actions.tsx
+++ b/apps/web/app/(workspace)/topbar-actions.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef } from "react";
+import { formatVersionLabel } from "@staaash/config/version";
 import {
   Upload,
   Sun,
@@ -118,7 +119,9 @@ export function TopbarActions({
           {hasUpdate ? (
             <div className="topbar-notif-item">
               <span className="topbar-notif-title">
-                v{latestVersion} available
+                {latestVersion
+                  ? `${formatVersionLabel(latestVersion)} available`
+                  : "Update available"}
               </span>
               {releaseUrl && (
                 <a

--- a/apps/web/app/admin/admin-format.ts
+++ b/apps/web/app/admin/admin-format.ts
@@ -42,11 +42,13 @@ export const getAdminStatusClassName = (status: string) =>
         : status === "warning" ||
             status === "accepted" ||
             status === "update-available" ||
-            status === "unavailable" ||
             status === "queued" ||
             status === "stale"
           ? "status-warning"
-          : status === "idle" || status === "stopped"
+          : status === "idle" ||
+              status === "stopped" ||
+              status === "unavailable" ||
+              status === "not checked"
             ? "status-muted"
             : status === "cancelled"
               ? "status-cancelled"

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { formatVersionLabel } from "@staaash/config/version";
 
 import {
   formatAdminBytes,
@@ -6,6 +7,7 @@ import {
 } from "@/app/admin/admin-format";
 import { requireAdminPageSession } from "@/server/auth/guards";
 import { getAdminOverviewSummary } from "@/server/admin/overview";
+import { getUpdateStatusLabel } from "@/lib/update-status";
 
 export const dynamic = "force-dynamic";
 
@@ -13,7 +15,11 @@ export default async function AdminOverviewPage() {
   const session = await requireAdminPageSession();
   const summary = await getAdminOverviewSummary(session.user.id);
 
-  const updateStatus = summary.updates.updateCheckStatus ?? "not checked";
+  const updateStatus = summary.updates.updateCheckStatus;
+  const updateStatusLabel = getUpdateStatusLabel(
+    updateStatus,
+    summary.updates.latestAvailableVersion,
+  );
   const retainedBytes = formatAdminBytes(summary.storage.retainedBytes);
   const failedWork = summary.jobs.failed + summary.jobs.dead;
   const activeWork = summary.jobs.queued + summary.jobs.running;
@@ -40,10 +46,10 @@ export default async function AdminOverviewPage() {
     {
       href: "/admin/settings",
       label: "Version",
-      value: summary.updates.currentVersion ?? "n/a",
+      value: formatVersionLabel(summary.updates.currentVersion),
       detail: summary.updates.latestAvailableVersion
-        ? `Latest ${summary.updates.latestAvailableVersion}`
-        : updateStatus,
+        ? `Latest ${formatVersionLabel(summary.updates.latestAvailableVersion)}`
+        : updateStatusLabel,
     },
   ];
 
@@ -168,7 +174,7 @@ export default async function AdminOverviewPage() {
           <section className="admin-overview-rail-card">
             <div className="admin-overview-panel-head">
               <h2>Updates</h2>
-              <p>{updateStatus}</p>
+              <p>{updateStatusLabel}</p>
             </div>
             <p>
               {summary.updates.updateCheckMessage ??

--- a/apps/web/app/admin/settings/settings-form.tsx
+++ b/apps/web/app/admin/settings/settings-form.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import { SearchIcon } from "lucide-react";
 
+import { formatVersionLabel } from "@staaash/config/version";
 import type { SystemSettings } from "@staaash/db/client";
 
 import {
@@ -19,6 +20,7 @@ import {
 } from "@/app/admin/admin-format";
 import { SettingsPanel } from "@/components/settings-panel";
 import { TimeZonePicker } from "@/components/time-zone-picker";
+import { getUpdateStatusLabel } from "@/lib/update-status";
 import type { JsonAdminUpdateStatus } from "@/server/admin/types";
 
 import { updateSystemSettings } from "./actions";
@@ -204,21 +206,25 @@ export function SettingsForm({ settings, updateStatus }: SettingsFormProps) {
           <dl className="settings-list settings-update-list">
             <SettingRow label="Current version">
               <span className="settings-row-value-text">
-                {updateStatus.currentVersion ?? "n/a"}
+                {updateStatus.currentVersion
+                  ? formatVersionLabel(updateStatus.currentVersion)
+                  : "n/a"}
               </span>
             </SettingRow>
             <SettingRow label="Latest published">
               <span className="settings-row-value-text">
-                {updateStatus.latestAvailableVersion ?? "n/a"}
+                {updateStatus.latestAvailableVersion
+                  ? formatVersionLabel(updateStatus.latestAvailableVersion)
+                  : "n/a"}
               </span>
             </SettingRow>
             <SettingRow label="Check status">
               <span
                 className={getAdminStatusClassName(
-                  updateStatus.updateCheckStatus ?? "error",
+                  updateStatus.updateCheckStatus ?? "not checked",
                 )}
               >
-                {updateStatus.updateCheckStatus ?? "not checked"}
+                {getUpdateStatusLabel(updateStatus.updateCheckStatus)}
               </span>
             </SettingRow>
             <SettingRow label="Last checked">

--- a/apps/web/app/admin/update-check-console.tsx
+++ b/apps/web/app/admin/update-check-console.tsx
@@ -3,38 +3,57 @@
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 
+import { waitForUpdateCheck } from "@/lib/update-check-client";
+
 export function UpdateCheckConsole() {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+  const [checking, setChecking] = useState(false);
 
   const handleCheckNow = async () => {
     setError(null);
     setSuccess(null);
+    setChecking(true);
 
-    const response = await fetch("/api/admin/updates/check", {
-      method: "POST",
-      headers: {
-        Accept: "application/json",
-      },
-    });
+    try {
+      const response = await fetch("/api/admin/updates/check", {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+        },
+      });
 
-    if (!response.ok) {
-      try {
-        const body = (await response.json()) as { error?: string };
-        setError(body.error ?? "Request failed.");
-      } catch {
-        setError("Request failed.");
+      if (!response.ok) {
+        let message = "Request failed.";
+        try {
+          const body = (await response.json()) as { error?: string };
+          message = body.error ?? message;
+        } catch {}
+        throw new Error(message);
       }
-      return;
-    }
 
-    const body = (await response.json()) as { message?: string };
-    setSuccess(body.message ?? "Update check queued.");
-    startTransition(() => {
-      router.refresh();
-    });
+      const body = (await response.json()) as { jobId: string };
+      setSuccess("Checking for updates…");
+
+      const result = await waitForUpdateCheck({ jobId: body.jobId });
+      setSuccess(
+        result.updateStatus.updateCheckMessage ?? "Update check completed.",
+      );
+      startTransition(() => {
+        router.refresh();
+      });
+    } catch (requestError) {
+      setSuccess(null);
+      setError(
+        requestError instanceof Error
+          ? requestError.message
+          : "Update check failed.",
+      );
+    } finally {
+      setChecking(false);
+    }
   };
 
   return (
@@ -43,11 +62,11 @@ export function UpdateCheckConsole() {
       {success ? <div className="banner banner-success">{success}</div> : null}
       <button
         className="button"
-        disabled={isPending}
+        disabled={checking || isPending}
         onClick={handleCheckNow}
         type="button"
       >
-        Check now
+        {checking || isPending ? "Checking…" : "Check now"}
       </button>
     </div>
   );

--- a/apps/web/app/api/admin/updates/check/route.ts
+++ b/apps/web/app/api/admin/updates/check/route.ts
@@ -1,8 +1,44 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { enforceSameOrigin, requireOwnerApiSession } from "@/server/admin/http";
-import { enqueueAdminUpdateCheck } from "@/server/admin/updates";
+import {
+  enqueueAdminUpdateCheck,
+  getAdminUpdateCheckJob,
+  getAdminUpdateStatus,
+  toJsonAdminUpdateStatus,
+} from "@/server/admin/updates";
 
+export async function GET(request: NextRequest) {
+  const auth = await requireOwnerApiSession(request);
+
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const jobId = request.nextUrl.searchParams.get("jobId")?.trim();
+  if (!jobId) {
+    return NextResponse.json({ error: "jobId is required." }, { status: 400 });
+  }
+
+  const job = await getAdminUpdateCheckJob(jobId);
+  if (!job) {
+    return NextResponse.json(
+      { error: "Update check job not found." },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json({
+    job: {
+      id: job.id,
+      status: job.status,
+      lastError: job.lastError,
+    },
+    updateStatus: toJsonAdminUpdateStatus(await getAdminUpdateStatus()),
+  });
+}
+
+// fallow-ignore-next-line code-duplication
 export async function POST(request: NextRequest) {
   const sameOriginError = enforceSameOrigin(request);
 

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2971,6 +2971,11 @@ h3 {
   background: oklch(60% 0.2 27);
 }
 
+.instance-dot--muted {
+  background: var(--muted-foreground);
+  opacity: 0.65;
+}
+
 /* About dialog — overrides shadcn DialogContent defaults */
 .instance-about-dialog {
   max-width: 420px !important;

--- a/apps/web/lib/update-check-client.ts
+++ b/apps/web/lib/update-check-client.ts
@@ -1,0 +1,83 @@
+import type { JsonAdminUpdateStatus } from "@/server/admin/types";
+
+type UpdateCheckJobStatus =
+  "queued" | "running" | "succeeded" | "failed" | "dead" | "cancelled";
+
+export type UpdateCheckPollResponse = {
+  job: {
+    id: string;
+    status: UpdateCheckJobStatus;
+    lastError: string | null;
+  };
+  updateStatus: JsonAdminUpdateStatus;
+};
+
+const readResponseError = async (response: Response) => {
+  try {
+    const body = (await response.json()) as { error?: string };
+    return body.error ?? "Update check status request failed.";
+  } catch {
+    return "Update check status request failed.";
+  }
+};
+
+const fetchUpdateCheckStatus = async (
+  jobId: string,
+  fetchStatus: typeof fetch,
+) => {
+  const response = await fetchStatus(
+    `/api/admin/updates/check?jobId=${encodeURIComponent(jobId)}`,
+    {
+      cache: "no-store",
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(await readResponseError(response));
+  }
+
+  return (await response.json()) as UpdateCheckPollResponse;
+};
+
+const readCompletedUpdateCheck = (body: UpdateCheckPollResponse) => {
+  if (body.job.status === "succeeded") return body;
+
+  if (["failed", "dead", "cancelled"].includes(body.job.status)) {
+    throw new Error(body.job.lastError ?? `Update check ${body.job.status}.`);
+  }
+
+  return null;
+};
+
+export const waitForUpdateCheck = async ({
+  jobId,
+  fetchStatus = fetch,
+  intervalMs = 1000,
+  maxAttempts = 60,
+  wait = (durationMs: number) =>
+    new Promise<void>((resolve) => setTimeout(resolve, durationMs)),
+}: {
+  jobId: string;
+  fetchStatus?: typeof fetch;
+  intervalMs?: number;
+  maxAttempts?: number;
+  wait?: (durationMs: number) => Promise<void>;
+}): Promise<UpdateCheckPollResponse> => {
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const body = await fetchUpdateCheckStatus(jobId, fetchStatus);
+    const completed = readCompletedUpdateCheck(body);
+    if (completed) return completed;
+
+    if (attempt < maxAttempts - 1) {
+      await wait(intervalMs);
+    }
+  }
+
+  throw new Error(
+    "Update check is still running. Refresh this page to view its result.",
+  );
+};

--- a/apps/web/lib/update-status.ts
+++ b/apps/web/lib/update-status.ts
@@ -1,0 +1,37 @@
+import { formatVersionLabel } from "@staaash/config/version";
+
+export type UpdateStatus =
+  "up-to-date" | "update-available" | "unavailable" | "error" | null;
+
+export const getUpdateStatusLabel = (
+  status: UpdateStatus,
+  latestVersion: string | null = null,
+) => {
+  switch (status) {
+    case "up-to-date":
+      return "Up to date";
+    case "update-available":
+      return latestVersion
+        ? `${formatVersionLabel(latestVersion)} available`
+        : "Update available";
+    case "unavailable":
+      return "Unavailable";
+    case "error":
+      return "Check failed";
+    default:
+      return "Not checked";
+  }
+};
+
+export const getUpdateStatusDotClassName = (status: UpdateStatus) => {
+  switch (status) {
+    case "up-to-date":
+      return "instance-dot instance-dot--online";
+    case "update-available":
+      return "instance-dot instance-dot--update";
+    case "error":
+      return "instance-dot instance-dot--error";
+    default:
+      return "instance-dot instance-dot--muted";
+  }
+};

--- a/apps/web/server/admin/updates.ts
+++ b/apps/web/server/admin/updates.ts
@@ -1,11 +1,11 @@
 import {
   ensureBackgroundJobScheduled,
+  findBackgroundJobById,
   UPDATE_CHECK_JOB_KIND,
 } from "@staaash/db/jobs";
 import { readInstanceUpdateCheck } from "@staaash/db/instance";
 
-import { version as packageVersion } from "../../package.json";
-
+import { resolveAppVersion } from "@/server/app-version";
 import { getSystemSettings } from "@/server/settings";
 
 import type { AdminUpdateStatus, JsonAdminUpdateStatus } from "./types";
@@ -20,9 +20,7 @@ export const getAdminUpdateStatus = async (): Promise<AdminUpdateStatus> => {
     currentVersion:
       process.env.NODE_ENV !== "production"
         ? "development"
-        : (process.env.STAAASH_VERSION ??
-          process.env.APP_VERSION ??
-          packageVersion),
+        : resolveAppVersion(),
     repository: settings.updateCheckRepository || null,
     lastUpdateCheckAt: state.lastUpdateCheckAt,
     updateCheckStatus: state.updateCheckStatus,
@@ -41,6 +39,11 @@ export const enqueueAdminUpdateCheck = async (now = new Date()) =>
     windowEnd: now,
     now,
   });
+
+export const getAdminUpdateCheckJob = async (jobId: string) => {
+  const job = await findBackgroundJobById({ jobId });
+  return job?.kind === UPDATE_CHECK_JOB_KIND ? job : null;
+};
 
 export const toJsonAdminUpdateStatus = (
   status: AdminUpdateStatus,

--- a/apps/web/server/app-version.test.ts
+++ b/apps/web/server/app-version.test.ts
@@ -5,15 +5,15 @@ import { version as packageVersion } from "../package.json";
 import { resolveAppVersion } from "./app-version";
 
 describe("resolveAppVersion", () => {
-  it("prefers the explicit Staaash version override", () => {
-    expect(resolveAppVersion("1.2.3", "2.0.0")).toBe("1.2.3");
+  it("uses a valid app version override", () => {
+    expect(resolveAppVersion("2.0.0")).toBe("2.0.0");
   });
 
-  it("uses the app version override when the Staaash version is unset", () => {
-    expect(resolveAppVersion(undefined, "2.0.0")).toBe("2.0.0");
+  it("ignores moving tag aliases", () => {
+    expect(resolveAppVersion("latest")).toBe(packageVersion);
   });
 
-  it("falls back to the package version", () => {
-    expect(resolveAppVersion(undefined, undefined)).toBe(packageVersion);
+  it("falls back to packaged version", () => {
+    expect(resolveAppVersion(undefined)).toBe(packageVersion);
   });
 });

--- a/apps/web/server/app-version.ts
+++ b/apps/web/server/app-version.ts
@@ -1,6 +1,6 @@
 import { version as packageVersion } from "../package.json";
+import { resolveRuntimeVersion } from "@staaash/config/version";
 
 export const resolveAppVersion = (
-  staaashVersion: string | undefined = process.env.STAAASH_VERSION,
   appVersion: string | undefined = process.env.APP_VERSION,
-) => staaashVersion ?? appVersion ?? packageVersion;
+) => resolveRuntimeVersion({ packageVersion, appVersion });

--- a/apps/web/server/health.ts
+++ b/apps/web/server/health.ts
@@ -9,8 +9,7 @@ import { readInstanceUpdateCheck } from "@staaash/db/instance";
 import { listWorkerInstances } from "@staaash/db/jobs";
 import { readLatestRestoreReconciliationRun } from "@staaash/db/reconciliation";
 
-import { version as packageVersion } from "../package.json";
-
+import { resolveAppVersion } from "@/server/app-version";
 import { getSystemSettings } from "@/server/settings";
 import { buildRestoreReconciliationHealthSummary } from "@/server/restore";
 import {
@@ -63,6 +62,7 @@ const toStorageWarningSummary = (
   };
 };
 
+// fallow-ignore-next-line unused-export
 export const getWorkerHeartbeatStatus = (
   lastSeenAt: Date | null,
   now = new Date(),
@@ -145,6 +145,7 @@ const writeWorkerHeartbeat = async (timestamp = new Date()) => {
   );
 };
 
+// fallow-ignore-next-line unused-export
 export const buildInstanceHealthSummary = ({
   databaseStatus,
   databaseMessage,
@@ -241,9 +242,7 @@ export const getReadiness = async () => {
       currentVersion:
         process.env.NODE_ENV !== "production"
           ? "development"
-          : (process.env.STAAASH_VERSION ??
-            process.env.APP_VERSION ??
-            packageVersion),
+          : resolveAppVersion(),
       lastUpdateCheckAt:
         instanceState?.lastUpdateCheckAt?.toISOString() ?? null,
       updateCheckStatus: instanceState?.updateCheckStatus ?? null,

--- a/apps/web/server/update-check-client.test.ts
+++ b/apps/web/server/update-check-client.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { waitForUpdateCheck } from "@/lib/update-check-client";
+
+const createResponse = (body: unknown, ok = true) =>
+  ({
+    ok,
+    json: async () => body,
+  }) as Response;
+
+const updateStatus = {
+  currentVersion: "1.0.0-rc.4",
+  repository: "itsmeares/staaash",
+  lastUpdateCheckAt: "2026-07-16T12:00:00.000Z",
+  updateCheckStatus: "up-to-date" as const,
+  updateCheckMessage: "Instance is up to date.",
+  latestAvailableVersion: "1.0.0-rc.4",
+};
+
+describe("waitForUpdateCheck", () => {
+  it("polls until the job succeeds", async () => {
+    const fetchStatus = vi
+      .fn()
+      .mockResolvedValueOnce(
+        createResponse({
+          job: { id: "job-1", status: "running", lastError: null },
+          updateStatus,
+        }),
+      )
+      .mockResolvedValueOnce(
+        createResponse({
+          job: { id: "job-1", status: "succeeded", lastError: null },
+          updateStatus,
+        }),
+      );
+    const wait = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      waitForUpdateCheck({
+        jobId: "job-1",
+        fetchStatus,
+        wait,
+        maxAttempts: 2,
+      }),
+    ).resolves.toMatchObject({
+      job: { status: "succeeded" },
+      updateStatus: { latestAvailableVersion: "1.0.0-rc.4" },
+    });
+    expect(wait).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces terminal worker failures", async () => {
+    const fetchStatus = vi.fn().mockResolvedValue(
+      createResponse({
+        job: {
+          id: "job-1",
+          status: "failed",
+          lastError: "Worker stopped.",
+        },
+        updateStatus,
+      }),
+    );
+
+    await expect(
+      waitForUpdateCheck({ jobId: "job-1", fetchStatus }),
+    ).rejects.toThrow("Worker stopped.");
+  });
+
+  it("surfaces API errors", async () => {
+    const fetchStatus = vi
+      .fn()
+      .mockResolvedValue(createResponse({ error: "Not found." }, false));
+
+    await expect(
+      waitForUpdateCheck({ jobId: "job-1", fetchStatus }),
+    ).rejects.toThrow("Not found.");
+  });
+
+  it("stops after the configured polling bound", async () => {
+    const fetchStatus = vi.fn().mockResolvedValue(
+      createResponse({
+        job: { id: "job-1", status: "queued", lastError: null },
+        updateStatus,
+      }),
+    );
+
+    await expect(
+      waitForUpdateCheck({
+        jobId: "job-1",
+        fetchStatus,
+        maxAttempts: 2,
+        wait: async () => undefined,
+      }),
+    ).rejects.toThrow("still running");
+    expect(fetchStatus).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/server/update-status.test.ts
+++ b/apps/web/server/update-status.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getUpdateStatusDotClassName,
+  getUpdateStatusLabel,
+} from "@/lib/update-status";
+
+describe("update status display", () => {
+  it("formats every persisted update state explicitly", () => {
+    expect(getUpdateStatusLabel("up-to-date")).toBe("Up to date");
+    expect(getUpdateStatusLabel("update-available", "v1.0.1")).toBe(
+      "v1.0.1 available",
+    );
+    expect(getUpdateStatusLabel("unavailable")).toBe("Unavailable");
+    expect(getUpdateStatusLabel("error")).toBe("Check failed");
+    expect(getUpdateStatusLabel(null)).toBe("Not checked");
+  });
+
+  it("uses neutral dots for unavailable and unchecked states", () => {
+    expect(getUpdateStatusDotClassName("unavailable")).toContain("--muted");
+    expect(getUpdateStatusDotClassName(null)).toContain("--muted");
+  });
+});

--- a/apps/worker/src/handlers/update-check.test.ts
+++ b/apps/worker/src/handlers/update-check.test.ts
@@ -32,21 +32,42 @@ const createJob = () =>
     updatedAt: new Date("2026-04-06T12:00:00.000Z"),
   }) as const;
 
+const restoreEnvironmentValue = (
+  name: "NODE_ENV" | "APP_VERSION" | "STAAASH_VERSION" | "UPDATE_CHECK_TOKEN",
+  value: string | undefined,
+) => {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+};
+
 describe("update check handler", () => {
   let originalNodeEnv: string | undefined;
+  let originalAppVersion: string | undefined;
+  let originalStaaashVersion: string | undefined;
+  let originalUpdateCheckToken: string | undefined;
 
   beforeEach(() => {
     originalNodeEnv = process.env.NODE_ENV;
+    originalAppVersion = process.env.APP_VERSION;
+    originalStaaashVersion = process.env.STAAASH_VERSION;
+    originalUpdateCheckToken = process.env.UPDATE_CHECK_TOKEN;
     process.env.NODE_ENV = "production";
+    process.env.APP_VERSION = "0.3.0-beta.1";
+    delete process.env.STAAASH_VERSION;
+    delete process.env.UPDATE_CHECK_TOKEN;
   });
 
   afterEach(() => {
-    process.env.NODE_ENV = originalNodeEnv;
+    restoreEnvironmentValue("NODE_ENV", originalNodeEnv);
+    restoreEnvironmentValue("APP_VERSION", originalAppVersion);
+    restoreEnvironmentValue("STAAASH_VERSION", originalStaaashVersion);
+    restoreEnvironmentValue("UPDATE_CHECK_TOKEN", originalUpdateCheckToken);
     vi.restoreAllMocks();
     vi.clearAllMocks();
     mockFindUnique.mockReset();
-    delete process.env.UPDATE_CHECK_TOKEN;
-    process.env.APP_VERSION = "0.3.0-beta.1";
   });
 
   it("marks update checks unavailable when no repository is configured", async () => {
@@ -73,9 +94,13 @@ describe("update check handler", () => {
       vi.fn().mockResolvedValue({
         ok: true,
         status: 200,
-        json: async () => ({
-          tag_name: "v0.3.0",
-        }),
+        json: async () => [
+          {
+            tag_name: "v0.3.0",
+            draft: false,
+            prerelease: false,
+          },
+        ],
       }),
     );
 
@@ -88,6 +113,141 @@ describe("update check handler", () => {
         updateCheckStatus: "update-available",
         latestAvailableVersion: "0.3.0",
       }),
+    );
+  });
+
+  it("selects highest compatible prerelease by SemVer", async () => {
+    process.env.APP_VERSION = "1.0.0-rc.2";
+    mockFindUnique.mockResolvedValue({
+      updateCheckRepository: "itsmeares/staaash",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => [
+          {
+            tag_name: "v1.0.0-rc.4",
+            draft: false,
+            prerelease: true,
+          },
+          {
+            tag_name: "v1.0.0-rc.10",
+            draft: false,
+            prerelease: true,
+          },
+          {
+            tag_name: "not-a-version",
+            draft: false,
+            prerelease: false,
+          },
+        ],
+      }),
+    );
+
+    const { handleUpdateCheck } = await import("./update-check.js");
+    await handleUpdateCheck(createJob());
+
+    expect(writeInstanceUpdateCheck).toHaveBeenCalledWith(
+      expect.objectContaining({
+        updateCheckStatus: "update-available",
+        latestAvailableVersion: "1.0.0-rc.10",
+      }),
+    );
+  });
+
+  it("ignores prereleases for stable installs", async () => {
+    process.env.APP_VERSION = "1.0.0";
+    mockFindUnique.mockResolvedValue({
+      updateCheckRepository: "itsmeares/staaash",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => [
+          {
+            tag_name: "v1.1.0-rc.1",
+            draft: false,
+            prerelease: true,
+          },
+          {
+            tag_name: "v1.0.1",
+            draft: false,
+            prerelease: false,
+          },
+        ],
+      }),
+    );
+
+    const { handleUpdateCheck } = await import("./update-check.js");
+    await handleUpdateCheck(createJob());
+
+    expect(writeInstanceUpdateCheck).toHaveBeenCalledWith(
+      expect.objectContaining({
+        updateCheckStatus: "update-available",
+        latestAvailableVersion: "1.0.1",
+      }),
+    );
+  });
+
+  it("reports up to date when current prerelease is newest", async () => {
+    process.env.APP_VERSION = "1.0.0-rc.4";
+    mockFindUnique.mockResolvedValue({
+      updateCheckRepository: "itsmeares/staaash",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => [
+          {
+            tag_name: "v1.0.0-rc.4",
+            draft: false,
+            prerelease: true,
+          },
+          {
+            tag_name: "v1.0.0-rc.3",
+            draft: false,
+            prerelease: true,
+          },
+        ],
+      }),
+    );
+
+    const { handleUpdateCheck } = await import("./update-check.js");
+    await handleUpdateCheck(createJob());
+
+    expect(writeInstanceUpdateCheck).toHaveBeenCalledWith(
+      expect.objectContaining({
+        updateCheckStatus: "up-to-date",
+        latestAvailableVersion: "1.0.0-rc.4",
+      }),
+    );
+  });
+
+  it("sends configured GitHub authentication", async () => {
+    process.env.UPDATE_CHECK_TOKEN = "test-token";
+    mockFindUnique.mockResolvedValue({
+      updateCheckRepository: "itsmeares/staaash",
+    });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { handleUpdateCheck } = await import("./update-check.js");
+    await handleUpdateCheck(createJob());
+
+    const request = fetchMock.mock.calls[0]!;
+    expect(request[0]).toContain("/releases?per_page=100");
+    expect((request[1].headers as Headers).get("Authorization")).toBe(
+      "Bearer test-token",
     );
   });
 

--- a/apps/worker/src/handlers/update-check.ts
+++ b/apps/worker/src/handlers/update-check.ts
@@ -1,96 +1,26 @@
 import type { BackgroundJobRecord } from "@staaash/db/jobs";
 import { writeInstanceUpdateCheck } from "@staaash/db/instance";
+import {
+  compareSemanticVersions,
+  isPrereleaseVersion,
+  normalizeSemanticVersion,
+  resolveRuntimeVersion,
+} from "@staaash/config/version";
 
 type GitHubReleaseResponse = {
   tag_name?: string;
   name?: string;
+  draft?: boolean;
+  prerelease?: boolean;
 };
 
 const GITHUB_API_ROOT = "https://api.github.com";
-
-const normalizeVersion = (value: string) => value.trim().replace(/^v/i, "");
-
-const parseVersion = (value: string) => {
-  const [coreVersion, prereleaseVersion] = normalizeVersion(value).split(
-    "-",
-    2,
-  );
-  const coreParts = coreVersion
-    .split(".")
-    .map((part) => Number.parseInt(part, 10));
-  const prereleaseParts = prereleaseVersion?.split(".") ?? [];
-
-  return {
-    coreParts,
-    prereleaseParts,
-  };
-};
-
-const comparePrereleaseParts = (
-  currentParts: string[],
-  latestParts: string[],
-) => {
-  if (currentParts.length === 0 && latestParts.length === 0) return 0;
-  if (currentParts.length === 0) return 1;
-  if (latestParts.length === 0) return -1;
-
-  const maxLength = Math.max(currentParts.length, latestParts.length);
-
-  for (let index = 0; index < maxLength; index += 1) {
-    const currentPart = currentParts[index];
-    const latestPart = latestParts[index];
-
-    if (currentPart === undefined) return -1;
-    if (latestPart === undefined) return 1;
-
-    const currentNumber = Number.parseInt(currentPart, 10);
-    const latestNumber = Number.parseInt(latestPart, 10);
-    const compareAsNumbers =
-      Number.isFinite(currentNumber) &&
-      Number.isFinite(latestNumber) &&
-      currentNumber.toString() === currentPart &&
-      latestNumber.toString() === latestPart;
-
-    if (compareAsNumbers && latestNumber !== currentNumber) {
-      return latestNumber > currentNumber ? -1 : 1;
-    }
-
-    if (!compareAsNumbers && latestPart !== currentPart) {
-      return latestPart > currentPart ? -1 : 1;
-    }
-  }
-
-  return 0;
-};
-
-const compareVersions = (currentVersion: string, latestVersion: string) => {
-  const current = parseVersion(currentVersion);
-  const latest = parseVersion(latestVersion);
-  const maxLength = Math.max(current.coreParts.length, latest.coreParts.length);
-
-  for (let index = 0; index < maxLength; index += 1) {
-    const currentPart = current.coreParts[index] ?? 0;
-    const latestPart = latest.coreParts[index] ?? 0;
-
-    if (latestPart > currentPart) {
-      return -1;
-    }
-
-    if (latestPart < currentPart) {
-      return 1;
-    }
-  }
-
-  return comparePrereleaseParts(
-    current.prereleaseParts,
-    latest.prereleaseParts,
-  );
-};
 
 const buildGitHubHeaders = () => {
   const headers = new Headers({
     Accept: "application/vnd.github+json",
     "User-Agent": "staaash-update-check",
+    "X-GitHub-Api-Version": "2022-11-28",
   });
   const token = process.env.UPDATE_CHECK_TOKEN?.trim();
 
@@ -101,9 +31,40 @@ const buildGitHubHeaders = () => {
   return headers;
 };
 
-const readLatestGitHubRelease = async (repository: string) => {
+const selectLatestCompatibleRelease = (
+  releases: GitHubReleaseResponse[],
+  currentVersion: string,
+) => {
+  const includePrereleases = isPrereleaseVersion(currentVersion);
+  const compatibleVersions = releases.flatMap((release) => {
+    if (release.draft) return [];
+
+    const version = normalizeSemanticVersion(release.tag_name ?? release.name);
+    if (!version) return [];
+
+    if (
+      !includePrereleases &&
+      (release.prerelease === true || isPrereleaseVersion(version))
+    ) {
+      return [];
+    }
+
+    return [version];
+  });
+
+  compatibleVersions.sort((left, right) =>
+    compareSemanticVersions(right, left),
+  );
+
+  return compatibleVersions[0] ?? null;
+};
+
+const readLatestGitHubRelease = async (
+  repository: string,
+  currentVersion: string,
+) => {
   const response = await fetch(
-    `${GITHUB_API_ROOT}/repos/${repository}/releases/latest`,
+    `${GITHUB_API_ROOT}/repos/${repository}/releases?per_page=100`,
     {
       headers: buildGitHubHeaders(),
     },
@@ -121,20 +82,20 @@ const readLatestGitHubRelease = async (repository: string) => {
     throw new Error(`GitHub release lookup failed with ${response.status}.`);
   }
 
-  const payload = (await response.json()) as GitHubReleaseResponse;
-  const rawVersion = payload.tag_name ?? payload.name ?? "";
+  const payload = (await response.json()) as GitHubReleaseResponse[];
+  const latestVersion = selectLatestCompatibleRelease(payload, currentVersion);
 
-  if (!rawVersion.trim()) {
+  if (!latestVersion) {
     return {
       status: "unavailable" as const,
       latestVersion: null,
-      message: `GitHub release metadata for ${repository} did not include a version tag.`,
+      message: `No compatible published GitHub release found for ${repository}.`,
     };
   }
 
   return {
     status: "available" as const,
-    latestVersion: normalizeVersion(rawVersion),
+    latestVersion,
   };
 };
 
@@ -159,10 +120,10 @@ export const handleUpdateCheck = async (
     where: { id: "singleton" },
   });
   const repository = settings?.updateCheckRepository?.trim();
-  const currentVersion =
-    process.env.STAAASH_VERSION?.trim() ??
-    process.env.APP_VERSION?.trim() ??
-    version;
+  const currentVersion = resolveRuntimeVersion({
+    packageVersion: version,
+    appVersion: process.env.APP_VERSION,
+  });
 
   if (!repository) {
     await writeInstanceUpdateCheck({
@@ -175,7 +136,7 @@ export const handleUpdateCheck = async (
   }
 
   try {
-    const release = await readLatestGitHubRelease(repository);
+    const release = await readLatestGitHubRelease(repository, currentVersion);
 
     if (release.status === "unavailable") {
       await writeInstanceUpdateCheck({
@@ -187,7 +148,10 @@ export const handleUpdateCheck = async (
       return;
     }
 
-    const comparison = compareVersions(currentVersion, release.latestVersion);
+    const comparison = compareSemanticVersions(
+      currentVersion,
+      release.latestVersion,
+    );
     const updateCheckStatus =
       comparison < 0 ? "update-available" : "up-to-date";
     const updateCheckMessage =

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -5,6 +5,9 @@ import {
   markWorkerInstanceStopped,
   registerWorkerInstance,
 } from "@staaash/db/jobs";
+import { resolveRuntimeVersion } from "@staaash/config/version";
+
+import { version as packageVersion } from "../package.json" with { type: "json" };
 
 import {
   getWorkerStoragePaths,
@@ -17,8 +20,10 @@ import { WorkerRunner } from "./runner.js";
 
 const storagePaths = getWorkerStoragePaths();
 const workerId = `${os.hostname()}-${process.pid}-${Date.now()}`;
-const workerVersion =
-  process.env.STAAASH_VERSION ?? process.env.APP_VERSION ?? null;
+const workerVersion = resolveRuntimeVersion({
+  packageVersion,
+  appVersion: process.env.APP_VERSION,
+});
 const workerHeartbeatMs = 30_000;
 const maintenanceMs = 60_000;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     environment:
       NODE_ENV: production
       PORT: "2113"
-      STAAASH_VERSION: ${STAAASH_VERSION:-latest}
       DATABASE_URL: postgresql://${DB_USERNAME:-postgres}:${DB_PASSWORD}@db:5432/${DB_DATABASE_NAME:-staaash}
       UPLOAD_LOCATION: /data/files
       SECURE_COOKIES: "${SECURE_COOKIES:-}"
@@ -34,7 +33,6 @@ services:
 
     environment:
       NODE_ENV: production
-      STAAASH_VERSION: ${STAAASH_VERSION:-latest}
       DATABASE_URL: postgresql://${DB_USERNAME:-postgres}:${DB_PASSWORD}@db:5432/${DB_DATABASE_NAME:-staaash}
       UPLOAD_LOCATION: /data/files
 

--- a/example.env
+++ b/example.env
@@ -6,7 +6,8 @@ UPLOAD_LOCATION=./library
 DB_DATA_LOCATION=./postgres
 
 # ── Version ──────────────────────────────────────────────────────────────────
-# Staaash version — use a pinned version (e.g. v1.2.3) if you'd like.
+# Docker image tag to install — use a pinned release (e.g. v1.2.3) if desired.
+# App screens always report immutable version metadata baked into selected image.
 STAAASH_VERSION=latest
 
 # ── Database - Not Recommended to Change ─────────────────────────────────────

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -18,6 +18,10 @@
     "./time-zone": {
       "types": "./dist/time-zone.d.ts",
       "default": "./dist/time-zone.js"
+    },
+    "./version": {
+      "types": "./dist/version.d.ts",
+      "default": "./dist/version.js"
     }
   },
   "types": "./dist/index.d.ts",

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -10,3 +10,12 @@ export {
   normalizeTimeZone,
   parseMaintenanceRunTime,
 } from "./time-zone.js";
+export {
+  compareSemanticVersions,
+  findReleaseVersionMismatches,
+  formatVersionLabel,
+  isPrereleaseVersion,
+  normalizeSemanticVersion,
+  parseSemanticVersion,
+  resolveRuntimeVersion,
+} from "./version.js";

--- a/packages/config/src/version.ts
+++ b/packages/config/src/version.ts
@@ -1,0 +1,168 @@
+const SEMVER_PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/u;
+
+const MOVING_VERSION_ALIASES = new Set(["latest", "main", "master", "edge"]);
+
+type ParsedSemanticVersion = {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: Array<number | string>;
+  normalized: string;
+};
+
+const parsePrereleasePart = (part: string): number | string => {
+  if (/^(0|[1-9]\d*)$/u.test(part)) {
+    return Number.parseInt(part, 10);
+  }
+
+  return part;
+};
+
+export const parseSemanticVersion = (
+  value: string | null | undefined,
+): ParsedSemanticVersion | null => {
+  const trimmed = value?.trim().replace(/^v/i, "") ?? "";
+
+  if (!trimmed || MOVING_VERSION_ALIASES.has(trimmed.toLowerCase())) {
+    return null;
+  }
+
+  const match = SEMVER_PATTERN.exec(trimmed);
+  if (!match) return null;
+
+  const prereleaseParts = match[4]?.split(".") ?? [];
+  if (
+    prereleaseParts.some(
+      (part) => /^\d+$/u.test(part) && !/^(0|[1-9]\d*)$/u.test(part),
+    )
+  ) {
+    return null;
+  }
+
+  return {
+    major: Number.parseInt(match[1]!, 10),
+    minor: Number.parseInt(match[2]!, 10),
+    patch: Number.parseInt(match[3]!, 10),
+    prerelease: prereleaseParts.map(parsePrereleasePart),
+    normalized: trimmed,
+  };
+};
+
+export const normalizeSemanticVersion = (value: string | null | undefined) =>
+  parseSemanticVersion(value)?.normalized ?? null;
+
+export const isPrereleaseVersion = (
+  value: string | null | undefined,
+): boolean => (parseSemanticVersion(value)?.prerelease.length ?? 0) > 0;
+
+const compareNumbers = (left: number, right: number) =>
+  left === right ? 0 : left < right ? -1 : 1;
+
+const comparePrereleaseParts = (
+  left: number | string,
+  right: number | string,
+) => {
+  if (left === right) return 0;
+
+  const leftIsNumber = typeof left === "number";
+  const rightIsNumber = typeof right === "number";
+  if (leftIsNumber && rightIsNumber) return compareNumbers(left, right);
+  if (leftIsNumber) return -1;
+  if (rightIsNumber) return 1;
+  return left < right ? -1 : 1;
+};
+
+const compareOptionalPrereleaseParts = (
+  left: number | string | undefined,
+  right: number | string | undefined,
+) => {
+  if (left === undefined) return right === undefined ? 0 : -1;
+  if (right === undefined) return 1;
+  return comparePrereleaseParts(left, right);
+};
+
+const comparePrereleaseVersions = (
+  left: ParsedSemanticVersion,
+  right: ParsedSemanticVersion,
+) => {
+  if (left.prerelease.length === 0) {
+    return right.prerelease.length === 0 ? 0 : 1;
+  }
+  if (right.prerelease.length === 0) return -1;
+
+  const maxLength = Math.max(left.prerelease.length, right.prerelease.length);
+  for (let index = 0; index < maxLength; index += 1) {
+    const leftPart = left.prerelease[index];
+    const rightPart = right.prerelease[index];
+    const comparison = compareOptionalPrereleaseParts(leftPart, rightPart);
+    if (comparison !== 0) return comparison;
+  }
+
+  return 0;
+};
+
+export const compareSemanticVersions = (
+  leftValue: string,
+  rightValue: string,
+): number => {
+  const left = parseSemanticVersion(leftValue);
+  const right = parseSemanticVersion(rightValue);
+
+  if (!left || !right) {
+    throw new Error("Cannot compare invalid semantic versions.");
+  }
+
+  for (const key of ["major", "minor", "patch"] as const) {
+    const comparison = compareNumbers(left[key], right[key]);
+    if (comparison !== 0) return comparison;
+  }
+
+  return comparePrereleaseVersions(left, right);
+};
+
+export const resolveRuntimeVersion = ({
+  packageVersion,
+  appVersion,
+}: {
+  packageVersion: string;
+  appVersion?: string | null;
+}) => {
+  const normalizedOverride = normalizeSemanticVersion(appVersion);
+  if (normalizedOverride) return normalizedOverride;
+
+  const normalizedPackageVersion = normalizeSemanticVersion(packageVersion);
+  if (!normalizedPackageVersion) {
+    throw new Error(`Invalid packaged app version: ${packageVersion}`);
+  }
+
+  return normalizedPackageVersion;
+};
+
+export const formatVersionLabel = (value: string) => {
+  const normalized = normalizeSemanticVersion(value);
+  return normalized ? `v${normalized}` : value.trim();
+};
+
+export const findReleaseVersionMismatches = ({
+  tag,
+  packageVersions,
+}: {
+  tag: string;
+  packageVersions: Record<string, string>;
+}) => {
+  const normalizedTag = normalizeSemanticVersion(tag);
+  if (!normalizedTag) {
+    return [`release tag "${tag}" is not valid SemVer`];
+  }
+
+  return Object.entries(packageVersions)
+    .filter(
+      ([, packageVersion]) =>
+        normalizeSemanticVersion(packageVersion) !== normalizedTag,
+    )
+    .map(
+      ([packageName, packageVersion]) =>
+        `${packageName} has ${packageVersion}; expected ${normalizedTag}`,
+    );
+};

--- a/packages/config/test/version.test.ts
+++ b/packages/config/test/version.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compareSemanticVersions,
+  findReleaseVersionMismatches,
+  formatVersionLabel,
+  isPrereleaseVersion,
+  normalizeSemanticVersion,
+  resolveRuntimeVersion,
+} from "../src/version.js";
+
+describe("version helpers", () => {
+  it("normalizes valid versions and rejects moving aliases", () => {
+    expect(normalizeSemanticVersion("v1.0.0-rc.4")).toBe("1.0.0-rc.4");
+    expect(normalizeSemanticVersion("latest")).toBeNull();
+    expect(normalizeSemanticVersion("main")).toBeNull();
+    expect(normalizeSemanticVersion("1.0")).toBeNull();
+    expect(normalizeSemanticVersion("1.0.0-rc.04")).toBeNull();
+  });
+
+  it("formats one leading v", () => {
+    expect(formatVersionLabel("1.0.0-rc.4")).toBe("v1.0.0-rc.4");
+    expect(formatVersionLabel("v1.0.0-rc.4")).toBe("v1.0.0-rc.4");
+    expect(formatVersionLabel("development")).toBe("development");
+  });
+
+  it("orders stable and prerelease versions using SemVer rules", () => {
+    expect(compareSemanticVersions("1.0.0-rc.3", "1.0.0-rc.4")).toBe(-1);
+    expect(compareSemanticVersions("1.0.0-rc.10", "1.0.0-rc.4")).toBe(1);
+    expect(compareSemanticVersions("1.0.0-rc.4", "1.0.0")).toBe(-1);
+    expect(compareSemanticVersions("1.0.0", "1.0.1-alpha.1")).toBe(-1);
+    expect(isPrereleaseVersion("v1.0.0-rc.4")).toBe(true);
+    expect(isPrereleaseVersion("v1.0.0")).toBe(false);
+  });
+
+  it("uses only valid APP_VERSION overrides", () => {
+    expect(
+      resolveRuntimeVersion({
+        packageVersion: "1.0.0-rc.4",
+        appVersion: "2.0.0",
+      }),
+    ).toBe("2.0.0");
+    expect(
+      resolveRuntimeVersion({
+        packageVersion: "1.0.0-rc.4",
+        appVersion: "latest",
+      }),
+    ).toBe("1.0.0-rc.4");
+  });
+
+  it("reports release tag and package version drift", () => {
+    expect(
+      findReleaseVersionMismatches({
+        tag: "v1.0.0-rc.4",
+        packageVersions: {
+          root: "1.0.0-rc.4",
+          web: "1.0.0-rc.3",
+        },
+      }),
+    ).toEqual(["web has 1.0.0-rc.3; expected 1.0.0-rc.4"]);
+  });
+});


### PR DESCRIPTION
## 🚀 Summary

Fix version reporting and update checks so Docker installs using the moving
`latest` image tag display the baked application version and can resolve
published prereleases.

## 📊 Impacts and Changes

- Treat `STAAASH_VERSION` only as the Docker image selector.
- Resolve the displayed web and worker version from baked package metadata,
  with an optional validated `APP_VERSION` override.
- Query GitHub's release list, ignore drafts, compare versions using SemVer,
  and match the installed stable or prerelease channel.
- Poll manual update-check jobs until completion and refresh the admin result.
- Use consistent version formatting and explicit update-status labels across
  the workspace badge and admin surfaces.
- Block releases when the tag and workspace package versions differ.
- No schema, auth, storage, sharing, or restore behavior changes.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

Additional checks:

- `pnpm typecheck`
- `pnpm format:check`
- `pnpm quality:fallow`
- Live GitHub release-list selection against `itsmeares/staaash`
- Docker Compose interpolation with `STAAASH_VERSION=latest`
- Production-mode browser smoke for the version badge, admin overview, and
  update-check settings

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

The corrected production behavior requires publishing and deploying a new
container image from this change.

## 🔗 Linked Issues

None.
