### PR TITLE
fix(worker): scan active files during reconciliation

### DIFF
--- a/apps/web/server/files/service.test.ts
+++ b/apps/web/server/files/service.test.ts
@@ -509,13 +509,13 @@ describe.sequential("files service", () => {
       ownerUserId: "member-1",
       folderId: root.id,
       name: "available.txt",
-      storageKey: "library/member-1/available.txt",
+      storageKey: "files/member-1/available.txt",
     });
     addFile({
       ownerUserId: "member-1",
       folderId: root.id,
       name: "missing.txt",
-      storageKey: "library/member-1/missing.txt",
+      storageKey: "files/member-1/missing.txt",
       storageStatus: "missing",
       storageCheckedAt: new Date("2026-05-20T10:00:00.000Z"),
       storageMissingAt: new Date("2026-05-20T10:00:00.000Z"),

--- a/apps/worker/src/handlers/media-derivative.test.ts
+++ b/apps/worker/src/handlers/media-derivative.test.ts
@@ -108,7 +108,7 @@ describe("media derivative handler", () => {
     );
     const filesRoot = path.join(tempRoot, "files");
     const tmpRoot = path.join(tempRoot, "tmp");
-    const sourcePath = path.join(filesRoot, "library", "owner-1", "clip.mov");
+    const sourcePath = path.join(filesRoot, "files", "owner-1", "clip.mov");
     await mkdir(path.dirname(sourcePath), { recursive: true });
     await writeFile(sourcePath, "source", "utf8");
 
@@ -127,7 +127,7 @@ describe("media derivative handler", () => {
           ownerUserId: "owner-1",
           mimeType: "video/quicktime",
           sizeBytes: 10_000n,
-          storageKey: "library/owner-1/clip.mov",
+          storageKey: "files/owner-1/clip.mov",
           deletedAt: null,
         })),
       },
@@ -217,7 +217,7 @@ describe("media derivative handler", () => {
     tempRoot = await mkdtemp(path.join(os.tmpdir(), "staaash-media-poster-"));
     const filesRoot = path.join(tempRoot, "files");
     const tmpRoot = path.join(tempRoot, "tmp");
-    const sourcePath = path.join(filesRoot, "library", "owner-1", "clip.mp4");
+    const sourcePath = path.join(filesRoot, "files", "owner-1", "clip.mp4");
     await mkdir(path.dirname(sourcePath), { recursive: true });
     await writeFile(sourcePath, "source", "utf8");
 
@@ -244,7 +244,7 @@ describe("media derivative handler", () => {
           ownerUserId: "owner-1",
           mimeType: "video/mp4",
           sizeBytes: 10_000n,
-          storageKey: "library/owner-1/clip.mp4",
+          storageKey: "files/owner-1/clip.mp4",
           deletedAt: null,
         })),
       },

--- a/apps/worker/src/handlers/restore-reconciliation.test.ts
+++ b/apps/worker/src/handlers/restore-reconciliation.test.ts
@@ -35,11 +35,11 @@ const createTempFilesRoot = () =>
 describe("restore reconciliation worker handler", () => {
   it("detects missing originals from DB metadata", async () => {
     const filesRoot = createTempFilesRoot();
-    await mkdir(path.join(filesRoot, "library", "member"), {
+    await mkdir(path.join(filesRoot, "files", "member"), {
       recursive: true,
     });
     await writeFile(
-      path.join(filesRoot, "library", "member", "present.txt"),
+      path.join(filesRoot, "files", "member", "present.txt"),
       "ok",
       "utf8",
     );
@@ -49,11 +49,11 @@ describe("restore reconciliation worker handler", () => {
         [
           {
             id: "file-1",
-            storageKey: "library/member/present.txt",
+            storageKey: "files/member/present.txt",
           },
           {
             id: "file-2",
-            storageKey: "library/member/missing.txt",
+            storageKey: "files/member/missing.txt",
           },
         ],
         filesRoot,
@@ -61,7 +61,7 @@ describe("restore reconciliation worker handler", () => {
     ).resolves.toEqual([
       {
         fileId: "file-2",
-        storageKey: "library/member/missing.txt",
+        storageKey: "files/member/missing.txt",
       },
     ]);
 
@@ -70,7 +70,7 @@ describe("restore reconciliation worker handler", () => {
 
   it("detects orphans only inside committed storage trees", async () => {
     const filesRoot = createTempFilesRoot();
-    await mkdir(path.join(filesRoot, "library", "member"), {
+    await mkdir(path.join(filesRoot, "files", "member"), {
       recursive: true,
     });
     await mkdir(path.join(filesRoot, ".trash", "member"), {
@@ -79,13 +79,19 @@ describe("restore reconciliation worker handler", () => {
     await mkdir(path.join(filesRoot, "tmp", "pending-delete"), {
       recursive: true,
     });
+    await mkdir(path.join(filesRoot, "tmp", "locks"), {
+      recursive: true,
+    });
+    await mkdir(path.join(filesRoot, "tmp", "derivatives"), {
+      recursive: true,
+    });
     await writeFile(
-      path.join(filesRoot, "library", "member", "known.txt"),
+      path.join(filesRoot, "files", "member", "known.txt"),
       "ok",
       "utf8",
     );
     await writeFile(
-      path.join(filesRoot, "library", "member", "orphan.txt"),
+      path.join(filesRoot, "files", "member", "orphan.txt"),
       "orphan",
       "utf8",
     );
@@ -99,14 +105,29 @@ describe("restore reconciliation worker handler", () => {
       "ignore me",
       "utf8",
     );
+    await writeFile(
+      path.join(filesRoot, "tmp", "locks", "ignored.lock"),
+      "ignore me",
+      "utf8",
+    );
+    await writeFile(
+      path.join(filesRoot, "tmp", "ignored.upload"),
+      "ignore me",
+      "utf8",
+    );
+    await writeFile(
+      path.join(filesRoot, "tmp", "derivatives", "ignored.tmp"),
+      "ignore me",
+      "utf8",
+    );
 
     await expect(
       collectOrphanedStorageKeys({
         filesRoot,
-        knownStorageKeys: new Set(["library/member/known.txt"]),
+        knownStorageKeys: new Set(["files/member/known.txt"]),
       }),
     ).resolves.toEqual([
-      "library/member/orphan.txt",
+      "files/member/orphan.txt",
       ".trash/member/trashed-orphan.txt",
     ]);
 
@@ -115,16 +136,16 @@ describe("restore reconciliation worker handler", () => {
 
   it("collects both missing originals and orphans", async () => {
     const filesRoot = createTempFilesRoot();
-    await mkdir(path.join(filesRoot, "library", "member"), {
+    await mkdir(path.join(filesRoot, "files", "member"), {
       recursive: true,
     });
     await writeFile(
-      path.join(filesRoot, "library", "member", "known.txt"),
+      path.join(filesRoot, "files", "member", "known.txt"),
       "ok",
       "utf8",
     );
     await writeFile(
-      path.join(filesRoot, "library", "member", "orphan.txt"),
+      path.join(filesRoot, "files", "member", "orphan.txt"),
       "orphan",
       "utf8",
     );
@@ -135,11 +156,11 @@ describe("restore reconciliation worker handler", () => {
         fileRecords: [
           {
             id: "file-1",
-            storageKey: "library/member/known.txt",
+            storageKey: "files/member/known.txt",
           },
           {
             id: "file-2",
-            storageKey: "library/member/missing.txt",
+            storageKey: "files/member/missing.txt",
           },
         ],
       }),
@@ -147,10 +168,10 @@ describe("restore reconciliation worker handler", () => {
       missingOriginals: [
         {
           fileId: "file-2",
-          storageKey: "library/member/missing.txt",
+          storageKey: "files/member/missing.txt",
         },
       ],
-      orphanedStorageKeys: ["library/member/orphan.txt"],
+      orphanedStorageKeys: ["files/member/orphan.txt"],
     });
 
     await rm(filesRoot, { recursive: true, force: true });
@@ -159,11 +180,11 @@ describe("restore reconciliation worker handler", () => {
   it("creates, runs, and completes reconciliation jobs", async () => {
     const filesRoot = createTempFilesRoot();
     const updateMany = vi.fn(async () => ({ count: 1 }));
-    await mkdir(path.join(filesRoot, "library", "member"), {
+    await mkdir(path.join(filesRoot, "files", "member"), {
       recursive: true,
     });
     await writeFile(
-      path.join(filesRoot, "library", "member", "known.txt"),
+      path.join(filesRoot, "files", "member", "known.txt"),
       "ok",
       "utf8",
     );
@@ -199,7 +220,7 @@ describe("restore reconciliation worker handler", () => {
             return [
               {
                 id: "file-1",
-                storageKey: "library/member/known.txt",
+                storageKey: "files/member/known.txt",
               },
             ];
           },
@@ -244,12 +265,25 @@ describe("restore reconciliation worker handler", () => {
   it("marks missing originals and restores available status when bytes exist again", async () => {
     const filesRoot = createTempFilesRoot();
     const updateMany = vi.fn(async () => ({ count: 1 }));
-    await mkdir(path.join(filesRoot, "library", "member"), {
+    await mkdir(path.join(filesRoot, "files", "member"), {
+      recursive: true,
+    });
+    await mkdir(path.join(filesRoot, ".trash", "member"), {
       recursive: true,
     });
     await writeFile(
-      path.join(filesRoot, "library", "member", "restored.txt"),
+      path.join(filesRoot, "files", "member", "restored.txt"),
       "ok",
+      "utf8",
+    );
+    await writeFile(
+      path.join(filesRoot, "files", "member", "orphan.txt"),
+      "orphan",
+      "utf8",
+    );
+    await writeFile(
+      path.join(filesRoot, ".trash", "member", "trashed-orphan.txt"),
+      "orphan",
       "utf8",
     );
 
@@ -282,11 +316,11 @@ describe("restore reconciliation worker handler", () => {
             return [
               {
                 id: "file-restored",
-                storageKey: "library/member/restored.txt",
+                storageKey: "files/member/restored.txt",
               },
               {
                 id: "file-missing",
-                storageKey: "library/member/missing.txt",
+                storageKey: "files/member/missing.txt",
               },
             ];
           },
@@ -325,10 +359,13 @@ describe("restore reconciliation worker handler", () => {
         missingOriginals: [
           {
             fileId: "file-missing",
-            storageKey: "library/member/missing.txt",
+            storageKey: "files/member/missing.txt",
           },
         ],
-        orphanedStorageKeys: [],
+        orphanedStorageKeys: [
+          "files/member/orphan.txt",
+          ".trash/member/trashed-orphan.txt",
+        ],
       },
     });
 

--- a/apps/worker/src/handlers/restore-reconciliation.ts
+++ b/apps/worker/src/handlers/restore-reconciliation.ts
@@ -117,7 +117,7 @@ export const collectOrphanedStorageKeys = async ({
 }): Promise<string[]> => {
   const committedStorageKeys = [
     ...(await walkCommittedStorageTree(
-      path.resolve(filesRoot, "library"),
+      path.resolve(filesRoot, "files"),
       filesRoot,
     )),
     ...(await walkCommittedStorageTree(
@@ -209,7 +209,7 @@ const markReconciledStorageStatus = async ({
  * The worker checks DB-tracked originals for missing blobs and scans the
  * committed storage namespaces for files that do not map back to metadata.
  * It intentionally ignores transient tmp infrastructure by only walking the
- * committed `library/` and `.trash/` trees.
+ * committed `files/` and `.trash/` trees.
  */
 export const handleRestoreReconciliation = async (
   job: BackgroundJobRecord,

--- a/packages/db/src/reconciliation.test.ts
+++ b/packages/db/src/reconciliation.test.ts
@@ -176,10 +176,10 @@ describe("restore reconciliation db helpers", () => {
             missingOriginals: [
               {
                 fileId: "file-1",
-                storageKey: "library/member/file-1.txt",
+                storageKey: "files/member/file-1.txt",
               },
             ],
-            orphanedStorageKeys: ["library/member/orphan.txt"],
+            orphanedStorageKeys: ["files/member/orphan.txt"],
           },
         },
         client,
@@ -192,10 +192,10 @@ describe("restore reconciliation db helpers", () => {
         missingOriginals: [
           {
             fileId: "file-1",
-            storageKey: "library/member/file-1.txt",
+            storageKey: "files/member/file-1.txt",
           },
         ],
-        orphanedStorageKeys: ["library/member/orphan.txt"],
+        orphanedStorageKeys: ["files/member/orphan.txt"],
       },
     });
 


### PR DESCRIPTION
## 🚀 Summary

Fixes audit finding REC-01 by updating restore reconciliation to scan the canonical `files/` namespace instead of the obsolete `library/` namespace. Existing `.trash/` orphan detection remains intact.

## 📊 Impacts and Changes

Restore reconciliation now detects untracked active objects under `files/`, preventing a false-clean result after restore. Transient `tmp/` infrastructure remains excluded, including pending-delete data, lock files, upload staging, and temporary derivatives.

No schema, migration, storage-layout, upload, trash, restore, or delete behavior changes outside reconciliation.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

Additional checks:

- `pnpm --filter worker exec vitest run src/handlers/restore-reconciliation.test.ts`
- `pnpm --filter worker typecheck`
- `pnpm --filter worker test`
- `pnpm format:check`
- `pnpm quality:fallow`
- `git diff --check`

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

None.

## 🔗 Linked Issues

None.