### PR TITLE
fix: make share-access cookies request-aware

### DIFF
--- a/apps/web/app/s/[token]/unlock/route.ts
+++ b/apps/web/app/s/[token]/unlock/route.ts
@@ -49,12 +49,15 @@ export async function POST(
         );
 
     response.cookies.set(
-      buildShareAccessCookie({
-        shareId: result.share.id,
-        tokenLookupKey: result.share.tokenLookupKey,
-        accessFingerprint: result.accessFingerprint,
-        token,
-      }),
+      buildShareAccessCookie(
+        {
+          shareId: result.share.id,
+          tokenLookupKey: result.share.tokenLookupKey,
+          accessFingerprint: result.accessFingerprint,
+          token,
+        },
+        request,
+      ),
     );
 
     return response;

--- a/apps/web/server/auth/session.ts
+++ b/apps/web/server/auth/session.ts
@@ -1,66 +1,16 @@
 import { cookies } from "next/headers";
 
 import { authService } from "@/server/auth/service";
-import { env } from "@/lib/env";
+import {
+  type CookieRequestContext,
+  resolveSecureCookie,
+} from "@/server/cookie-security";
 
 // fallow-ignore-next-line unused-export
 export const SESSION_COOKIE_NAME = "staaash_session";
 // fallow-ignore-next-line unused-export
 export const ONBOARDED_COOKIE_NAME = "staaash_onboarded";
 export const THEME_COOKIE_NAME = "staaash_theme";
-
-type CookieRequestContext = {
-  headers?: {
-    get(name: string): string | null;
-  };
-  nextUrl?: {
-    protocol?: string;
-  };
-  url?: string;
-};
-
-const normalizeProtocol = (protocol: string) =>
-  protocol.replace(/:$/, "").trim().toLowerCase();
-
-const getForwardedProtocol = (context?: CookieRequestContext) => {
-  const proto = context?.headers
-    ?.get("x-forwarded-proto")
-    ?.split(",")[0]
-    ?.trim();
-
-  return proto ? normalizeProtocol(proto) : null;
-};
-
-const getRequestProtocol = (context?: CookieRequestContext) => {
-  const forwardedProtocol = getForwardedProtocol(context);
-  if (forwardedProtocol) return forwardedProtocol;
-
-  const nextUrlProtocol = context?.nextUrl?.protocol;
-  if (nextUrlProtocol) return normalizeProtocol(nextUrlProtocol);
-
-  if (context?.url) {
-    try {
-      return normalizeProtocol(new URL(context.url).protocol);
-    } catch {
-      return null;
-    }
-  }
-
-  return null;
-};
-
-const resolveSecureCookie = (context?: CookieRequestContext) => {
-  if (env.SECURE_COOKIES !== undefined) {
-    return env.SECURE_COOKIES;
-  }
-
-  const protocol = getRequestProtocol(context);
-  if (protocol) {
-    return protocol === "https";
-  }
-
-  return env.NODE_ENV === "production";
-};
 
 const baseCookie = (context?: CookieRequestContext) => ({
   name: SESSION_COOKIE_NAME,

--- a/apps/web/server/cookie-security.ts
+++ b/apps/web/server/cookie-security.ts
@@ -1,0 +1,54 @@
+import { env } from "@/lib/env";
+
+export type CookieRequestContext = {
+  headers?: {
+    get(name: string): string | null;
+  };
+  nextUrl?: {
+    protocol?: string;
+  };
+  url?: string;
+};
+
+const normalizeProtocol = (protocol: string) =>
+  protocol.replace(/:$/, "").trim().toLowerCase();
+
+const getForwardedProtocol = (context?: CookieRequestContext) => {
+  const proto = context?.headers
+    ?.get("x-forwarded-proto")
+    ?.split(",")[0]
+    ?.trim();
+
+  return proto ? normalizeProtocol(proto) : null;
+};
+
+const getRequestProtocol = (context?: CookieRequestContext) => {
+  const forwardedProtocol = getForwardedProtocol(context);
+  if (forwardedProtocol) return forwardedProtocol;
+
+  const nextUrlProtocol = context?.nextUrl?.protocol;
+  if (nextUrlProtocol) return normalizeProtocol(nextUrlProtocol);
+
+  if (context?.url) {
+    try {
+      return normalizeProtocol(new URL(context.url).protocol);
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+};
+
+export const resolveSecureCookie = (context?: CookieRequestContext) => {
+  if (env.SECURE_COOKIES !== undefined) {
+    return env.SECURE_COOKIES;
+  }
+
+  const protocol = getRequestProtocol(context);
+  if (protocol) {
+    return protocol === "https";
+  }
+
+  return env.NODE_ENV === "production";
+};

--- a/apps/web/server/sharing/access-cookie.test.ts
+++ b/apps/web/server/sharing/access-cookie.test.ts
@@ -1,14 +1,39 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import {
-  buildShareAccessFingerprint,
-  buildClearedShareAccessCookie,
-  buildShareAccessCookie,
-  verifyShareAccessCookie,
-} from "@/server/sharing/access-cookie";
+const loadAccessCookieModule = async ({
+  nodeEnv = "test",
+  secureCookies,
+}: {
+  nodeEnv?: "development" | "test" | "production";
+  secureCookies?: boolean;
+} = {}) => {
+  vi.resetModules();
+  vi.doMock("@/lib/env", () => ({
+    env: {
+      NODE_ENV: nodeEnv,
+      SECURE_COOKIES: secureCookies,
+    },
+  }));
+
+  return import("@/server/sharing/access-cookie");
+};
+
+const requestContext = (url: string, headers?: HeadersInit) => ({
+  url,
+  headers: new Headers(headers),
+});
 
 describe("share access cookies", () => {
-  it("verifies cookies against the current share fingerprint without storing the hash", () => {
+  afterEach(() => {
+    vi.doUnmock("@/lib/env");
+  });
+
+  it("verifies cookies against the current share fingerprint without storing the hash", async () => {
+    const {
+      buildShareAccessCookie,
+      buildShareAccessFingerprint,
+      verifyShareAccessCookie,
+    } = await loadAccessCookieModule();
     const cookie = buildShareAccessCookie({
       shareId: "share-1",
       tokenLookupKey: "lookup-1",
@@ -42,10 +67,114 @@ describe("share access cookies", () => {
     expect(decodedPayload).toContain("accessFingerprint");
   });
 
-  it("clears the cookie on the scoped share path", () => {
-    const cookie = buildClearedShareAccessCookie("lookup-1.signature");
+  it("uses non-secure cookies for production plain HTTP without an override", async () => {
+    const { buildShareAccessCookie } = await loadAccessCookieModule({
+      nodeEnv: "production",
+    });
 
-    expect(cookie.maxAge).toBe(0);
-    expect(cookie.path).toBe("/s/lookup-1.signature");
+    expect(
+      buildShareAccessCookie(
+        {
+          shareId: "share-1",
+          tokenLookupKey: "lookup-1",
+          accessFingerprint: "fingerprint-1",
+          token: "lookup-1.signature",
+        },
+        requestContext("http://46.1.113.7:2113/s/lookup-1.signature/unlock"),
+      ),
+    ).toMatchObject({ secure: false });
+  });
+
+  it("uses secure cookies for production forwarded HTTPS without an override", async () => {
+    const { buildShareAccessCookie } = await loadAccessCookieModule({
+      nodeEnv: "production",
+    });
+
+    expect(
+      buildShareAccessCookie(
+        {
+          shareId: "share-1",
+          tokenLookupKey: "lookup-1",
+          accessFingerprint: "fingerprint-1",
+          token: "lookup-1.signature",
+        },
+        requestContext("http://staaash:2113/s/lookup-1.signature/unlock", {
+          "x-forwarded-proto": "https",
+        }),
+      ),
+    ).toMatchObject({ secure: true });
+  });
+
+  it("lets SECURE_COOKIES=true override plain HTTP requests", async () => {
+    const { buildShareAccessCookie } = await loadAccessCookieModule({
+      nodeEnv: "production",
+      secureCookies: true,
+    });
+
+    expect(
+      buildShareAccessCookie(
+        {
+          shareId: "share-1",
+          tokenLookupKey: "lookup-1",
+          accessFingerprint: "fingerprint-1",
+          token: "lookup-1.signature",
+        },
+        requestContext("http://46.1.113.7:2113/s/lookup-1.signature/unlock"),
+      ),
+    ).toMatchObject({ secure: true });
+  });
+
+  it("lets SECURE_COOKIES=false override forwarded HTTPS requests", async () => {
+    const { buildShareAccessCookie } = await loadAccessCookieModule({
+      nodeEnv: "production",
+      secureCookies: false,
+    });
+
+    expect(
+      buildShareAccessCookie(
+        {
+          shareId: "share-1",
+          tokenLookupKey: "lookup-1",
+          accessFingerprint: "fingerprint-1",
+          token: "lookup-1.signature",
+        },
+        requestContext("http://staaash:2113/s/lookup-1.signature/unlock", {
+          "x-forwarded-proto": "https",
+        }),
+      ),
+    ).toMatchObject({ secure: false });
+  });
+
+  it("clears the scoped cookie with the same request-aware policy", async () => {
+    const { buildClearedShareAccessCookie } = await loadAccessCookieModule({
+      nodeEnv: "production",
+    });
+    const directHttpCookie = buildClearedShareAccessCookie(
+      "lookup-1.signature",
+      requestContext("http://46.1.113.7:2113/s/lookup-1.signature"),
+    );
+    const forwardedHttpsCookie = buildClearedShareAccessCookie(
+      "lookup-1.signature",
+      requestContext("http://staaash:2113/s/lookup-1.signature", {
+        "x-forwarded-proto": "https",
+      }),
+    );
+
+    expect(directHttpCookie).toMatchObject({
+      maxAge: 0,
+      path: "/s/lookup-1.signature",
+      secure: false,
+    });
+    expect(forwardedHttpsCookie).toMatchObject({ secure: true });
+  });
+
+  it("keeps the secure production fallback without request context", async () => {
+    const { buildClearedShareAccessCookie } = await loadAccessCookieModule({
+      nodeEnv: "production",
+    });
+
+    expect(buildClearedShareAccessCookie("lookup-1.signature")).toMatchObject({
+      secure: true,
+    });
   });
 });

--- a/apps/web/server/sharing/access-cookie.ts
+++ b/apps/web/server/sharing/access-cookie.ts
@@ -1,6 +1,9 @@
 import { createHmac } from "node:crypto";
 
-import { env } from "@/lib/env";
+import {
+  type CookieRequestContext,
+  resolveSecureCookie,
+} from "@/server/cookie-security";
 import { getAuthSecretSync } from "@/server/settings";
 
 export const SHARE_ACCESS_COOKIE_NAME = "staaash_share_access";
@@ -29,12 +32,12 @@ export const buildShareAccessFingerprint = ({
     .update(passwordHash)
     .digest("base64url");
 
-const baseCookie = {
+const baseCookie = (context?: CookieRequestContext) => ({
   name: SHARE_ACCESS_COOKIE_NAME,
   httpOnly: true,
   sameSite: "lax" as const,
-  secure: env.NODE_ENV === "production",
-};
+  secure: resolveSecureCookie(context),
+});
 
 type ShareCookiePayload = {
   shareId: string;
@@ -69,14 +72,17 @@ const deserializePayload = (value: string): ShareCookiePayload | null => {
   }
 };
 
-export const buildShareAccessCookie = ({
-  shareId,
-  tokenLookupKey,
-  accessFingerprint,
-  token,
-}: ShareCookiePayload & {
-  token: string;
-}) => {
+export const buildShareAccessCookie = (
+  {
+    shareId,
+    tokenLookupKey,
+    accessFingerprint,
+    token,
+  }: ShareCookiePayload & {
+    token: string;
+  },
+  context?: CookieRequestContext,
+) => {
   const payload = serializePayload({
     shareId,
     tokenLookupKey,
@@ -84,14 +90,17 @@ export const buildShareAccessCookie = ({
   });
 
   return {
-    ...baseCookie,
+    ...baseCookie(context),
     path: `/s/${encodeURIComponent(token)}`,
     value: `${payload}.${signValue(payload)}`,
   };
 };
 
-export const buildClearedShareAccessCookie = (token: string) => ({
-  ...baseCookie,
+export const buildClearedShareAccessCookie = (
+  token: string,
+  context?: CookieRequestContext,
+) => ({
+  ...baseCookie(context),
   path: `/s/${encodeURIComponent(token)}`,
   value: "",
   expires: new Date(0),

--- a/apps/web/server/sharing/unlock-route.test.ts
+++ b/apps/web/server/sharing/unlock-route.test.ts
@@ -1,0 +1,96 @@
+import { NextRequest } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  unlockShare: vi.fn(),
+}));
+
+vi.mock("@/server/sharing/service", () => ({
+  sharingService: {
+    unlockShare: mocks.unlockShare,
+  },
+}));
+
+const loadUnlockRoute = async () => {
+  vi.resetModules();
+  vi.doMock("@/lib/env", () => ({
+    env: {
+      NODE_ENV: "production",
+      SECURE_COOKIES: undefined,
+    },
+  }));
+
+  return import("@/app/s/[token]/unlock/route");
+};
+
+const unlockResult = {
+  share: {
+    id: "share-1",
+    tokenLookupKey: "lookup-1",
+  },
+  accessFingerprint: "fingerprint-1",
+};
+
+const jsonRequest = (url: string, headers: Record<string, string>) =>
+  new NextRequest(url, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify({ password: "secret-pass" }),
+  });
+
+const expectCookieSecure = (setCookie: string, expected: boolean) => {
+  if (expected) {
+    expect(setCookie).toContain("Secure");
+  } else {
+    expect(setCookie).not.toContain("Secure");
+  }
+};
+
+describe("share unlock route cookies", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.doUnmock("@/lib/env");
+  });
+
+  it("sets a non-secure share-access cookie over production plain HTTP", async () => {
+    mocks.unlockShare.mockResolvedValueOnce(unlockResult);
+    const { POST } = await loadUnlockRoute();
+    const response = await POST(
+      jsonRequest("http://46.1.113.7:2113/s/lookup-1.signature/unlock", {
+        host: "46.1.113.7:2113",
+        origin: "http://46.1.113.7:2113",
+      }),
+      { params: Promise.resolve({ token: "lookup-1.signature" }) },
+    );
+
+    expect(response.status).toBe(200);
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("staaash_share_access=");
+    expect(setCookie).toContain("Path=/s/lookup-1.signature");
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("SameSite=lax");
+    expectCookieSecure(setCookie, false);
+  });
+
+  it("sets a secure share-access cookie over production forwarded HTTPS", async () => {
+    mocks.unlockShare.mockResolvedValueOnce(unlockResult);
+    const { POST } = await loadUnlockRoute();
+    const response = await POST(
+      jsonRequest("http://staaash:2113/s/lookup-1.signature/unlock", {
+        host: "staaash.example.com",
+        origin: "https://staaash.example.com",
+        "x-forwarded-proto": "https",
+      }),
+      { params: Promise.resolve({ token: "lookup-1.signature" }) },
+    );
+
+    expect(response.status).toBe(200);
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("staaash_share_access=");
+    expectCookieSecure(setCookie, true);
+  });
+});


### PR DESCRIPTION
## 🚀 Summary

Fix SHARE-01 by applying the existing request-aware secure-cookie policy to password-protected public-share access cookies.

- Extract the session cookie protocol and override resolver into a shared server helper.
- Use the shared policy when setting and clearing share-access cookies.
- Pass the unlock route's real request context to the share-cookie builder.
- Add unit and route-level regression coverage for HTTP, forwarded HTTPS, explicit overrides, clearing, and signature/fingerprint verification.

## 📊 Impacts and Changes

Password-protected shares now remain unlocked on direct production HTTP deployments when `SECURE_COOKIES` does not force secure cookies. Forwarded HTTPS and explicit `SECURE_COOKIES` overrides remain authoritative.

This changes only share-access cookie security resolution. Session behavior, cookie lifetime, cookie name and path, signed payloads, access fingerprints, password hashing, token handling, schema, storage, and restore behavior remain unchanged.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

No browser E2E was run for this focused cookie-policy change. Unit and route integration tests inspect emitted cookie attributes directly.

## 🔗 Linked Issues

SHARE-01 engineering audit finding.