### PR TITLE
Release v1.0.0-rc.6

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "private": true,
   "scripts": {
     "build:deps": "pnpm --filter @staaash/config build && pnpm --filter @staaash/db build",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worker",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "staaash",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "description": "Self-hosted personal cloud drive monorepo.",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@staaash/config",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "private": true,
   "type": "module",
   "files": [

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@staaash/db",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "private": true,
   "type": "module",
   "files": [


### PR DESCRIPTION
## 🚀 Summary

Bump all release manifests from `1.0.0-rc.5` to `1.0.0-rc.6` for the Node.js 24 worker-startup hotfix release.

## 📊 Impacts and Changes

- Update the root, web, worker, config, and database package versions.
- Release source includes the merged worker startup fix from #137.
- No schema, auth, storage, sharing, or restore behavior changes.

## 🧪 Testing Checklist

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm format:check`
- [x] `pnpm quality:fallow`
- [x] Worker compiled-runtime smoke resolved `1.0.0-rc.6`
- [x] UI manually verified (not applicable: version-only release change)

## Review Checklist

- [x] All five release manifests match `1.0.0-rc.6`.
- [x] Operational impact is documented above.
- [x] No secrets or credentials are included.
- [x] No schema, auth, storage, sharing, or restore changes are included.

## 🧗 Follow-ups or Limitations

After merge, tag `v1.0.0-rc.6`, publish the prerelease, and verify GHCR image metadata and release assets.

## 🔗 Linked Issues

- #137