### PR TITLE
Fix Playwright email sign-in locator

### DIFF
--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -95,7 +95,7 @@ export const signIn = async (
   await page.goto(`/?next=${encodeURIComponent(next)}`);
   await page.keyboard.press("Enter");
   await page.waitForSelector(".entry-form");
-  await page.getByLabel("Username or email").fill(identifier);
+  await page.getByLabel("Email", { exact: true }).fill(identifier);
   await page.getByLabel("Password").fill(password);
   await page.getByRole("button", { name: "Sign in" }).press("Enter");
   await page.waitForURL((url) => url.pathname === next, { timeout: 20_000 });

--- a/apps/web/e2e/keyboard-accessibility.spec.ts
+++ b/apps/web/e2e/keyboard-accessibility.spec.ts
@@ -56,8 +56,8 @@ test("sign-in intro opens and submits with keyboard", async ({ page }) => {
   ).not.toBeFocused();
   await page.keyboard.press("Enter");
 
-  await expect(page.getByLabel("Username or email")).toBeFocused();
-  await page.getByLabel("Username or email").fill(credentials.identifier);
+  await expect(page.getByLabel("Email", { exact: true })).toBeFocused();
+  await page.getByLabel("Email", { exact: true }).fill(credentials.identifier);
   await page.getByLabel("Password").fill(credentials.password);
   await page.getByRole("button", { name: "Sign in" }).press("Enter");
 
@@ -76,7 +76,7 @@ test("incomplete-onboarding user can finish setup with keyboard", async ({
     page.getByRole("button", { name: /Click anywhere to begin/i }),
   ).not.toBeFocused();
   await page.keyboard.press("Enter");
-  await page.getByLabel("Username or email").fill(credentials.identifier);
+  await page.getByLabel("Email", { exact: true }).fill(credentials.identifier);
   await page.getByLabel("Password").fill(credentials.password);
   await page.getByRole("button", { name: "Sign in" }).press("Enter");
 


### PR DESCRIPTION
## 🚀 Summary

- Update the shared Playwright sign-in helper to locate the accessible `Email` field.
- Align keyboard E2E sign-in locators with the same email-only contract.
- Leave product authentication behavior and UI unchanged.

## 📊 Impacts and Changes

The release-validation harness now matches the current sign-in UI contract. No schema, authentication behavior, storage, restore, or UI/UX changes.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

Additional validation:

- `pnpm --filter web typecheck`
- `pnpm format:check`
- Isolated focused and full Playwright runs confirmed no failure still searches for `Username or email`.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

The isolated full E2E suite still reports seven unrelated failures documented during validation. They remain outside this PR's scope.

## 🔗 Linked Issues

None.