### PR TITLE
fix(storage): preserve trash paths on ancestor rename

### DIFF
--- a/apps/web/server/files/service.test.ts
+++ b/apps/web/server/files/service.test.ts
@@ -728,6 +728,193 @@ describe.sequential("files service", () => {
     ).resolves.toBe("trashed contents");
   });
 
+  it("does not move an unrelated same-name trashed folder when renaming an active folder", async () => {
+    await cleanDataRoot();
+    const { repo, state } = createMemoryRepository();
+    const service = createService(repo);
+    const root = await service.ensureFilesRoot("member-1");
+    const oldParent = await service.createFolder({
+      actorUserId: "member-1",
+      actorRole: "member",
+      parentId: root.id,
+      name: "Parent",
+    });
+    const oldUpload = await service.uploadFiles({
+      actorUserId: "member-1",
+      actorRole: "member",
+      folderId: oldParent.folder.id,
+      items: [
+        {
+          clientKey: "old-file",
+          originalName: "old.txt",
+          conflictStrategy: "fail",
+          file: new File(["old parent contents"], "old.txt", {
+            type: "text/plain",
+          }),
+        },
+      ],
+    });
+
+    await service.trashFolder({
+      actorUserId: "member-1",
+      actorRole: "member",
+      folderId: oldParent.folder.id,
+    });
+
+    const activeParent = await service.createFolder({
+      actorUserId: "member-1",
+      actorRole: "member",
+      parentId: root.id,
+      name: "Parent",
+    });
+    const child = await service.createFolder({
+      actorUserId: "member-1",
+      actorRole: "member",
+      parentId: activeParent.folder.id,
+      name: "Child",
+    });
+    const activeUpload = await service.uploadFiles({
+      actorUserId: "member-1",
+      actorRole: "member",
+      folderId: child.folder.id,
+      items: [
+        {
+          clientKey: "active-file",
+          originalName: "active.txt",
+          conflictStrategy: "fail",
+          file: new File(["active child contents"], "active.txt", {
+            type: "text/plain",
+          }),
+        },
+      ],
+    });
+    const descendantUpload = await service.uploadFiles({
+      actorUserId: "member-1",
+      actorRole: "member",
+      folderId: child.folder.id,
+      items: [
+        {
+          clientKey: "descendant-file",
+          originalName: "trashed.txt",
+          conflictStrategy: "fail",
+          file: new File(["active parent trash"], "trashed.txt", {
+            type: "text/plain",
+          }),
+        },
+      ],
+    });
+
+    await service.trashFile({
+      actorUserId: "member-1",
+      actorRole: "member",
+      fileId: descendantUpload.uploadedFiles[0]!.id,
+    });
+    const oldTrashedFileBeforeRename = state.files.find(
+      (file) => file.id === oldUpload.uploadedFiles[0]!.id,
+    );
+
+    expect(oldTrashedFileBeforeRename?.storageKey).toBe(
+      ".trash/member-1/Parent/old.txt",
+    );
+
+    await service.renameFolder({
+      actorUserId: "member-1",
+      actorRole: "member",
+      folderId: activeParent.folder.id,
+      name: "Renamed",
+    });
+
+    const oldTrashedFile = state.files.find(
+      (file) => file.id === oldUpload.uploadedFiles[0]!.id,
+    );
+    const oldTrashedFolder = state.folders.find(
+      (folder) => folder.id === oldParent.folder.id,
+    );
+    const affectedTrashedFile = state.files.find(
+      (file) => file.id === descendantUpload.uploadedFiles[0]!.id,
+    );
+    const activeFile = state.files.find(
+      (file) => file.id === activeUpload.uploadedFiles[0]!.id,
+    );
+
+    expect(oldTrashedFile).toMatchObject({
+      storageKey: ".trash/member-1/Parent/old.txt",
+    });
+    expect(oldTrashedFile?.deletedAt).not.toBeNull();
+    expect(oldTrashedFolder).toMatchObject({
+      name: "Parent",
+      parentId: root.id,
+    });
+    expect(oldTrashedFolder?.deletedAt).not.toBeNull();
+    await expect(
+      readFile(getStoragePath(oldTrashedFile!.storageKey), "utf8"),
+    ).resolves.toBe("old parent contents");
+    await expect(
+      access(getStoragePath(".trash/member-1/Renamed/old.txt")),
+    ).rejects.toBeDefined();
+
+    expect(affectedTrashedFile).toMatchObject({
+      storageKey: ".trash/member-1/Renamed/Child/trashed.txt",
+    });
+    expect(affectedTrashedFile?.deletedAt).not.toBeNull();
+    await expect(
+      readFile(getStoragePath(affectedTrashedFile!.storageKey), "utf8"),
+    ).resolves.toBe("active parent trash");
+    await expect(
+      access(getStoragePath(".trash/member-1/Parent/Child/trashed.txt")),
+    ).rejects.toBeDefined();
+
+    expect(activeFile?.storageKey).toBe(
+      "files/member-1/Renamed/Child/active.txt",
+    );
+    await expect(
+      readFile(getStoragePath(activeFile!.storageKey), "utf8"),
+    ).resolves.toBe("active child contents");
+
+    await service.restoreFile({
+      actorUserId: "member-1",
+      actorRole: "member",
+      fileId: descendantUpload.uploadedFiles[0]!.id,
+    });
+    const restoredAffectedFile = state.files.find(
+      (file) => file.id === descendantUpload.uploadedFiles[0]!.id,
+    );
+    expect(restoredAffectedFile).toMatchObject({
+      folderId: child.folder.id,
+      storageKey: "files/member-1/Renamed/Child/trashed.txt",
+      deletedAt: null,
+    });
+    await expect(
+      readFile(getStoragePath(restoredAffectedFile!.storageKey), "utf8"),
+    ).resolves.toBe("active parent trash");
+    await expect(
+      access(getStoragePath(".trash/member-1/Renamed/Child/trashed.txt")),
+    ).rejects.toBeDefined();
+
+    const restoredOldParent = await service.restoreFolder({
+      actorUserId: "member-1",
+      actorRole: "member",
+      folderId: oldParent.folder.id,
+    });
+    const restoredOldFile = state.files.find(
+      (file) => file.id === oldUpload.uploadedFiles[0]!.id,
+    );
+    expect(restoredOldParent.restoredTo).toMatchObject({
+      kind: "original-parent",
+      folderId: root.id,
+    });
+    expect(restoredOldFile).toMatchObject({
+      storageKey: "files/member-1/Parent/old.txt",
+      deletedAt: null,
+    });
+    await expect(
+      readFile(getStoragePath(restoredOldFile!.storageKey), "utf8"),
+    ).resolves.toBe("old parent contents");
+    await expect(
+      access(getStoragePath(".trash/member-1/Parent/old.txt")),
+    ).rejects.toBeDefined();
+  });
+
   it("renames an active ancestor without stranding a trashed descendant folder tree", async () => {
     await cleanDataRoot();
     const { repo, state } = createMemoryRepository();
@@ -909,11 +1096,37 @@ describe.sequential("files service", () => {
         },
       ],
     });
+    const trashedTree = await service.createFolder({
+      actorUserId: "member-1",
+      actorRole: "member",
+      parentId: child.folder.id,
+      name: "TrashedTree",
+    });
+    const treeUpload = await service.uploadFiles({
+      actorUserId: "member-1",
+      actorRole: "member",
+      folderId: trashedTree.folder.id,
+      items: [
+        {
+          clientKey: "tree-file",
+          originalName: "inside.txt",
+          conflictStrategy: "fail",
+          file: new File(["tree contents"], "inside.txt", {
+            type: "text/plain",
+          }),
+        },
+      ],
+    });
 
     await service.trashFile({
       actorUserId: "member-1",
       actorRole: "member",
       fileId: trashedUpload.uploadedFiles[0]!.id,
+    });
+    await service.trashFolder({
+      actorUserId: "member-1",
+      actorRole: "member",
+      folderId: trashedTree.folder.id,
     });
     failNextUpdateFile(new Error("rename metadata failed"));
 
@@ -937,6 +1150,10 @@ describe.sequential("files service", () => {
       state.files.find((file) => file.id === trashedUpload.uploadedFiles[0]!.id)
         ?.storageKey,
     ).toBe(".trash/member-1/Parent/Child/trashed.txt");
+    expect(
+      state.files.find((file) => file.id === treeUpload.uploadedFiles[0]!.id)
+        ?.storageKey,
+    ).toBe(".trash/member-1/Parent/Child/TrashedTree/inside.txt");
     await expect(
       readFile(
         getStoragePath("files/member-1/Parent/Child/active.txt"),
@@ -950,10 +1167,19 @@ describe.sequential("files service", () => {
       ),
     ).resolves.toBe("trashed contents");
     await expect(
+      readFile(
+        getStoragePath(".trash/member-1/Parent/Child/TrashedTree/inside.txt"),
+        "utf8",
+      ),
+    ).resolves.toBe("tree contents");
+    await expect(
       access(getStoragePath("files/member-1/Renamed")),
     ).rejects.toBeDefined();
     await expect(
-      access(getStoragePath(".trash/member-1/Renamed")),
+      access(getStoragePath(".trash/member-1/Renamed/Child/trashed.txt")),
+    ).rejects.toBeDefined();
+    await expect(
+      access(getStoragePath(".trash/member-1/Renamed/Child/TrashedTree")),
     ).rejects.toBeDefined();
   });
 

--- a/apps/web/server/files/service.test.ts
+++ b/apps/web/server/files/service.test.ts
@@ -576,6 +576,387 @@ describe.sequential("files service", () => {
     });
   });
 
+  it("renames an active ancestor without stranding a standalone trashed descendant file", async () => {
+    await cleanDataRoot();
+    const { repo, state } = createMemoryRepository();
+    const service = createService(repo);
+    const root = await service.ensureFilesRoot("member-1");
+    const parent = await service.createFolder({
+      actorUserId: "member-1",
+      actorRole: "member",
+      parentId: root.id,
+      name: "Parent",
+    });
+    const child = await service.createFolder({
+      actorUserId: "member-1",
+      actorRole: "member",
+      parentId: parent.folder.id,
+      name: "Child",
+    });
+    const activeUpload = await service.uploadFiles({
+      actorUserId: "member-1",
+      actorRole: "member",
+      folderId: child.folder.id,
+      items: [
+        {
+          clientKey: "active",
+          originalName: "active.txt",
+          conflictStrategy: "fail",
+          file: new File(["active contents"], "active.txt", {
+            type: "text/plain",
+          }),
+        },
+      ],
+    });
+    const trashedUpload = await service.uploadFiles({
+      actorUserId: "member-1",
+      actorRole: "member",
+      folderId: child.folder.id,
+      items: [
+        {
+          clientKey: "trashed",
+          originalName: "trashed.txt",
+          conflictStrategy: "fail",
+          file: new File(["trashed contents"], "trashed.txt", {
+            type: "text/plain",
+          }),
+        },
+      ],
+    });
+    const otherRoot = await service.ensureFilesRoot("member-2");
+    const otherUpload = await service.uploadFiles({
+      actorUserId: "member-2",
+      actorRole: "member",
+      folderId: otherRoot.id,
+      items: [
+        {
+          clientKey: "other-user",
+          originalName: "untouched.txt",
+          conflictStrategy: "fail",
+          file: new File(["other contents"], "untouched.txt", {
+            type: "text/plain",
+          }),
+        },
+      ],
+    });
+
+    await service.trashFile({
+      actorUserId: "member-1",
+      actorRole: "member",
+      fileId: trashedUpload.uploadedFiles[0]!.id,
+    });
+    await service.renameFolder({
+      actorUserId: "member-1",
+      actorRole: "member",
+      folderId: parent.folder.id,
+      name: "Renamed",
+    });
+
+    const activeFile = state.files.find(
+      (file) => file.id === activeUpload.uploadedFiles[0]!.id,
+    );
+    const trashedFile = state.files.find(
+      (file) => file.id === trashedUpload.uploadedFiles[0]!.id,
+    );
+    const otherFile = state.files.find(
+      (file) => file.id === otherUpload.uploadedFiles[0]!.id,
+    );
+
+    expect(activeFile?.storageKey).toBe(
+      "files/member-1/Renamed/Child/active.txt",
+    );
+    expect(trashedFile).toMatchObject({
+      folderId: child.folder.id,
+      storageKey: ".trash/member-1/Renamed/Child/trashed.txt",
+    });
+    expect(trashedFile?.deletedAt).not.toBeNull();
+    expect(trashedFile?.storageKey.startsWith("files/")).toBe(false);
+    await expect(
+      access(getStoragePath("files/member-1/Renamed/Child")),
+    ).resolves.toBeUndefined();
+    await expect(
+      access(getStoragePath(".trash/member-1/Parent/Child/trashed.txt")),
+    ).rejects.toBeDefined();
+    await expect(
+      readFile(getStoragePath(trashedFile!.storageKey), "utf8"),
+    ).resolves.toBe("trashed contents");
+    await expect(
+      readFile(getStoragePath(activeFile!.storageKey), "utf8"),
+    ).resolves.toBe("active contents");
+    await expect(
+      access(getStoragePath("files/member-1/Renamed/Child/trashed.txt")),
+    ).rejects.toBeDefined();
+    expect(otherFile?.storageKey).toBe("files/member-2/untouched.txt");
+    await expect(
+      readFile(getStoragePath(otherFile!.storageKey), "utf8"),
+    ).resolves.toBe("other contents");
+
+    const trash = await service.listTrashFolders({
+      actorUserId: "member-1",
+      actorRole: "member",
+    });
+    expect(trash.files).toHaveLength(1);
+    expect(trash.files[0]).toMatchObject({
+      originalPathLabel: "Files / Renamed / Child / trashed.txt",
+      restoreLocation: {
+        kind: "original-parent",
+        folderId: child.folder.id,
+        pathLabel: "Files / Renamed / Child",
+      },
+    });
+
+    const restored = await service.restoreFile({
+      actorUserId: "member-1",
+      actorRole: "member",
+      fileId: trashedUpload.uploadedFiles[0]!.id,
+    });
+    const restoredFile = state.files.find(
+      (file) => file.id === trashedUpload.uploadedFiles[0]!.id,
+    );
+
+    expect(restored.restoredTo).toMatchObject({
+      kind: "original-parent",
+      folderId: child.folder.id,
+    });
+    expect(restoredFile).toMatchObject({
+      folderId: child.folder.id,
+      storageKey: "files/member-1/Renamed/Child/trashed.txt",
+      deletedAt: null,
+    });
+    await expect(
+      readFile(getStoragePath(restoredFile!.storageKey), "utf8"),
+    ).resolves.toBe("trashed contents");
+  });
+
+  it("renames an active ancestor without stranding a trashed descendant folder tree", async () => {
+    await cleanDataRoot();
+    const { repo, state } = createMemoryRepository();
+    const service = createService(repo);
+    const root = await service.ensureFilesRoot("member-1");
+    const parent = await service.createFolder({
+      actorUserId: "member-1",
+      actorRole: "member",
+      parentId: root.id,
+      name: "Parent",
+    });
+    const child = await service.createFolder({
+      actorUserId: "member-1",
+      actorRole: "member",
+      parentId: parent.folder.id,
+      name: "Child",
+    });
+    const trashedTree = await service.createFolder({
+      actorUserId: "member-1",
+      actorRole: "member",
+      parentId: child.folder.id,
+      name: "TrashedTree",
+    });
+    const nested = await service.createFolder({
+      actorUserId: "member-1",
+      actorRole: "member",
+      parentId: trashedTree.folder.id,
+      name: "Nested",
+    });
+    const upload = await service.uploadFiles({
+      actorUserId: "member-1",
+      actorRole: "member",
+      folderId: nested.folder.id,
+      items: [
+        {
+          clientKey: "nested-file",
+          originalName: "inside.txt",
+          conflictStrategy: "fail",
+          file: new File(["folder tree contents"], "inside.txt", {
+            type: "text/plain",
+          }),
+        },
+      ],
+    });
+
+    await service.trashFolder({
+      actorUserId: "member-1",
+      actorRole: "member",
+      folderId: trashedTree.folder.id,
+    });
+    await service.renameFolder({
+      actorUserId: "member-1",
+      actorRole: "member",
+      folderId: parent.folder.id,
+      name: "Renamed",
+    });
+
+    const trashedFolder = state.folders.find(
+      (folder) => folder.id === trashedTree.folder.id,
+    );
+    const trashedNestedFolder = state.folders.find(
+      (folder) => folder.id === nested.folder.id,
+    );
+    const trashedFile = state.files.find(
+      (file) => file.id === upload.uploadedFiles[0]!.id,
+    );
+
+    expect(trashedFolder?.deletedAt).not.toBeNull();
+    expect(trashedNestedFolder?.deletedAt).not.toBeNull();
+    expect(trashedFile).toMatchObject({
+      storageKey: ".trash/member-1/Renamed/Child/TrashedTree/Nested/inside.txt",
+    });
+    expect(trashedFile?.deletedAt).not.toBeNull();
+    await expect(
+      access(getStoragePath(".trash/member-1/Parent/Child/TrashedTree")),
+    ).rejects.toBeDefined();
+    await expect(
+      readFile(getStoragePath(trashedFile!.storageKey), "utf8"),
+    ).resolves.toBe("folder tree contents");
+    await expect(
+      access(
+        getStoragePath(
+          "files/member-1/Renamed/Child/TrashedTree/Nested/inside.txt",
+        ),
+      ),
+    ).rejects.toBeDefined();
+
+    const trash = await service.listTrashFolders({
+      actorUserId: "member-1",
+      actorRole: "member",
+    });
+    expect(trash.items).toHaveLength(1);
+    expect(trash.items[0]).toMatchObject({
+      originalPathLabel: "Files / Renamed / Child / TrashedTree",
+      restoreLocation: {
+        kind: "original-parent",
+        folderId: child.folder.id,
+        pathLabel: "Files / Renamed / Child",
+      },
+    });
+
+    const restored = await service.restoreFolder({
+      actorUserId: "member-1",
+      actorRole: "member",
+      folderId: trashedTree.folder.id,
+    });
+    const restoredFolder = state.folders.find(
+      (folder) => folder.id === trashedTree.folder.id,
+    );
+    const restoredNestedFolder = state.folders.find(
+      (folder) => folder.id === nested.folder.id,
+    );
+    const restoredFile = state.files.find(
+      (file) => file.id === upload.uploadedFiles[0]!.id,
+    );
+
+    expect(restored.restoredTo).toMatchObject({
+      kind: "original-parent",
+      folderId: child.folder.id,
+    });
+    expect(restoredFolder).toMatchObject({
+      parentId: child.folder.id,
+      deletedAt: null,
+    });
+    expect(restoredNestedFolder?.deletedAt).toBeNull();
+    expect(restoredFile).toMatchObject({
+      storageKey: "files/member-1/Renamed/Child/TrashedTree/Nested/inside.txt",
+      deletedAt: null,
+    });
+    await expect(
+      readFile(getStoragePath(restoredFile!.storageKey), "utf8"),
+    ).resolves.toBe("folder tree contents");
+  });
+
+  it("rolls back active and trash paths when folder rename metadata updating fails", async () => {
+    await cleanDataRoot();
+    const { repo, state, failNextUpdateFile } = createMemoryRepository();
+    const service = createService(repo);
+    const root = await service.ensureFilesRoot("member-1");
+    const parent = await service.createFolder({
+      actorUserId: "member-1",
+      actorRole: "member",
+      parentId: root.id,
+      name: "Parent",
+    });
+    const child = await service.createFolder({
+      actorUserId: "member-1",
+      actorRole: "member",
+      parentId: parent.folder.id,
+      name: "Child",
+    });
+    const activeUpload = await service.uploadFiles({
+      actorUserId: "member-1",
+      actorRole: "member",
+      folderId: child.folder.id,
+      items: [
+        {
+          clientKey: "active",
+          originalName: "active.txt",
+          conflictStrategy: "fail",
+          file: new File(["active contents"], "active.txt", {
+            type: "text/plain",
+          }),
+        },
+      ],
+    });
+    const trashedUpload = await service.uploadFiles({
+      actorUserId: "member-1",
+      actorRole: "member",
+      folderId: child.folder.id,
+      items: [
+        {
+          clientKey: "trashed",
+          originalName: "trashed.txt",
+          conflictStrategy: "fail",
+          file: new File(["trashed contents"], "trashed.txt", {
+            type: "text/plain",
+          }),
+        },
+      ],
+    });
+
+    await service.trashFile({
+      actorUserId: "member-1",
+      actorRole: "member",
+      fileId: trashedUpload.uploadedFiles[0]!.id,
+    });
+    failNextUpdateFile(new Error("rename metadata failed"));
+
+    await expect(
+      service.renameFolder({
+        actorUserId: "member-1",
+        actorRole: "member",
+        folderId: parent.folder.id,
+        name: "Renamed",
+      }),
+    ).rejects.toThrow("rename metadata failed");
+
+    expect(
+      state.folders.find((folder) => folder.id === parent.folder.id)?.name,
+    ).toBe("Parent");
+    expect(
+      state.files.find((file) => file.id === activeUpload.uploadedFiles[0]!.id)
+        ?.storageKey,
+    ).toBe("files/member-1/Parent/Child/active.txt");
+    expect(
+      state.files.find((file) => file.id === trashedUpload.uploadedFiles[0]!.id)
+        ?.storageKey,
+    ).toBe(".trash/member-1/Parent/Child/trashed.txt");
+    await expect(
+      readFile(
+        getStoragePath("files/member-1/Parent/Child/active.txt"),
+        "utf8",
+      ),
+    ).resolves.toBe("active contents");
+    await expect(
+      readFile(
+        getStoragePath(".trash/member-1/Parent/Child/trashed.txt"),
+        "utf8",
+      ),
+    ).resolves.toBe("trashed contents");
+    await expect(
+      access(getStoragePath("files/member-1/Renamed")),
+    ).rejects.toBeDefined();
+    await expect(
+      access(getStoragePath(".trash/member-1/Renamed")),
+    ).rejects.toBeDefined();
+  });
+
   it("moves, trashes, restores, and permanently deletes files", async () => {
     await cleanDataRoot();
     const { repo, addFolder } = createMemoryRepository();

--- a/apps/web/server/files/service.ts
+++ b/apps/web/server/files/service.ts
@@ -1150,19 +1150,38 @@ export const createFilesService = ({
           toPath: getStoragePath(activeToStorageKey),
         },
       ];
-      const hasTrashedDescendants =
-        descendants.some((item) => item.deletedAt !== null) ||
-        descendantFiles.some((item) => item.deletedAt !== null);
+      const topLevelTrashedFolders = descendants.filter((item) => {
+        if (!item.deletedAt) {
+          return false;
+        }
 
-      if (hasTrashedDescendants) {
+        const parent = item.parentId
+          ? currentFolderMap.get(item.parentId)
+          : null;
+
+        return !parent?.deletedAt;
+      });
+      const standaloneTrashedFiles = descendantFiles.filter((item) => {
+        if (!item.deletedAt) {
+          return false;
+        }
+
+        const parent = item.folderId
+          ? currentFolderMap.get(item.folderId)
+          : null;
+
+        return !parent?.deletedAt;
+      });
+
+      for (const trashedFolder of topLevelTrashedFolders) {
         const trashFromStorageKey = buildFolderStorageKey({
-          folder,
+          folder: trashedFolder,
           folderMap: currentFolderMap,
           filesRoot,
           trashed: true,
         });
         const trashToStorageKey = buildFolderStorageKey({
-          folder: nextFolder,
+          folder: trashedFolder,
           folderMap: nextFolderMap,
           filesRoot,
           trashed: true,
@@ -1170,6 +1189,20 @@ export const createFilesService = ({
 
         storageMoves.push({
           fromPath: getStoragePath(trashFromStorageKey),
+          toPath: getStoragePath(trashToStorageKey),
+        });
+      }
+
+      for (const trashedFile of standaloneTrashedFiles) {
+        const trashToStorageKey = buildFileStorageKey({
+          file: trashedFile,
+          folderMap: nextFolderMap,
+          filesRoot,
+          trashed: true,
+        });
+
+        storageMoves.push({
+          fromPath: getStoragePath(trashedFile.storageKey),
           toPath: getStoragePath(trashToStorageKey),
         });
       }

--- a/apps/web/server/files/service.ts
+++ b/apps/web/server/files/service.ts
@@ -37,6 +37,7 @@ import {
   finalizePendingDelete,
   getDirectoryMutationLockKey,
   getEntryMutationLockKey,
+  moveStorageEntriesWithLock,
   moveStorageEntryWithLock,
   quarantineDeleteWithLock,
   rollbackPendingDelete,
@@ -1131,73 +1132,117 @@ export const createFilesService = ({
       });
       const previousFileStates: Array<Pick<StoredFile, "id" | "storageKey">> =
         [];
-      const fromStorageKey = buildFolderStorageKey({
+      const activeFromStorageKey = buildFolderStorageKey({
         folder,
         folderMap: currentFolderMap,
         filesRoot,
         trashed: false,
       });
-      const toStorageKey = buildFolderStorageKey({
+      const activeToStorageKey = buildFolderStorageKey({
         folder: nextFolder,
         folderMap: nextFolderMap,
         filesRoot,
         trashed: false,
       });
+      const storageMoves = [
+        {
+          fromPath: getStoragePath(activeFromStorageKey),
+          toPath: getStoragePath(activeToStorageKey),
+        },
+      ];
+      const hasTrashedDescendants =
+        descendants.some((item) => item.deletedAt !== null) ||
+        descendantFiles.some((item) => item.deletedAt !== null);
 
-      await moveStorageEntry({
-        fromStorageKey,
-        toStorageKey,
-      });
-
-      try {
-        const updatedFolder = await activeRepo.updateFolder({
-          id: folder.id,
-          name: normalizedName,
+      if (hasTrashedDescendants) {
+        const trashFromStorageKey = buildFolderStorageKey({
+          folder,
+          folderMap: currentFolderMap,
+          filesRoot,
+          trashed: true,
+        });
+        const trashToStorageKey = buildFolderStorageKey({
+          folder: nextFolder,
+          folderMap: nextFolderMap,
+          filesRoot,
+          trashed: true,
         });
 
-        for (const descendantFile of descendantFiles) {
-          const nextStorageKey = buildFileStorageKey({
-            file: descendantFile,
-            folderMap: nextFolderMap,
-            filesRoot,
-            trashed: false,
-          });
-
-          if (nextStorageKey === descendantFile.storageKey) {
-            continue;
-          }
-
-          previousFileStates.push({
-            id: descendantFile.id,
-            storageKey: descendantFile.storageKey,
-          });
-          await activeRepo.updateFile({
-            id: descendantFile.id,
-            storageKey: nextStorageKey,
-          });
-        }
-
-        return {
-          folder: updatedFolder,
-        };
-      } catch (error) {
-        for (const previousFileState of previousFileStates.reverse()) {
-          await activeRepo.updateFile({
-            id: previousFileState.id,
-            storageKey: previousFileState.storageKey,
-          });
-        }
-
-        await activeRepo.updateFolder({
-          id: folder.id,
-          name: folder.name,
+        storageMoves.push({
+          fromPath: getStoragePath(trashFromStorageKey),
+          toPath: getStoragePath(trashToStorageKey),
         });
-        await moveStorageEntry({
-          fromStorageKey: toStorageKey,
-          toStorageKey: fromStorageKey,
-        });
-        throw error;
       }
+
+      return moveStorageEntriesWithLock({
+        entries: storageMoves,
+        lockKeys: storageMoves.flatMap(({ fromPath, toPath }) => [
+          getEntryMutationLockKey(fromPath),
+          getDirectoryMutationLockKey(fromPath),
+          getDirectoryMutationLockKey(toPath),
+        ]),
+        applyMetadataUpdate: async () => {
+          let folderUpdated = false;
+
+          try {
+            const updatedFolder = await activeRepo.updateFolder({
+              id: folder.id,
+              name: normalizedName,
+            });
+            folderUpdated = true;
+
+            for (const descendantFile of descendantFiles) {
+              const nextStorageKey = buildFileStorageKey({
+                file: descendantFile,
+                folderMap: nextFolderMap,
+                filesRoot,
+                trashed: descendantFile.deletedAt !== null,
+              });
+
+              if (nextStorageKey === descendantFile.storageKey) {
+                continue;
+              }
+
+              previousFileStates.push({
+                id: descendantFile.id,
+                storageKey: descendantFile.storageKey,
+              });
+              await activeRepo.updateFile({
+                id: descendantFile.id,
+                storageKey: nextStorageKey,
+              });
+            }
+
+            return {
+              folder: updatedFolder,
+            };
+          } catch (error) {
+            for (const previousFileState of [...previousFileStates].reverse()) {
+              try {
+                await activeRepo.updateFile({
+                  id: previousFileState.id,
+                  storageKey: previousFileState.storageKey,
+                });
+              } catch {
+                // Preserve the original metadata error.
+              }
+            }
+
+            if (folderUpdated) {
+              try {
+                await activeRepo.updateFolder({
+                  id: folder.id,
+                  name: folder.name,
+                });
+              } catch {
+                // Preserve the original metadata error.
+              }
+            }
+
+            throw error;
+          }
+        },
+      });
     },
 
     async moveFolder({

--- a/apps/web/server/storage-mutations.ts
+++ b/apps/web/server/storage-mutations.ts
@@ -64,6 +64,13 @@ type MoveStorageEntryWithLockOptions = {
   deadline?: StorageDeadline;
 };
 
+type MoveStorageEntriesWithLockOptions<T> = {
+  entries: Array<Pick<MoveStorageEntryWithLockOptions, "fromPath" | "toPath">>;
+  lockKeys: string[];
+  deadline?: StorageDeadline;
+  applyMetadataUpdate: () => Promise<T>;
+};
+
 type QuarantineDeleteWithLockOptions = {
   fileId: string;
   originalStorageKey: string;
@@ -300,6 +307,49 @@ export const moveStorageEntryWithLock = async ({
       await assertPathMissing(toPath);
       await mkdir(path.dirname(toPath), { recursive: true });
       await rename(fromPath, toPath);
+    },
+  });
+
+export const moveStorageEntriesWithLock = async <T>({
+  entries,
+  lockKeys,
+  deadline,
+  applyMetadataUpdate,
+}: MoveStorageEntriesWithLockOptions<T>) =>
+  withStorageLocks({
+    lockKeys,
+    deadline,
+    callback: async () => {
+      const pendingEntries = entries.filter(
+        ({ fromPath, toPath }) => fromPath !== toPath,
+      );
+      const movedEntries: typeof pendingEntries = [];
+
+      for (const { fromPath, toPath } of pendingEntries) {
+        await assertPathPresent(fromPath);
+        await assertPathMissing(toPath);
+      }
+
+      try {
+        for (const entry of pendingEntries) {
+          await mkdir(path.dirname(entry.toPath), { recursive: true });
+          await rename(entry.fromPath, entry.toPath);
+          movedEntries.push(entry);
+        }
+
+        return await applyMetadataUpdate();
+      } catch (error) {
+        for (const entry of [...movedEntries].reverse()) {
+          try {
+            await mkdir(path.dirname(entry.fromPath), { recursive: true });
+            await rename(entry.toPath, entry.fromPath);
+          } catch {
+            // Preserve the original storage or metadata error.
+          }
+        }
+
+        throw error;
+      }
     },
   });
 


### PR DESCRIPTION
## 🚀 Summary

Fixes audit finding `STO-01`: renaming an active ancestor no longer strands already-trashed descendant files or folder trees.

`renameFolder` keeps deleted descendant storage keys under `.trash/`, selects only affected trash entries, and coordinates active/trash movements under one storage lock set.

## 📊 Impacts and Changes

- Active descendants continue moving to the renamed `files/...` hierarchy.
- Top-level trashed descendant folder trees move once; standalone trashed descendant files move individually.
- Unrelated same-name trashed folder trees sharing the old physical trash prefix remain unchanged and restorable.
- Trashed bytes never enter the active namespace during ancestor rename.
- Restores still target the original parent when active and Files root only when current rules require fallback.
- Metadata update failures restore every moved entry plus prior folder/file metadata while preserving the original error.
- No schema, auth, retention, permanent-delete, or restore-destination policy changes.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

Additional validation:

- `pnpm --filter web exec vitest run server/files/service.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web test`
- `pnpm format:check`
- `pnpm quality:fallow`
- `git diff --check`

Regression coverage includes same-name unrelated trash isolation, restore behavior for both logical trees, active descendant movement, canonical path checks, and rollback across standalone-file plus folder-tree trash moves.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

This scoped fix does not redesign crash consistency or claim filesystem/database mutations are crash-atomic.

## 🔗 Linked Issues

None.