### PR TITLE
fix(release): keep prereleases off latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
             latest=false
           tags: |
             type=ref,event=tag
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Build and push
         uses: docker/build-push-action@v7


### PR DESCRIPTION
## 🚀 Summary

Gate Docker `latest` metadata generation to stable release tags.

Exact pushed version tags remain published for every `v*` release. Alpha, beta, and release-candidate tags no longer update `ghcr.io/itsmeares/staaash:latest`.

## 📊 Impacts and Changes

- Stable tags such as `v1.0.0` publish both `:v1.0.0` and `:latest`.
- Prerelease tags publish only their exact version tag.
- Workflow trigger and GitHub Release prerelease behavior remain unchanged.
- Schema, auth, storage, and restore behavior: None.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] Release behavior matrix validated with a temporary non-committed workflow evaluator.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

Additional checks: `pnpm format:check`, `pnpm quality:fallow`, `git diff --check`, YAML parsing, metadata-action syntax validation against official documentation, and all five required tag cases.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

No live tag, image, or GitHub Release publication was performed.

## 🔗 Linked Issues

Audit finding REL-02. No GitHub issue linked.