### PR TITLE
docs: require offline PostgreSQL backups

### DIFF
--- a/docs/operations/backup-restore.md
+++ b/docs/operations/backup-restore.md
@@ -17,39 +17,69 @@ database migration runs.
 
 ## Backup Checklist
 
-1. Stop writes for a moment.
-   The simplest way is to stop Staaash while the backup runs:
+1. Stop application writes, then cleanly stop PostgreSQL:
 
    ```console
    docker compose stop staaash worker
+   docker compose stop db
    ```
 
-2. Copy `library` and `postgres` to your backup location.
-
-3. Start Staaash again:
+2. Confirm that all three services are stopped:
 
    ```console
-   docker compose up -d
+   docker compose ps --status running
    ```
 
-4. Keep more than one backup copy.
-   A good starting point is one local backup and one backup outside the machine.
+   The command must show no running services. Do not begin the copy while
+   `staaash`, `worker`, or `db` is running. Raw PostgreSQL data-directory copies
+   must not be taken while PostgreSQL is running.
+
+3. While all three services remain stopped, copy both configured host data
+   locations into the same backup set:
+   - `UPLOAD_LOCATION` (default: `./library`)
+   - `DB_DATA_LOCATION` (default: `./postgres`)
+
+   Read the paths from the deployment's `.env` file. Do not restart any service
+   until both copies have finished.
+
+4. Preserve the completed backup unchanged. Keep more than one backup copy; a
+   good starting point is one local backup and one backup outside the machine.
+
+5. Restart the complete stack:
+
+   ```console
+   docker compose up -d db staaash worker
+   ```
+
+6. Perform the restore drill below on a separate clean deployment before
+   trusting the backup.
 
 ## Restore Drill
 
-Test restore before you need it for real.
+Test restore before you need it for real. Use a copy for the drill and keep the
+original backup unchanged.
 
-1. Start from a clean folder with `docker-compose.yml` and `.env`.
-2. Put the backed-up `library` and `postgres` folders back in place.
-3. Start Staaash:
+1. Start from a separate clean folder with matching `docker-compose.yml` and
+   `.env` files. Do not start the deployment yet.
+2. Confirm that this clean deployment has no running services:
 
    ```console
-   docker compose up -d
+   docker compose ps --status running
    ```
 
-4. Sign in as the owner.
-5. Open the admin area and run the restore reconciliation job.
-6. Check the basics:
+3. Put both backed-up host data locations in the paths configured by
+   `UPLOAD_LOCATION` and `DB_DATA_LOCATION` in the clean deployment's `.env`
+   file. If those variables were not customized, restore them as `./library`
+   and `./postgres`. Keep PostgreSQL stopped until both locations are in place.
+4. Start the complete stack:
+
+   ```console
+   docker compose up -d db staaash worker
+   ```
+
+5. Sign in as the owner.
+6. Open the admin area and run the restore reconciliation job.
+7. Check the basics:
    - upload a small file
    - download an existing file
    - open a folder
@@ -113,5 +143,9 @@ Older alpha or beta schemas are not upgraded directly by this baseline. Update t
 
 - File names and folder paths live in the database.
 - File bytes live in `library`.
-- A backup that only includes one of them is incomplete.
-- Preview files can be rebuilt later, but original files cannot.
+- A backup containing only uploaded files is incomplete.
+- A backup containing only the database is incomplete.
+- Raw PostgreSQL data-directory copies must not be taken while PostgreSQL is
+  running.
+- Preview and other derivative files can be rebuilt later, but original uploaded
+  files cannot.


### PR DESCRIPTION
## 🚀 Summary

Fix BKP-01 by correcting the physical-backup procedure so PostgreSQL is cleanly stopped before its raw data directory is copied.

## 📊 Impacts and Changes

- Stop `staaash` and `worker`, then `db`, before copying data.
- Confirm no Compose services are running before backup or restore copying.
- Copy `UPLOAD_LOCATION` and `DB_DATA_LOCATION` within one stopped maintenance window.
- Restart the complete stack explicitly and test restores on a separate clean deployment.
- Clarify that either data location alone is an incomplete backup.
- Documentation only; no application, Compose, schema, migration, storage, or restore behavior changes.

Root cause: the previous checklist stopped application services but left PostgreSQL running during a raw filesystem copy.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.
- [x] `pnpm format:check` passed
- [x] `pnpm quality:fallow` passed
- [x] `git diff --check` passed

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

No live backup or restore was executed; validation remained documentation-only and non-destructive.

## 🔗 Linked Issues

None.