### PR TITLE
fix(auth): revoke sibling sessions after required password change

### DIFF
--- a/apps/web/app/api/auth/password-change-required/route.ts
+++ b/apps/web/app/api/auth/password-change-required/route.ts
@@ -32,10 +32,14 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await readRequestBody(request);
-    const user = await authService.changeRequiredPassword(session.user.id, {
-      password: body.password,
-      confirmPassword: body.confirmPassword,
-    });
+    const user = await authService.changeRequiredPassword(
+      session.user.id,
+      session.id,
+      {
+        password: body.password,
+        confirmPassword: body.confirmPassword,
+      },
+    );
     const onboardingCompleted = Boolean(
       user.preferences?.onboardingCompletedAt,
     );

--- a/apps/web/server/auth/password-change-required-route.test.ts
+++ b/apps/web/server/auth/password-change-required-route.test.ts
@@ -1,0 +1,74 @@
+import { NextRequest } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { changeRequiredPassword, getSession } = vi.hoisted(() => ({
+  changeRequiredPassword: vi.fn(),
+  getSession: vi.fn(),
+}));
+
+vi.mock("@/server/auth/service", () => ({
+  authService: {
+    changeRequiredPassword,
+    getSession,
+  },
+}));
+
+const request = () =>
+  new NextRequest("http://localhost:3000/api/auth/password-change-required", {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+      cookie: "staaash_session=session-token",
+      host: "localhost:3000",
+    },
+    body: JSON.stringify({
+      password: "replacement-pass-1",
+      confirmPassword: "replacement-pass-1",
+    }),
+  });
+
+describe("required password change route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes the authenticated user and current session IDs to the service", async () => {
+    getSession.mockResolvedValueOnce({
+      id: "session-current",
+      user: { id: "user-1" },
+    });
+    changeRequiredPassword.mockResolvedValueOnce({
+      preferences: null,
+    });
+    const { POST } =
+      await import("@/app/api/auth/password-change-required/route");
+
+    const response = await POST(request());
+
+    expect(getSession).toHaveBeenCalledWith("session-token");
+    expect(changeRequiredPassword).toHaveBeenCalledWith(
+      "user-1",
+      "session-current",
+      {
+        password: "replacement-pass-1",
+        confirmPassword: "replacement-pass-1",
+      },
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("set-cookie") ?? "").not.toContain(
+      "staaash_session",
+    );
+  });
+
+  it("rejects a missing authenticated session before changing the password", async () => {
+    getSession.mockResolvedValueOnce(null);
+    const { POST } =
+      await import("@/app/api/auth/password-change-required/route");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(401);
+    expect(changeRequiredPassword).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/server/auth/repository.test.ts
+++ b/apps/web/server/auth/repository.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getPrisma } = vi.hoisted(() => ({
+  getPrisma: vi.fn(),
+}));
+
+vi.mock("@staaash/db/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@staaash/db/client")>();
+
+  return {
+    ...actual,
+    getPrisma,
+  };
+});
+
+import { prismaAuthRepository } from "@/server/auth/repository";
+
+const now = new Date("2026-06-16T10:00:00.000Z");
+
+const updatedUser = {
+  id: "user-1",
+  email: "member@example.com",
+  storageId: "member",
+  displayName: null,
+  avatarUrl: null,
+  isOwner: false,
+  isAdmin: false,
+  passwordChangeRequiredAt: null,
+  temporaryPasswordIssuedAt: null,
+  temporaryPasswordIssuedByUserId: null,
+  storageLimitBytes: null,
+  preferences: null,
+  createdAt: now,
+  updatedAt: now,
+};
+
+describe("auth repository", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("updates the user and revokes active sibling sessions in one transaction", async () => {
+    const updateUser = vi.fn().mockResolvedValue(updatedUser);
+    const revokeSiblingSessions = vi.fn().mockResolvedValue({ count: 1 });
+    const transactionClient = {
+      user: { update: updateUser },
+      session: { updateMany: revokeSiblingSessions },
+    };
+    const transaction = vi.fn(
+      async (
+        callback: (client: typeof transactionClient) => Promise<unknown>,
+      ) => callback(transactionClient),
+    );
+    getPrisma.mockReturnValue({ $transaction: transaction });
+
+    const result = await prismaAuthRepository.changeRequiredPassword({
+      userId: "user-1",
+      currentSessionId: "session-current",
+      passwordHash: "replacement-password-hash",
+      now,
+    });
+
+    expect(transaction).toHaveBeenCalledOnce();
+    expect(updateUser).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      data: {
+        passwordHash: "replacement-password-hash",
+        passwordChangeRequiredAt: null,
+        temporaryPasswordIssuedAt: null,
+        temporaryPasswordIssuedByUserId: null,
+        updatedAt: now,
+      },
+      include: {
+        preferences: true,
+      },
+    });
+    expect(revokeSiblingSessions).toHaveBeenCalledWith({
+      where: {
+        userId: "user-1",
+        revokedAt: null,
+        id: {
+          not: "session-current",
+        },
+      },
+      data: {
+        revokedAt: now,
+      },
+    });
+    expect(result).toMatchObject({
+      id: "user-1",
+      passwordChangeRequiredAt: null,
+      temporaryPasswordIssuedAt: null,
+      temporaryPasswordIssuedByUserId: null,
+    });
+  });
+});

--- a/apps/web/server/auth/repository.ts
+++ b/apps/web/server/auth/repository.ts
@@ -63,6 +63,13 @@ type SetTemporaryPasswordParams = {
   now: Date;
 };
 
+type ChangeRequiredPasswordParams = {
+  userId: string;
+  currentSessionId: string;
+  passwordHash: string;
+  now: Date;
+};
+
 type SavePreferencesParams = {
   userId: string;
   theme: string;
@@ -93,9 +100,7 @@ export type AuthRepository = {
   ): Promise<AuthUser | null>;
   setTemporaryPassword(params: SetTemporaryPasswordParams): Promise<AuthUser>;
   changeRequiredPassword(
-    userId: string,
-    passwordHash: string,
-    now: Date,
+    params: ChangeRequiredPasswordParams,
   ): Promise<AuthUser | null>;
   createSession(params: CreateSessionParams): Promise<AuthSession>;
   findSessionByTokenHash(tokenHash: string): Promise<StoredAuthSession | null>;
@@ -488,25 +493,42 @@ const createPrismaAuthRepository = (
       }
     },
 
-    async changeRequiredPassword(userId, passwordHash, now) {
+    async changeRequiredPassword(params) {
       const client = getClient();
 
       try {
-        const user = await client.user.update({
-          where: { id: userId },
-          data: {
-            passwordHash,
-            passwordChangeRequiredAt: null,
-            temporaryPasswordIssuedAt: null,
-            temporaryPasswordIssuedByUserId: null,
-            updatedAt: now,
-          },
-          include: {
-            preferences: true,
-          },
-        });
+        return await client.$transaction(
+          async (tx: Prisma.TransactionClient) => {
+            const user = await tx.user.update({
+              where: { id: params.userId },
+              data: {
+                passwordHash: params.passwordHash,
+                passwordChangeRequiredAt: null,
+                temporaryPasswordIssuedAt: null,
+                temporaryPasswordIssuedByUserId: null,
+                updatedAt: params.now,
+              },
+              include: {
+                preferences: true,
+              },
+            });
 
-        return toAuthUser(user);
+            await tx.session.updateMany({
+              where: {
+                userId: params.userId,
+                revokedAt: null,
+                id: {
+                  not: params.currentSessionId,
+                },
+              },
+              data: {
+                revokedAt: params.now,
+              },
+            });
+
+            return toAuthUser(user);
+          },
+        );
       } catch (error) {
         if (
           error instanceof Prisma.PrismaClientKnownRequestError &&

--- a/apps/web/server/auth/service.test.ts
+++ b/apps/web/server/auth/service.test.ts
@@ -154,13 +154,26 @@ const createRepo = (state: State): AuthRepository => ({
     }
     return toAuthUser(user);
   },
-  async changeRequiredPassword(userId, passwordHash) {
-    const user = state.users.find((candidate) => candidate.id === userId);
+  async changeRequiredPassword(params) {
+    const user = state.users.find(
+      (candidate) => candidate.id === params.userId,
+    );
     if (!user) return null;
-    user.passwordHash = passwordHash;
+    user.passwordHash = params.passwordHash;
     user.passwordChangeRequiredAt = null;
     user.temporaryPasswordIssuedAt = null;
     user.temporaryPasswordIssuedByUserId = null;
+
+    for (const session of state.sessions) {
+      if (
+        session.user.id === params.userId &&
+        !session.revokedAt &&
+        session.id !== params.currentSessionId
+      ) {
+        session.revokedAt = params.now;
+      }
+    }
+
     return toAuthUser(user);
   },
   async createSession(params) {
@@ -324,5 +337,225 @@ describe("auth service", () => {
     expect(result.temporaryPassword).toBe("new-member-pass");
     expect(result.user.passwordChangeRequiredAt).toEqual(now);
     expect(state.sessions[0]?.revokedAt).toEqual(now);
+  });
+
+  it("changes a required password while preserving only the current session", async () => {
+    const alreadyRevokedAt = new Date("2026-06-15T10:00:00.000Z");
+    const unchangedUpdatedAt = new Date("2026-06-14T10:00:00.000Z");
+    const state: State = {
+      users: [
+        makeUser({
+          id: "owner-1",
+          email: "owner@example.com",
+          isOwner: true,
+          isAdmin: true,
+        }),
+        makeUser({
+          id: "member-1",
+          email: "member@example.com",
+        }),
+        makeUser({
+          id: "other-1",
+          email: "other@example.com",
+        }),
+      ],
+      sessions: [],
+    };
+    const service = createAuthService({
+      repo: createRepo(state),
+      now: () => now,
+      sessionMaxAgeDays: 30,
+    });
+
+    await service.resetTemporaryPassword("owner-1", "member-1", {
+      temporaryPassword: "temporary-pass-1",
+      confirmTemporaryPassword: "temporary-pass-1",
+      requirePasswordChange: true,
+    });
+    const temporaryPasswordHash = state.users[1]!.passwordHash;
+    const sessionA = await service.signIn({
+      email: "member@example.com",
+      password: "temporary-pass-1",
+    });
+    const sessionB = await service.signIn({
+      email: "member@example.com",
+      password: "temporary-pass-1",
+    });
+    expect(state.users[1]!.passwordChangeRequiredAt).toEqual(now);
+    expect(
+      state.sessions
+        .filter((session) => session.user.id === "member-1")
+        .map((session) => session.revokedAt),
+    ).toEqual([null, null]);
+    const otherUserSession: StoredAuthSession = {
+      id: "other-session",
+      user: toAuthUser(state.users[2]!),
+      tokenHash: "other-token-hash",
+      expiresAt: new Date("2026-07-16T10:00:00.000Z"),
+      revokedAt: null,
+      userAgent: null,
+      ipAddress: null,
+      lastSeenAt: now,
+      createdAt: now,
+      updatedAt: unchangedUpdatedAt,
+    };
+    const alreadyRevokedSession: StoredAuthSession = {
+      id: "already-revoked-session",
+      user: toAuthUser(state.users[1]!),
+      tokenHash: "already-revoked-token-hash",
+      expiresAt: new Date("2026-07-16T10:00:00.000Z"),
+      revokedAt: alreadyRevokedAt,
+      userAgent: null,
+      ipAddress: null,
+      lastSeenAt: unchangedUpdatedAt,
+      createdAt: unchangedUpdatedAt,
+      updatedAt: unchangedUpdatedAt,
+    };
+    state.sessions.push(otherUserSession, alreadyRevokedSession);
+
+    const updated = await service.changeRequiredPassword(
+      "member-1",
+      sessionA.session.id,
+      {
+        password: "replacement-pass-1",
+        confirmPassword: "replacement-pass-1",
+      },
+    );
+
+    expect(state.users[1]!.passwordHash).not.toBe(temporaryPasswordHash);
+    expect(updated).toMatchObject({
+      passwordChangeRequiredAt: null,
+      temporaryPasswordIssuedAt: null,
+      temporaryPasswordIssuedByUserId: null,
+    });
+    expect(
+      state.sessions.find((session) => session.id === sessionA.session.id)
+        ?.revokedAt,
+    ).toBeNull();
+    expect(
+      state.sessions.find((session) => session.id === sessionB.session.id)
+        ?.revokedAt,
+    ).toEqual(now);
+    expect(otherUserSession).toMatchObject({
+      revokedAt: null,
+      updatedAt: unchangedUpdatedAt,
+    });
+    expect(alreadyRevokedSession).toMatchObject({
+      revokedAt: alreadyRevokedAt,
+      lastSeenAt: unchangedUpdatedAt,
+      updatedAt: unchangedUpdatedAt,
+    });
+
+    await expect(
+      service.getSession(sessionA.sessionToken),
+    ).resolves.toMatchObject({ id: sessionA.session.id });
+    await expect(service.getSession(sessionB.sessionToken)).resolves.toBeNull();
+    await expect(
+      service.signIn({
+        email: "member@example.com",
+        password: "temporary-pass-1",
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_CREDENTIALS" });
+    await expect(
+      service.signIn({
+        email: "member@example.com",
+        password: "replacement-pass-1",
+      }),
+    ).resolves.toMatchObject({ user: { id: "member-1" } });
+  });
+
+  it("does not change the password or revoke sessions when no change is required", async () => {
+    const member = makeUser({
+      id: "member-1",
+      email: "member@example.com",
+      passwordHash: "unchanged-password-hash",
+    });
+    const state: State = {
+      users: [member],
+      sessions: [
+        {
+          id: "session-a",
+          user: toAuthUser(member),
+          tokenHash: "token-a",
+          expiresAt: new Date("2026-07-16T10:00:00.000Z"),
+          revokedAt: null,
+          userAgent: null,
+          ipAddress: null,
+          lastSeenAt: now,
+          createdAt: now,
+          updatedAt: now,
+        },
+        {
+          id: "session-b",
+          user: toAuthUser(member),
+          tokenHash: "token-b",
+          expiresAt: new Date("2026-07-16T10:00:00.000Z"),
+          revokedAt: null,
+          userAgent: null,
+          ipAddress: null,
+          lastSeenAt: now,
+          createdAt: now,
+          updatedAt: now,
+        },
+      ],
+    };
+    const service = createAuthService({
+      repo: createRepo(state),
+      now: () => now,
+      sessionMaxAgeDays: 30,
+    });
+
+    const result = await service.changeRequiredPassword(
+      "member-1",
+      "session-a",
+      {
+        password: "replacement-pass-1",
+        confirmPassword: "replacement-pass-1",
+      },
+    );
+
+    expect(result.id).toBe("member-1");
+    expect(member.passwordHash).toBe("unchanged-password-hash");
+    expect(state.sessions.map((session) => session.revokedAt)).toEqual([
+      null,
+      null,
+    ]);
+  });
+
+  it("preserves required password change validation and missing-user errors", async () => {
+    const member = makeUser({
+      id: "member-1",
+      passwordHash: "unchanged-password-hash",
+      passwordChangeRequiredAt: now,
+      temporaryPasswordIssuedAt: now,
+      temporaryPasswordIssuedByUserId: "owner-1",
+    });
+    const state: State = { users: [member], sessions: [] };
+    const service = createAuthService({
+      repo: createRepo(state),
+      now: () => now,
+      sessionMaxAgeDays: 30,
+    });
+
+    await expect(
+      service.changeRequiredPassword("member-1", "session-a", {
+        password: "short",
+        confirmPassword: "short",
+      }),
+    ).rejects.toMatchObject({ name: "ZodError" });
+    await expect(
+      service.changeRequiredPassword("member-1", "session-a", {
+        password: "replacement-pass-1",
+        confirmPassword: "different-pass-12",
+      }),
+    ).rejects.toMatchObject({ code: "PASSWORD_CONFIRMATION_MISMATCH" });
+    await expect(
+      service.changeRequiredPassword("missing-user", "session-a", {
+        password: "replacement-pass-1",
+        confirmPassword: "replacement-pass-1",
+      }),
+    ).rejects.toMatchObject({ code: "USER_NOT_FOUND" });
+    expect(member.passwordHash).toBe("unchanged-password-hash");
+    expect(member.passwordChangeRequiredAt).toEqual(now);
   });
 });

--- a/apps/web/server/auth/service.ts
+++ b/apps/web/server/auth/service.ts
@@ -477,6 +477,7 @@ export const createAuthService = ({
 
     async changeRequiredPassword(
       userId: string,
+      currentSessionId: string,
       input: { password: string; confirmPassword: string },
     ) {
       const parsed = requiredPasswordChangeInputSchema.parse(input);
@@ -497,11 +498,12 @@ export const createAuthService = ({
       }
 
       const passwordHash = await crypto.hashPassword(parsed.password);
-      const updated = await activeRepo.changeRequiredPassword(
+      const updated = await activeRepo.changeRequiredPassword({
         userId,
+        currentSessionId,
         passwordHash,
-        now(),
-      );
+        now: now(),
+      });
 
       if (!updated) {
         throw new AuthError("USER_NOT_FOUND");


### PR DESCRIPTION
## 🚀 Summary

Fixes audit finding AUTH-01 by revoking sibling sessions after a mandatory password change while preserving the session that submitted the change.

## 📊 Impacts and Changes

- Passes the authenticated current session ID into the required-password-change service.
- Updates the password, clears temporary-password metadata, and revokes other active sessions for the same user in one database transaction.
- Preserves the current session token and cookie.
- Leaves other users, already-revoked sessions, normal sign-in, and the no-change-required path unchanged.
- No schema, migration, storage, restore, or UI changes.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

Additional checks:

- `pnpm --filter web exec vitest run server/auth/service.test.ts server/auth/password-change-required-route.test.ts server/auth/repository.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web test`
- `pnpm format:check`
- `pnpm quality:fallow`
- `git diff --check`

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

No live PostgreSQL integration test was added. Repository-level coverage verifies that the user update and filtered sibling-session revocation use the same Prisma transaction callback.

## 🔗 Linked Issues

None. Audit finding: AUTH-01.
