### PR TITLE
fix(security): harden public share content

### DIFF
--- a/apps/web/app/s/[token]/content/route.ts
+++ b/apps/web/app/s/[token]/content/route.ts
@@ -1,37 +1,9 @@
-import { cookies } from "next/headers";
-
-import { createShareErrorResponse } from "@/app/s/share-response";
-import { SHARE_ACCESS_COOKIE_NAME } from "@/server/sharing/access-cookie";
-import { sharingService } from "@/server/sharing/service";
-import {
-  createMediaErrorResponse,
-  MediaContentError,
-} from "@/server/media/content-response";
-import { createInlineContentResponse } from "@/server/media/derivative-content-response";
+import { createPublicShareContentRouteResponse } from "@/app/s/content-route-response";
 
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ token: string }> },
 ) {
   const { token } = await params;
-  const cookieStore = await cookies();
-
-  try {
-    const { file } = await sharingService.getSharedFileContent({
-      token,
-      shareAccessCookieValue:
-        cookieStore.get(SHARE_ACCESS_COOKIE_NAME)?.value ?? null,
-    });
-
-    return await createInlineContentResponse({
-      request,
-      file,
-    });
-  } catch (error) {
-    if (error instanceof MediaContentError) {
-      return createMediaErrorResponse(error);
-    }
-
-    return createShareErrorResponse(error);
-  }
+  return createPublicShareContentRouteResponse({ request, token });
 }

--- a/apps/web/app/s/[token]/files/[fileId]/content/route.ts
+++ b/apps/web/app/s/[token]/files/[fileId]/content/route.ts
@@ -1,38 +1,13 @@
-import { cookies } from "next/headers";
-
-import { createShareErrorResponse } from "@/app/s/share-response";
-import { SHARE_ACCESS_COOKIE_NAME } from "@/server/sharing/access-cookie";
-import { sharingService } from "@/server/sharing/service";
-import {
-  createMediaErrorResponse,
-  MediaContentError,
-} from "@/server/media/content-response";
-import { createInlineContentResponse } from "@/server/media/derivative-content-response";
+import { createPublicShareContentRouteResponse } from "@/app/s/content-route-response";
 
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ token: string; fileId: string }> },
 ) {
   const { token, fileId } = await params;
-  const cookieStore = await cookies();
-
-  try {
-    const { file } = await sharingService.getSharedNestedFileContent({
-      token,
-      fileId,
-      shareAccessCookieValue:
-        cookieStore.get(SHARE_ACCESS_COOKIE_NAME)?.value ?? null,
-    });
-
-    return await createInlineContentResponse({
-      request,
-      file,
-    });
-  } catch (error) {
-    if (error instanceof MediaContentError) {
-      return createMediaErrorResponse(error);
-    }
-
-    return createShareErrorResponse(error);
-  }
+  return createPublicShareContentRouteResponse({
+    request,
+    token,
+    fileId,
+  });
 }

--- a/apps/web/app/s/[token]/files/[fileId]/page.tsx
+++ b/apps/web/app/s/[token]/files/[fileId]/page.tsx
@@ -11,6 +11,7 @@ import { getShareBaseUrl } from "@/server/request";
 import { SHARE_ACCESS_COOKIE_NAME } from "@/server/sharing/access-cookie";
 import { ShareError, isShareError } from "@/server/sharing/errors";
 import { getSharePageMetadata } from "@/server/sharing/metadata";
+import { getPublicShareFilePreview } from "@/server/sharing/public-file-preview";
 import { sharingService } from "@/server/sharing/service";
 
 export const dynamic = "force-dynamic";
@@ -80,6 +81,7 @@ export default async function SharedNestedFilePage({
     if (!file.viewerKind) {
       notFound();
     }
+    const preview = await getPublicShareFilePreview(file);
 
     const backHref =
       file.folderId === resolution.listing.rootFolder.id
@@ -94,6 +96,7 @@ export default async function SharedNestedFilePage({
         downloadHref={`/s/${encodeURIComponent(token)}/files/${file.id}/download`}
         file={file}
         headerLabel="Shared file"
+        preview={preview}
         searchParams={resolvedSearchParams}
         share={resolution.share}
       />

--- a/apps/web/app/s/[token]/page.tsx
+++ b/apps/web/app/s/[token]/page.tsx
@@ -6,6 +6,7 @@ import { getShareBaseUrl } from "@/server/request";
 import { SHARE_ACCESS_COOKIE_NAME } from "@/server/sharing/access-cookie";
 import { ShareError, isShareError } from "@/server/sharing/errors";
 import { getSharePageMetadata } from "@/server/sharing/metadata";
+import { getPublicShareFilePreview } from "@/server/sharing/public-file-preview";
 import { sharingService } from "@/server/sharing/service";
 
 export const dynamic = "force-dynamic";
@@ -50,9 +51,14 @@ export default async function SharedRootPage({
       shareAccessCookieValue:
         cookieStore.get(SHARE_ACCESS_COOKIE_NAME)?.value ?? null,
     });
+    const filePreview =
+      resolution.kind === "file" && resolution.access.isUnlocked
+        ? await getPublicShareFilePreview(resolution.file)
+        : null;
 
     return (
       <ShareView
+        filePreview={filePreview}
         resolution={resolution}
         searchParams={resolvedSearchParams}
         token={token}

--- a/apps/web/app/s/content-route-response.ts
+++ b/apps/web/app/s/content-route-response.ts
@@ -23,7 +23,7 @@ export const createPublicShareContentRouteResponse = async ({
     cookieStore.get(SHARE_ACCESS_COOKIE_NAME)?.value ?? null;
 
   try {
-    const { file } = fileId
+    const { file, downloadDisabled } = fileId
       ? await sharingService.getSharedNestedFileContent({
           token,
           fileId,
@@ -33,15 +33,10 @@ export const createPublicShareContentRouteResponse = async ({
           token,
           shareAccessCookieValue,
         });
-    const resolution = await sharingService.resolvePublicShare({
-      token,
-      shareAccessCookieValue,
-    });
-
     return await createPublicShareContentResponse({
       request,
       file,
-      downloadDisabled: resolution.share.downloadDisabled,
+      downloadDisabled,
     });
   } catch (error) {
     if (error instanceof MediaContentError) {

--- a/apps/web/app/s/content-route-response.ts
+++ b/apps/web/app/s/content-route-response.ts
@@ -1,0 +1,45 @@
+import { cookies } from "next/headers";
+
+import { createShareErrorResponse } from "@/app/s/share-response";
+import {
+  createMediaErrorResponse,
+  MediaContentError,
+} from "@/server/media/content-response";
+import { createPublicShareContentResponse } from "@/server/media/public-share-content-response";
+import { SHARE_ACCESS_COOKIE_NAME } from "@/server/sharing/access-cookie";
+import { sharingService } from "@/server/sharing/service";
+
+export const createPublicShareContentRouteResponse = async ({
+  request,
+  token,
+  fileId,
+}: {
+  request: Request;
+  token: string;
+  fileId?: string;
+}): Promise<Response> => {
+  const cookieStore = await cookies();
+  const shareAccessCookieValue =
+    cookieStore.get(SHARE_ACCESS_COOKIE_NAME)?.value ?? null;
+
+  try {
+    const { file } = fileId
+      ? await sharingService.getSharedNestedFileContent({
+          token,
+          fileId,
+          shareAccessCookieValue,
+        })
+      : await sharingService.getSharedFileContent({
+          token,
+          shareAccessCookieValue,
+        });
+
+    return await createPublicShareContentResponse({ request, file });
+  } catch (error) {
+    if (error instanceof MediaContentError) {
+      return createMediaErrorResponse(error);
+    }
+
+    return createShareErrorResponse(error);
+  }
+};

--- a/apps/web/app/s/content-route-response.ts
+++ b/apps/web/app/s/content-route-response.ts
@@ -33,8 +33,16 @@ export const createPublicShareContentRouteResponse = async ({
           token,
           shareAccessCookieValue,
         });
+    const resolution = await sharingService.resolvePublicShare({
+      token,
+      shareAccessCookieValue,
+    });
 
-    return await createPublicShareContentResponse({ request, file });
+    return await createPublicShareContentResponse({
+      request,
+      file,
+      downloadDisabled: resolution.share.downloadDisabled,
+    });
   } catch (error) {
     if (error instanceof MediaContentError) {
       return createMediaErrorResponse(error);

--- a/apps/web/app/s/poster-response.ts
+++ b/apps/web/app/s/poster-response.ts
@@ -67,5 +67,6 @@ export const createSharePosterResponse = async ({
     request,
     derivative,
     fileName: createPosterFileName(file.name),
+    downloadDisabled: resolution.share.downloadDisabled,
   });
 };

--- a/apps/web/app/s/poster-response.ts
+++ b/apps/web/app/s/poster-response.ts
@@ -4,7 +4,7 @@ import {
   createMediaErrorResponse,
   MediaContentError,
 } from "@/server/media/content-response";
-import { createReadyDerivativeContentResponse } from "@/server/media/derivative-content-response";
+import { createPublicReadyDerivativeContentResponse } from "@/server/media/public-share-content-response";
 import type { FileSummary } from "@/server/files/types";
 import { sharingService } from "@/server/sharing/service";
 
@@ -63,7 +63,7 @@ export const createSharePosterResponse = async ({
   const derivative = await findReadyPosterDerivative(file.id);
   if (!derivative) throw posterNotFound();
 
-  return createReadyDerivativeContentResponse({
+  return createPublicReadyDerivativeContentResponse({
     request,
     derivative,
     fileName: createPosterFileName(file.name),

--- a/apps/web/app/s/share-view.tsx
+++ b/apps/web/app/s/share-view.tsx
@@ -14,6 +14,7 @@ import { authService } from "@/server/auth/service";
 import { ShareAudioPlayer } from "./share-audio-player";
 import type { FileSummary } from "@/server/files/types";
 import { ShareError } from "@/server/sharing/errors";
+import { isPublicShareMimeSafeInline } from "@/server/media/public-share-content-policy";
 import type {
   PublicShareResolution,
   ShareLinkSummary,
@@ -173,6 +174,7 @@ export function ShareFilePage({
     ? file.name.split(".").pop()?.toLowerCase()
     : null;
   const formatLabel = ext ?? file.mimeType;
+  const safeNativeInline = isPublicShareMimeSafeInline(file.mimeType);
 
   return (
     <main className="share-page sp-file-layout">
@@ -193,9 +195,9 @@ export function ShareFilePage({
       </div>
 
       {/* Content */}
-      {file.viewerKind === "audio" ? (
+      {file.viewerKind === "audio" && safeNativeInline ? (
         <ShareAudioPlayer src={contentHref} fileName={file.name} />
-      ) : file.viewerKind === "pdf" ? (
+      ) : file.viewerKind === "pdf" && safeNativeInline ? (
         <embed
           src={contentHref}
           type="application/pdf"
@@ -203,7 +205,8 @@ export function ShareFilePage({
         />
       ) : file.viewerKind === "text" ? (
         <TextFileViewer contentHref={contentHref} />
-      ) : file.viewerKind === "image" || file.viewerKind === "video" ? (
+      ) : (file.viewerKind === "image" || file.viewerKind === "video") &&
+        safeNativeInline ? (
         <section
           className="panel stack sp-media"
           style={{

--- a/apps/web/app/s/share-view.tsx
+++ b/apps/web/app/s/share-view.tsx
@@ -14,7 +14,7 @@ import { authService } from "@/server/auth/service";
 import { ShareAudioPlayer } from "./share-audio-player";
 import type { FileSummary } from "@/server/files/types";
 import { ShareError } from "@/server/sharing/errors";
-import { isPublicShareMimeSafeInline } from "@/server/media/public-share-content-policy";
+import { isPublicShareFileNativeViewSafe } from "@/server/media/public-share-content-policy";
 import type {
   PublicShareResolution,
   ShareLinkSummary,
@@ -174,7 +174,9 @@ export function ShareFilePage({
     ? file.name.split(".").pop()?.toLowerCase()
     : null;
   const formatLabel = ext ?? file.mimeType;
-  const safeNativeInline = isPublicShareMimeSafeInline(file.mimeType);
+  const safeNativeInline = isPublicShareFileNativeViewSafe(file);
+  const canViewTextSource =
+    file.viewerKind === "text" && (safeNativeInline || !share.downloadDisabled);
 
   return (
     <main className="share-page sp-file-layout">
@@ -203,7 +205,7 @@ export function ShareFilePage({
           type="application/pdf"
           style={{ width: "100%", height: "75vh" }}
         />
-      ) : file.viewerKind === "text" ? (
+      ) : canViewTextSource ? (
         <TextFileViewer contentHref={contentHref} />
       ) : (file.viewerKind === "image" || file.viewerKind === "video") &&
         safeNativeInline ? (

--- a/apps/web/app/s/share-view.tsx
+++ b/apps/web/app/s/share-view.tsx
@@ -16,6 +16,7 @@ import type { FileSummary } from "@/server/files/types";
 import { ShareError } from "@/server/sharing/errors";
 import { isPublicShareFileNativeViewSafe } from "@/server/media/public-share-content-policy";
 import type {
+  PublicShareFilePreview,
   PublicShareResolution,
   ShareLinkSummary,
 } from "@/server/sharing/types";
@@ -155,6 +156,7 @@ export function ShareFilePage({
   downloadHref,
   file,
   headerLabel,
+  preview,
   searchParams,
   share,
 }: {
@@ -164,6 +166,7 @@ export function ShareFilePage({
   downloadHref?: string;
   file: FileSummary;
   headerLabel: string;
+  preview?: PublicShareFilePreview | null;
   searchParams: Record<string, string | string[] | undefined>;
   share: Pick<ShareLinkSummary, "downloadDisabled" | "expiresAt">;
 }) {
@@ -174,7 +177,7 @@ export function ShareFilePage({
     ? file.name.split(".").pop()?.toLowerCase()
     : null;
   const formatLabel = ext ?? file.mimeType;
-  const safeNativeInline = isPublicShareFileNativeViewSafe(file);
+  const safeNativeInline = isPublicShareFileNativeViewSafe(file, preview);
   const canViewTextSource =
     file.viewerKind === "text" && (safeNativeInline || !share.downloadDisabled);
 
@@ -281,12 +284,18 @@ export function ShareFilePage({
 }
 
 type ShareViewProps = {
+  filePreview?: PublicShareFilePreview | null;
   resolution: PublicShareResolution;
   token: string;
   searchParams: Record<string, string | string[] | undefined>;
 };
 
-export function ShareView({ resolution, token, searchParams }: ShareViewProps) {
+export function ShareView({
+  filePreview,
+  resolution,
+  token,
+  searchParams,
+}: ShareViewProps) {
   const error = getSingleSearchParam(searchParams, "error");
   const success = getSingleSearchParam(searchParams, "success");
   const isLocked =
@@ -316,6 +325,7 @@ export function ShareView({ resolution, token, searchParams }: ShareViewProps) {
         downloadHref={`/s/${encodeURIComponent(token)}/download`}
         file={resolution.file}
         headerLabel="Shared file"
+        preview={filePreview}
         searchParams={searchParams}
         share={resolution.share}
       />

--- a/apps/web/e2e/public-share-active-content.spec.ts
+++ b/apps/web/e2e/public-share-active-content.spec.ts
@@ -1,0 +1,236 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { getMemberCredentials, getOwnerCredentials, signIn } from "./helpers";
+
+type ActiveFixture = {
+  body: string;
+  mimeType: string;
+  name: string;
+};
+
+type UploadResponse = {
+  uploadedFiles: Array<{ id: string }>;
+};
+
+type ShareResponse = {
+  share: { shareUrl?: string };
+};
+
+const activeEmbedSelector = [
+  'audio[src*="/content"]',
+  'embed[src*="/content"]',
+  'iframe[src*="/content"]',
+  'img[src*="/content"]',
+  'object[data*="/content"]',
+  'video[src*="/content"]',
+].join(", ");
+
+const readExecutionMarkers = (page: Page) =>
+  page.evaluate(() => {
+    const markerWindow = window as typeof window & {
+      __staaashSec01HtmlExecuted?: boolean;
+      __staaashSec01SvgExecuted?: boolean;
+    };
+    return {
+      html: markerWindow.__staaashSec01HtmlExecuted,
+      svg: markerWindow.__staaashSec01SvgExecuted,
+    };
+  });
+
+const expectApiSuccess = async (
+  response: Awaited<ReturnType<Page["request"]["post"]>>,
+) => {
+  if (!response.ok()) {
+    throw new Error(
+      `Fixture API request failed (${response.status()}): ${await response.text()}`,
+    );
+  }
+};
+
+const uploadAndShareActiveFixture = async (
+  page: Page,
+  fixture: ActiveFixture,
+) => {
+  const origin = new URL(page.url()).origin;
+  const uploadResponse = await page
+    .context()
+    .request.post(`${origin}/api/files/files`, {
+      headers: {
+        accept: "application/json",
+        origin,
+      },
+      multipart: {
+        files: {
+          name: fixture.name,
+          mimeType: fixture.mimeType,
+          buffer: Buffer.from(fixture.body),
+        },
+        manifest: JSON.stringify([
+          {
+            clientKey: fixture.name,
+            conflictStrategy: "fail",
+            originalName: fixture.name,
+          },
+        ]),
+      },
+    });
+  await expectApiSuccess(uploadResponse);
+
+  const upload = (await uploadResponse.json()) as UploadResponse;
+  const fileId = upload.uploadedFiles[0]?.id;
+  if (!fileId) {
+    throw new Error("Fixture upload returned no file id.");
+  }
+
+  const shareResponse = await page
+    .context()
+    .request.post(`${origin}/api/shares`, {
+      data: {
+        downloadDisabled: false,
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        fileId,
+        targetType: "file",
+      },
+      headers: {
+        accept: "application/json",
+        origin,
+      },
+    });
+  await expectApiSuccess(shareResponse);
+
+  const share = (await shareResponse.json()) as ShareResponse;
+  if (!share.share.shareUrl) {
+    throw new Error("Fixture share creation returned no public URL.");
+  }
+
+  return share.share.shareUrl;
+};
+
+const expectDirectContentDownload = async ({
+  page,
+  contentUrl,
+  expectedFileName,
+  expectedPageUrl,
+}: {
+  page: Page;
+  contentUrl: string;
+  expectedFileName: string;
+  expectedPageUrl: string;
+}) => {
+  const downloadPromise = page.waitForEvent("download");
+  await page.evaluate((href) => window.location.assign(href), contentUrl);
+  const download = await downloadPromise;
+
+  expect(download.suggestedFilename()).toBe(expectedFileName);
+  expect(page.url()).toBe(expectedPageUrl);
+  expect(await readExecutionMarkers(page)).toEqual({
+    html: false,
+    svg: false,
+  });
+
+  await download.delete();
+};
+
+test("public active files cannot execute on authenticated app origin", async ({
+  page,
+}, testInfo) => {
+  await page.addInitScript(() => {
+    const markerWindow = window as typeof window & {
+      __staaashSec01HtmlExecuted: boolean;
+      __staaashSec01SvgExecuted: boolean;
+    };
+    markerWindow.__staaashSec01HtmlExecuted = false;
+    markerWindow.__staaashSec01SvgExecuted = false;
+  });
+
+  await signIn(page, { ...getMemberCredentials(), next: "/files" });
+
+  const fixtureSuffix = `${Date.now()}-${testInfo.retry}`;
+  const htmlFixture = {
+    body: `<!doctype html>
+<meta charset="utf-8">
+<title>SEC-01 inert fixture</title>
+<script>
+window.__staaashSec01HtmlExecuted = true;
+fetch("/api/files/files?sec01-probe=html");
+</script>
+<p>SEC-01 inert HTML fixture</p>`,
+    mimeType: "text/html",
+    name: `sec01-active-${fixtureSuffix}.html`,
+  } satisfies ActiveFixture;
+  const svgFixture = {
+    body: `<svg xmlns="http://www.w3.org/2000/svg" onload="window.__staaashSec01SvgExecuted = true">
+  <text x="10" y="20">SEC-01 inert SVG fixture</text>
+</svg>`,
+    mimeType: "image/svg+xml",
+    name: `sec01-active-${fixtureSuffix}.svg`,
+  } satisfies ActiveFixture;
+
+  const shareUrls = {
+    html: await uploadAndShareActiveFixture(page, htmlFixture),
+    svg: await uploadAndShareActiveFixture(page, svgFixture),
+  };
+
+  await page.context().clearCookies();
+  await signIn(page, { ...getOwnerCredentials(), next: "/home" });
+
+  const probeRequests: string[] = [];
+  const authenticatedMutationRequests: string[] = [];
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.searchParams.has("sec01-probe")) {
+      probeRequests.push(url.toString());
+    }
+    if (
+      url.pathname.startsWith("/api/") &&
+      !["GET", "HEAD", "OPTIONS"].includes(request.method())
+    ) {
+      authenticatedMutationRequests.push(
+        `${request.method()} ${request.url()}`,
+      );
+    }
+  });
+
+  await page.goto(shareUrls.html);
+  await expect(
+    page.getByRole("heading", { name: htmlFixture.name }),
+  ).toBeVisible();
+  await expect(page.locator(activeEmbedSelector)).toHaveCount(0);
+  await expect(page.locator("pre")).toContainText(
+    "window.__staaashSec01HtmlExecuted = true;",
+  );
+  await expect(page.locator("pre")).toContainText(
+    'fetch("/api/files/files?sec01-probe=html");',
+  );
+  expect(await readExecutionMarkers(page)).toEqual({ html: false, svg: false });
+  expect(probeRequests).toEqual([]);
+
+  const htmlPageUrl = page.url();
+  await expectDirectContentDownload({
+    page,
+    contentUrl: `${htmlPageUrl}/content`,
+    expectedFileName: htmlFixture.name,
+    expectedPageUrl: htmlPageUrl,
+  });
+
+  await page.goto(shareUrls.svg);
+  await expect(
+    page.getByRole("heading", { name: svgFixture.name }),
+  ).toBeVisible();
+  await expect(page.locator(activeEmbedSelector)).toHaveCount(0);
+  expect(await readExecutionMarkers(page)).toEqual({ html: false, svg: false });
+
+  const svgPageUrl = page.url();
+  await expectDirectContentDownload({
+    page,
+    contentUrl: `${svgPageUrl}/content`,
+    expectedFileName: svgFixture.name,
+    expectedPageUrl: svgPageUrl,
+  });
+
+  expect(probeRequests).toEqual([]);
+  expect(authenticatedMutationRequests).toEqual([]);
+
+  await page.goto("/home");
+  await expect(page).toHaveURL(/\/home$/u);
+});

--- a/apps/web/e2e/public-share-active-content.spec.ts
+++ b/apps/web/e2e/public-share-active-content.spec.ts
@@ -1,9 +1,10 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Download, type Page } from "@playwright/test";
 
 import { getMemberCredentials, getOwnerCredentials, signIn } from "./helpers";
 
 type ActiveFixture = {
   body: string;
+  downloadDisabled: boolean;
   mimeType: string;
   name: string;
 };
@@ -86,7 +87,7 @@ const uploadAndShareActiveFixture = async (
     .context()
     .request.post(`${origin}/api/shares`, {
       data: {
-        downloadDisabled: false,
+        downloadDisabled: fixture.downloadDisabled,
         expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
         fileId,
         targetType: "file",
@@ -131,6 +132,35 @@ const expectDirectContentDownload = async ({
   await download.delete();
 };
 
+const expectDirectContentBlocked = async ({
+  page,
+  contentUrl,
+}: {
+  page: Page;
+  contentUrl: string;
+}) => {
+  const downloads: string[] = [];
+  const onDownload = (download: Download) => {
+    downloads.push(download.suggestedFilename());
+  };
+  page.on("download", onDownload);
+
+  try {
+    const response = await page.goto(contentUrl);
+    expect(response?.status()).toBe(403);
+    await expect(page.locator("body")).toHaveText(
+      "Downloads are disabled for this shared link.",
+    );
+    expect(downloads).toEqual([]);
+    expect(await readExecutionMarkers(page)).toEqual({
+      html: false,
+      svg: false,
+    });
+  } finally {
+    page.off("download", onDownload);
+  }
+};
+
 test("public active files cannot execute on authenticated app origin", async ({
   page,
 }, testInfo) => {
@@ -155,6 +185,7 @@ window.__staaashSec01HtmlExecuted = true;
 fetch("/api/files/files?sec01-probe=html");
 </script>
 <p>SEC-01 inert HTML fixture</p>`,
+    downloadDisabled: false,
     mimeType: "text/html",
     name: `sec01-active-${fixtureSuffix}.html`,
   } satisfies ActiveFixture;
@@ -162,6 +193,7 @@ fetch("/api/files/files?sec01-probe=html");
     body: `<svg xmlns="http://www.w3.org/2000/svg" onload="window.__staaashSec01SvgExecuted = true">
   <text x="10" y="20">SEC-01 inert SVG fixture</text>
 </svg>`,
+    downloadDisabled: true,
     mimeType: "image/svg+xml",
     name: `sec01-active-${fixtureSuffix}.svg`,
   } satisfies ActiveFixture;
@@ -218,14 +250,13 @@ fetch("/api/files/files?sec01-probe=html");
     page.getByRole("heading", { name: svgFixture.name }),
   ).toBeVisible();
   await expect(page.locator(activeEmbedSelector)).toHaveCount(0);
+  await expect(page.getByText("Downloads off")).toBeVisible();
   expect(await readExecutionMarkers(page)).toEqual({ html: false, svg: false });
 
   const svgPageUrl = page.url();
-  await expectDirectContentDownload({
+  await expectDirectContentBlocked({
     page,
     contentUrl: `${svgPageUrl}/content`,
-    expectedFileName: svgFixture.name,
-    expectedPageUrl: svgPageUrl,
   });
 
   expect(probeRequests).toEqual([]);

--- a/apps/web/server/media/content-response.test.ts
+++ b/apps/web/server/media/content-response.test.ts
@@ -21,9 +21,14 @@ vi.mock("@/server/files/repository", () => ({
   },
 }));
 
-vi.mock("@/server/media/heic-converter", () => ({
-  convertHeicToJpeg: convertHeicToJpegMock,
-}));
+vi.mock("@/server/media/heic-converter", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/server/media/heic-converter")>();
+  return {
+    ...actual,
+    convertHeicToJpeg: convertHeicToJpegMock,
+  };
+});
 
 const makeFile = (
   overrides: Partial<{
@@ -123,7 +128,7 @@ describe("media content response", () => {
     expect(getStoragePathMock).not.toHaveBeenCalled();
   });
 
-  it("still streams successfully after handing the file descriptor to the stream", async () => {
+  it("streams successfully and closes the handed-off file descriptor", async () => {
     const fakeHandle = {
       stat: vi.fn().mockResolvedValue({ size: 11 }),
       close: vi.fn().mockResolvedValue(undefined),
@@ -147,7 +152,9 @@ describe("media content response", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("content-length")).toBe("11");
     await expect(response.text()).resolves.toBe("hello world");
-    expect(fakeHandle.close).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(fakeHandle.close).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("keeps private authenticated response behavior unchanged", async () => {
@@ -198,6 +205,7 @@ describe("media content response", () => {
       await import("@/server/media/public-share-content-response");
     const response = await createPublicShareContentResponse({
       request: new Request("http://localhost/content"),
+      downloadDisabled: false,
       file: makeFile({
         name: "photo.heic",
         mimeType: "image/heic",
@@ -214,10 +222,83 @@ describe("media content response", () => {
     expect(response.headers.get("content-security-policy")).toBe(
       "sandbox; default-src 'none'; form-action 'none'; base-uri 'none'",
     );
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
     expect(new Uint8Array(await response.arrayBuffer())).toEqual(jpegBytes);
     expect(convertHeicToJpegMock).toHaveBeenCalledWith(
       Buffer.from("heic-source"),
     );
+  });
+
+  it("does not fall back to original HEIC bytes when conversion fails", async () => {
+    const fakeHandle = {
+      stat: vi.fn().mockResolvedValue({ size: 12 }),
+      readFile: vi.fn().mockResolvedValue(Buffer.from("heic-source")),
+      close: vi.fn().mockResolvedValue(undefined),
+      createReadStream: vi.fn(),
+    };
+    openMock.mockResolvedValueOnce(fakeHandle);
+    getStoragePathMock.mockReturnValueOnce("C:\\temp\\photo.heif");
+    convertHeicToJpegMock.mockRejectedValueOnce(
+      new Error("HEIF conversion failed"),
+    );
+
+    const { createPublicShareContentResponse } =
+      await import("@/server/media/public-share-content-response");
+
+    await expect(
+      createPublicShareContentResponse({
+        request: new Request("http://localhost/content"),
+        downloadDisabled: false,
+        file: makeFile({
+          name: "photo.heif",
+          mimeType: "image/heif",
+          sizeBytes: 12,
+          viewerKind: "image",
+        }),
+      }),
+    ).rejects.toThrow("HEIF conversion failed");
+
+    expect(fakeHandle.readFile).toHaveBeenCalledTimes(1);
+    expect(fakeHandle.createReadStream).not.toHaveBeenCalled();
+    expect(fakeHandle.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels and closes an attachment stream blocked by download policy", async () => {
+    const nodeStream = new Readable({
+      read() {
+        // Keep stream open until policy cancellation.
+      },
+    });
+    const destroySpy = vi.spyOn(nodeStream, "destroy");
+    const fakeHandle = {
+      stat: vi.fn().mockResolvedValue({ size: 16 }),
+      close: vi.fn().mockResolvedValue(undefined),
+      createReadStream: vi.fn(() => nodeStream),
+    };
+    openMock.mockResolvedValueOnce(fakeHandle);
+    getStoragePathMock.mockReturnValueOnce("C:\\temp\\payload.html");
+
+    const { createPublicShareContentResponse } =
+      await import("@/server/media/public-share-content-response");
+
+    await expect(
+      createPublicShareContentResponse({
+        request: new Request("http://localhost/content"),
+        downloadDisabled: true,
+        file: makeFile({
+          name: "payload.html",
+          mimeType: "text/html",
+          sizeBytes: 16,
+          viewerKind: "text",
+        }),
+      }),
+    ).rejects.toMatchObject({
+      code: "SHARE_DOWNLOAD_DISABLED",
+      status: 403,
+    });
+
+    expect(destroySpy).toHaveBeenCalledTimes(1);
+    expect(fakeHandle.close).toHaveBeenCalledTimes(1);
   });
 
   it("marks the file missing when original bytes are gone", async () => {

--- a/apps/web/server/media/content-response.test.ts
+++ b/apps/web/server/media/content-response.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const openMock = vi.fn();
 const getStoragePathMock = vi.fn();
 const markFileStorageMissingMock = vi.fn();
+const convertHeicToJpegMock = vi.fn();
 
 vi.mock("node:fs/promises", () => ({
   open: openMock,
@@ -20,6 +21,10 @@ vi.mock("@/server/files/repository", () => ({
   },
 }));
 
+vi.mock("@/server/media/heic-converter", () => ({
+  convertHeicToJpeg: convertHeicToJpegMock,
+}));
+
 const makeFile = (
   overrides: Partial<{
     id: string;
@@ -29,7 +34,7 @@ const makeFile = (
     name: string;
     mimeType: string;
     sizeBytes: number;
-    viewerKind: "image" | "video" | null;
+    viewerKind: "audio" | "image" | "pdf" | "text" | "video" | null;
     deletedAt: Date | null;
     createdAt: Date;
     updatedAt: Date;
@@ -143,6 +148,76 @@ describe("media content response", () => {
     expect(response.headers.get("content-length")).toBe("11");
     await expect(response.text()).resolves.toBe("hello world");
     expect(fakeHandle.close).not.toHaveBeenCalled();
+  });
+
+  it("keeps private authenticated response behavior unchanged", async () => {
+    const fakeHandle = {
+      stat: vi.fn().mockResolvedValue({ size: 16 }),
+      close: vi.fn().mockResolvedValue(undefined),
+      createReadStream: vi.fn(() =>
+        Readable.from([Buffer.from("<h1>private</h1>")]),
+      ),
+    };
+    openMock.mockResolvedValueOnce(fakeHandle);
+    getStoragePathMock.mockReturnValueOnce("C:\\temp\\private.html");
+
+    const { createInlineOriginalContentResponse } =
+      await import("@/server/media/content-response");
+    const response = await createInlineOriginalContentResponse({
+      request: new Request("http://localhost/content"),
+      file: makeFile({
+        name: "private.html",
+        mimeType: "text/html",
+        sizeBytes: 16,
+        viewerKind: "text",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/html");
+    expect(response.headers.get("content-disposition")).toBe(
+      "inline; filename*=UTF-8''private.html",
+    );
+    expect(response.headers.has("content-security-policy")).toBe(false);
+    expect(await response.text()).toBe("<h1>private</h1>");
+  });
+
+  it("applies public policy to emitted JPEG after HEIC conversion", async () => {
+    const jpegBytes = new Uint8Array([0xff, 0xd8, 0xff, 0xd9]);
+    const fakeHandle = {
+      stat: vi.fn().mockResolvedValue({ size: 12 }),
+      readFile: vi.fn().mockResolvedValue(Buffer.from("heic-source")),
+      close: vi.fn().mockResolvedValue(undefined),
+      createReadStream: vi.fn(),
+    };
+    openMock.mockResolvedValueOnce(fakeHandle);
+    getStoragePathMock.mockReturnValueOnce("C:\\temp\\photo.heic");
+    convertHeicToJpegMock.mockResolvedValueOnce(jpegBytes.buffer);
+
+    const { createPublicShareContentResponse } =
+      await import("@/server/media/public-share-content-response");
+    const response = await createPublicShareContentResponse({
+      request: new Request("http://localhost/content"),
+      file: makeFile({
+        name: "photo.heic",
+        mimeType: "image/heic",
+        sizeBytes: 12,
+        viewerKind: "image",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/jpeg");
+    expect(response.headers.get("content-disposition")).toBe(
+      "inline; filename*=UTF-8''photo.heic",
+    );
+    expect(response.headers.get("content-security-policy")).toBe(
+      "sandbox; default-src 'none'; form-action 'none'; base-uri 'none'",
+    );
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(jpegBytes);
+    expect(convertHeicToJpegMock).toHaveBeenCalledWith(
+      Buffer.from("heic-source"),
+    );
   });
 
   it("marks the file missing when original bytes are gone", async () => {

--- a/apps/web/server/media/content-response.ts
+++ b/apps/web/server/media/content-response.ts
@@ -4,24 +4,7 @@ import type { Readable } from "node:stream";
 import { getStoragePath } from "@/server/storage";
 import { prismaFilesRepository } from "@/server/files/repository";
 import type { StoredFile } from "@/server/files/types";
-import { convertHeicToJpeg } from "./heic-converter";
-
-const HEIC_MIME_TYPES = new Set([
-  "image/heic",
-  "image/heif",
-  "image/heic-sequence",
-  "image/heif-sequence",
-]);
-const HEIC_EXTENSIONS = new Set(["heic", "heif"]);
-
-const isHeicFile = (file: Pick<StoredFile, "mimeType" | "name">): boolean => {
-  if (
-    HEIC_MIME_TYPES.has(file.mimeType.split(";")[0]?.trim().toLowerCase() ?? "")
-  )
-    return true;
-  const ext = file.name.split(".").pop()?.toLowerCase() ?? "";
-  return HEIC_EXTENSIONS.has(ext);
-};
+import { convertHeicToJpeg, isHeicFile } from "./heic-converter";
 
 const buildInlineDisposition = (fileName: string) =>
   `inline; filename*=UTF-8''${encodeURIComponent(fileName)}`;
@@ -158,14 +141,22 @@ const isMissingStorageObject = (error: unknown) => {
 // Readable.toWeb() does not guard controller.enqueue/close against ERR_INVALID_STATE
 // when the consumer cancels mid-stream (common with video range requests).
 // Using pull() + pause/resume to avoid unbounded memory growth with large files.
-const toWebStream = (
+const createMediaBodyStream = (
   readable: Readable,
   signal: AbortSignal,
-  extraCleanup?: () => void,
+  extraCleanup?: () => Promise<void> | void,
 ): ReadableStream<Uint8Array> => {
-  const destroy = () => {
+  let cleanupPromise: Promise<void> | null = null;
+  const cleanup = () => {
+    cleanupPromise ??= Promise.resolve()
+      .then(() => extraCleanup?.())
+      .then(() => undefined)
+      .catch(() => undefined);
+    return cleanupPromise;
+  };
+  const destroy = async () => {
     readable.destroy();
-    extraCleanup?.();
+    await cleanup();
   };
 
   return new ReadableStream<Uint8Array>(
@@ -177,7 +168,7 @@ const toWebStream = (
               new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength),
             );
           } catch {
-            destroy();
+            void destroy();
             return;
           }
           if ((controller.desiredSize ?? 1) <= 0) {
@@ -190,6 +181,7 @@ const toWebStream = (
           } catch {
             // already closed
           }
+          void cleanup();
         });
         readable.on("error", (err) => {
           try {
@@ -197,14 +189,24 @@ const toWebStream = (
           } catch {
             // already closed/errored
           }
+          void cleanup();
         });
-        signal.addEventListener("abort", destroy, { once: true });
+        readable.on("close", () => {
+          void cleanup();
+        });
+        signal.addEventListener(
+          "abort",
+          () => {
+            void destroy();
+          },
+          { once: true },
+        );
       },
       pull() {
         readable.resume();
       },
       cancel() {
-        destroy();
+        return destroy();
       },
     },
     new ByteLengthQueuingStrategy({ highWaterMark: 512 * 1024 }),
@@ -250,10 +252,9 @@ export const createInlineOriginalContentResponse = async ({
         highWaterMark: 512 * 1024,
       });
       streamCreated = true;
-      nodeStream.on("close", () => {
-        fileHandle.close().catch(() => {});
-      });
-      return toWebStream(nodeStream, request.signal);
+      return createMediaBodyStream(nodeStream, request.signal, () =>
+        fileHandle.close().catch(() => {}),
+      );
     };
 
     if (file.viewerKind === "image") {

--- a/apps/web/server/media/content-response.ts
+++ b/apps/web/server/media/content-response.ts
@@ -4,6 +4,7 @@ import type { Readable } from "node:stream";
 import { getStoragePath } from "@/server/storage";
 import { prismaFilesRepository } from "@/server/files/repository";
 import type { StoredFile } from "@/server/files/types";
+import { convertHeicToJpeg } from "./heic-converter";
 
 const HEIC_MIME_TYPES = new Set([
   "image/heic",
@@ -257,20 +258,10 @@ export const createInlineOriginalContentResponse = async ({
 
     if (file.viewerKind === "image") {
       if (isHeicFile(file)) {
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        const heicConvert = require("heic-convert") as (options: {
-          buffer: Buffer;
-          format: "JPEG";
-          quality: number;
-        }) => Promise<ArrayBuffer>;
         const inputBuffer = await fileHandle.readFile();
         streamCreated = true;
         await fileHandle.close().catch(() => {});
-        const outputBuffer = await heicConvert({
-          buffer: inputBuffer,
-          format: "JPEG",
-          quality: 0.92,
-        });
+        const outputBuffer = await convertHeicToJpeg(inputBuffer);
         return new Response(outputBuffer, {
           status: 200,
           headers: {

--- a/apps/web/server/media/derivative-content-response.test.ts
+++ b/apps/web/server/media/derivative-content-response.test.ts
@@ -99,6 +99,7 @@ describe("public derivative content responses", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.touchDerivativeViewed.mockResolvedValue(undefined);
     mocks.getStoragePath.mockImplementation((storageKey: string) =>
       paths.get(storageKey),
     );
@@ -132,6 +133,61 @@ describe("public derivative content responses", () => {
       PUBLIC_SHARE_CONTENT_SECURITY_POLICY,
     );
     expect(await response.text()).toBe("2345");
+  });
+
+  it("serves a ready MP4 preview inline for an unsafe original when downloads are disabled", async () => {
+    mocks.findFirst.mockResolvedValue({
+      id: "derivative-1",
+      status: "ready",
+      storageKey: "derivative",
+      sizeBytes: 10n,
+      mimeType: "video/mp4",
+    });
+    const { createPublicShareContentResponse } =
+      await import("./public-share-content-response");
+
+    const response = await createPublicShareContentResponse({
+      request: new Request("http://localhost/content"),
+      downloadDisabled: true,
+      file: makeVideoFile({
+        name: "source.mov",
+        mimeType: "video/quicktime",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("video/mp4");
+    expect(response.headers.get("content-disposition")).toMatch(/^inline;/u);
+    expect(response.headers.get("content-security-policy")).toBe(
+      PUBLIC_SHARE_CONTENT_SECURITY_POLICY,
+    );
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(await response.text()).toBe("0123456789");
+  });
+
+  it("fails a ready derivative with missing MIME closed", async () => {
+    mocks.findFirst.mockResolvedValue({
+      id: "derivative-1",
+      status: "ready",
+      storageKey: "unsafeDerivative",
+      sizeBytes: 21n,
+      mimeType: null,
+    });
+    const { createPublicShareContentResponse } =
+      await import("./public-share-content-response");
+
+    const response = await createPublicShareContentResponse({
+      request: new Request("http://localhost/content"),
+      downloadDisabled: false,
+      file: makeVideoFile(),
+    });
+
+    expect(response.headers.get("content-type")).toBe(
+      "application/octet-stream",
+    );
+    expect(response.headers.get("content-disposition")).toMatch(
+      /^attachment;/u,
+    );
   });
 
   it("forces a non-allowlisted derivative MIME to attachment", async () => {

--- a/apps/web/server/media/derivative-content-response.test.ts
+++ b/apps/web/server/media/derivative-content-response.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rename, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -115,6 +115,7 @@ describe("public derivative content responses", () => {
       request: new Request("http://localhost/poster", {
         headers: { range: "bytes=2-5" },
       }),
+      downloadDisabled: false,
       derivative: {
         storageKey: "derivative",
         sizeBytes: 10n,
@@ -138,6 +139,7 @@ describe("public derivative content responses", () => {
       await import("./public-share-content-response");
     const response = await createPublicReadyDerivativeContentResponse({
       request: new Request("http://localhost/poster"),
+      downloadDisabled: false,
       derivative: {
         storageKey: "unsafeDerivative",
         sizeBytes: 21n,
@@ -159,6 +161,32 @@ describe("public derivative content responses", () => {
     expect(await response.text()).toBe("<svg><script /></svg>");
   });
 
+  it("cancels an unsafe derivative blocked by download policy", async () => {
+    const { createPublicReadyDerivativeContentResponse } =
+      await import("./public-share-content-response");
+
+    await expect(
+      createPublicReadyDerivativeContentResponse({
+        request: new Request("http://localhost/poster"),
+        downloadDisabled: true,
+        derivative: {
+          storageKey: "unsafeDerivative",
+          sizeBytes: 21n,
+          mimeType: "image/svg+xml",
+        },
+        fileName: "generated.svg",
+      }),
+    ).rejects.toMatchObject({
+      code: "SHARE_DOWNLOAD_DISABLED",
+      status: 403,
+    });
+
+    const originalPath = paths.get("unsafeDerivative")!;
+    const movedPath = `${originalPath}.moved`;
+    await rename(originalPath, movedPath);
+    await rename(movedPath, originalPath);
+  });
+
   it("re-evaluates original MIME when derivative lookup falls back", async () => {
     mocks.findFirst
       .mockResolvedValueOnce(null)
@@ -167,6 +195,7 @@ describe("public derivative content responses", () => {
       await import("./public-share-content-response");
     const response = await createPublicShareContentResponse({
       request: new Request("http://localhost/content"),
+      downloadDisabled: false,
       file: makeVideoFile({
         name: "disguised.html",
         mimeType: "text/html; charset=UTF-8",

--- a/apps/web/server/media/derivative-content-response.test.ts
+++ b/apps/web/server/media/derivative-content-response.test.ts
@@ -1,0 +1,189 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import type { StoredFile } from "@/server/files/types";
+
+const PUBLIC_SHARE_CONTENT_SECURITY_POLICY =
+  "sandbox; default-src 'none'; form-action 'none'; base-uri 'none'";
+
+const mocks = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  getStoragePath: vi.fn(),
+  markFileStorageMissing: vi.fn(),
+  scheduleDerivativeGenerate: vi.fn(),
+  touchDerivativeViewed: vi.fn(),
+}));
+
+vi.mock("@staaash/db/client", () => ({
+  getPrisma: () => ({
+    mediaDerivative: { findFirst: mocks.findFirst },
+  }),
+}));
+
+vi.mock("@staaash/db/media-derivatives", () => ({
+  DERIVATIVE_KIND_PREVIEW: "preview",
+  DERIVATIVE_PROFILE_1080P: "preview-1080p",
+  DERIVATIVE_STATUS_FAILED: "failed",
+  DERIVATIVE_STATUS_PROCESSING: "processing",
+  DERIVATIVE_STATUS_QUEUED: "queued",
+  DERIVATIVE_STATUS_READY: "ready",
+  DERIVATIVE_STATUS_STALE: "stale",
+  scheduleDerivativeGenerate: mocks.scheduleDerivativeGenerate,
+  touchDerivativeViewed: mocks.touchDerivativeViewed,
+}));
+
+vi.mock("@/server/settings", () => ({
+  getSystemSettings: vi.fn(),
+}));
+
+vi.mock("@/server/storage", () => ({
+  getStoragePath: mocks.getStoragePath,
+}));
+
+vi.mock("@/server/files/repository", () => ({
+  prismaFilesRepository: {
+    markFileStorageMissing: mocks.markFileStorageMissing,
+  },
+}));
+
+const fixedNow = new Date("2026-07-20T12:00:00.000Z");
+
+const makeVideoFile = (overrides: Partial<StoredFile> = {}): StoredFile => ({
+  id: "video-1",
+  ownerUserId: "member-1",
+  ownerStorageId: "member-1",
+  folderId: "folder-1",
+  name: "clip.mp4",
+  mimeType: "video/mp4",
+  sizeBytes: 16,
+  viewerKind: "video",
+  deletedAt: null,
+  createdAt: fixedNow,
+  updatedAt: fixedNow,
+  storageKey: "original",
+  storageStatus: "available",
+  storageCheckedAt: null,
+  storageMissingAt: null,
+  contentChecksum: null,
+  ...overrides,
+});
+
+describe("public derivative content responses", () => {
+  let tempDir = "";
+  const paths = new Map<string, string>();
+
+  beforeAll(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "staaash-derivative-"));
+    const fixtures = {
+      derivative: "0123456789",
+      original: "<h1>fallback</h1>",
+      unsafeDerivative: "<svg><script /></svg>",
+    };
+    for (const [storageKey, bytes] of Object.entries(fixtures)) {
+      const fixturePath = path.join(tempDir, storageKey);
+      await writeFile(fixturePath, bytes, "utf8");
+      paths.set(storageKey, fixturePath);
+    }
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getStoragePath.mockImplementation((storageKey: string) =>
+      paths.get(storageKey),
+    );
+  });
+
+  afterAll(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("uses emitted safe derivative MIME for 206 policy headers", async () => {
+    const { createPublicReadyDerivativeContentResponse } =
+      await import("./public-share-content-response");
+    const response = await createPublicReadyDerivativeContentResponse({
+      request: new Request("http://localhost/poster", {
+        headers: { range: "bytes=2-5" },
+      }),
+      derivative: {
+        storageKey: "derivative",
+        sizeBytes: 10n,
+        mimeType: "ViDeO/Mp4; codecs=avc1",
+      },
+      fileName: "generated.mp4",
+    });
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("content-type")).toBe("video/mp4");
+    expect(response.headers.get("content-disposition")).toMatch(/^inline;/u);
+    expect(response.headers.get("content-range")).toBe("bytes 2-5/10");
+    expect(response.headers.get("content-security-policy")).toBe(
+      PUBLIC_SHARE_CONTENT_SECURITY_POLICY,
+    );
+    expect(await response.text()).toBe("2345");
+  });
+
+  it("forces a non-allowlisted derivative MIME to attachment", async () => {
+    const { createPublicReadyDerivativeContentResponse } =
+      await import("./public-share-content-response");
+    const response = await createPublicReadyDerivativeContentResponse({
+      request: new Request("http://localhost/poster"),
+      derivative: {
+        storageKey: "unsafeDerivative",
+        sizeBytes: 21n,
+        mimeType: "image/svg+xml",
+      },
+      fileName: "generated.svg",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "application/octet-stream",
+    );
+    expect(response.headers.get("content-disposition")).toMatch(
+      /^attachment;/u,
+    );
+    expect(response.headers.get("content-security-policy")).toBe(
+      PUBLIC_SHARE_CONTENT_SECURITY_POLICY,
+    );
+    expect(await response.text()).toBe("<svg><script /></svg>");
+  });
+
+  it("re-evaluates original MIME when derivative lookup falls back", async () => {
+    mocks.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ status: "processing" });
+    const { createPublicShareContentResponse } =
+      await import("./public-share-content-response");
+    const response = await createPublicShareContentResponse({
+      request: new Request("http://localhost/content"),
+      file: makeVideoFile({
+        name: "disguised.html",
+        mimeType: "text/html; charset=UTF-8",
+        sizeBytes: 17,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "application/octet-stream",
+    );
+    expect(response.headers.get("content-disposition")).toMatch(
+      /^attachment;/u,
+    );
+    expect(response.headers.get("content-security-policy")).toBe(
+      PUBLIC_SHARE_CONTENT_SECURITY_POLICY,
+    );
+    expect(await response.text()).toBe("<h1>fallback</h1>");
+  });
+});

--- a/apps/web/server/media/derivative-content-response.ts
+++ b/apps/web/server/media/derivative-content-response.ts
@@ -209,7 +209,7 @@ export const createInlineContentResponse = async ({
       request,
       derivative.storageKey,
       Number(derivative.sizeBytes),
-      derivative.mimeType ?? "video/mp4",
+      derivative.mimeType ?? "application/octet-stream",
       file.name,
     );
 

--- a/apps/web/server/media/heic-converter.ts
+++ b/apps/web/server/media/heic-converter.ts
@@ -1,3 +1,26 @@
+import type { FileSummary } from "@/server/files/types";
+
+const HEIC_MIME_TYPES = new Set([
+  "image/heic",
+  "image/heif",
+  "image/heic-sequence",
+  "image/heif-sequence",
+]);
+const HEIC_EXTENSIONS = new Set(["heic", "heif"]);
+
+export const isHeicFile = (
+  file: Pick<FileSummary, "mimeType" | "name">,
+): boolean => {
+  if (
+    HEIC_MIME_TYPES.has(file.mimeType.split(";")[0]?.trim().toLowerCase() ?? "")
+  ) {
+    return true;
+  }
+
+  const extension = file.name.split(".").pop()?.toLowerCase() ?? "";
+  return HEIC_EXTENSIONS.has(extension);
+};
+
 export const convertHeicToJpeg = async (inputBuffer: Buffer) => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const heicConvert = require("heic-convert") as (options: {

--- a/apps/web/server/media/heic-converter.ts
+++ b/apps/web/server/media/heic-converter.ts
@@ -1,0 +1,14 @@
+export const convertHeicToJpeg = async (inputBuffer: Buffer) => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const heicConvert = require("heic-convert") as (options: {
+    buffer: Buffer;
+    format: "JPEG";
+    quality: number;
+  }) => Promise<ArrayBuffer>;
+
+  return heicConvert({
+    buffer: inputBuffer,
+    format: "JPEG",
+    quality: 0.92,
+  });
+};

--- a/apps/web/server/media/public-share-content-policy.test.ts
+++ b/apps/web/server/media/public-share-content-policy.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyPublicShareContentPolicy,
+  getPublicShareResponseMimeType,
+  isPublicShareMimeSafeInline,
+} from "./public-share-content-policy";
+
+const applyPolicy = (mimeType: string, fileName = "fixture.file") =>
+  applyPublicShareContentPolicy(
+    new Response("fixture-bytes", {
+      headers: { "content-type": getPublicShareResponseMimeType(mimeType) },
+    }),
+    fileName,
+  );
+
+describe("public share browser content policy", () => {
+  it("normalizes case and valid parameters before exact allowlist matching", () => {
+    expect(
+      applyPolicy(" ImAgE/JpEg ; charset=UTF-8 ").headers.get("content-type"),
+    ).toBe("image/jpeg");
+    expect(
+      applyPolicy('text/plain; charset="utf-8"').headers.get("content-type"),
+    ).toBe("text/plain");
+    expect(isPublicShareMimeSafeInline("VIDEO/MP4; codecs=avc1")).toBe(true);
+  });
+
+  it.each([
+    "text/html",
+    "TEXT/HTML; Charset=UTF-8",
+    "application/xhtml+xml",
+    "image/svg+xml",
+    "ImAgE/SvG+XmL; charset=utf-8",
+    "application/xml",
+    "text/xml",
+    "application/javascript",
+    "text/javascript",
+    "application/ecmascript",
+    "text/ecmascript",
+  ])("forces active MIME %s to a non-executable attachment", (mimeType) => {
+    const headers = applyPolicy(mimeType, "active file.html").headers;
+
+    expect(isPublicShareMimeSafeInline(mimeType)).toBe(false);
+    expect(headers.get("content-disposition")).toBe(
+      "attachment; filename*=UTF-8''active%20file.html",
+    );
+    expect(headers.get("content-security-policy")).toBe(
+      "sandbox; default-src 'none'; form-action 'none'; base-uri 'none'",
+    );
+    expect(headers.get("content-type")).toBe("application/octet-stream");
+    expect(headers.get("x-content-type-options")).toBe("nosniff");
+  });
+
+  it.each([
+    "",
+    "   ",
+    "image",
+    "/png",
+    "image/",
+    "image/png; charset",
+    "image/png; =utf-8",
+    "image/png, text/html",
+    "image/png\r\ntext/html",
+    "application/x-unknown",
+  ])("fails closed for unknown, empty, or malformed MIME %j", (mimeType) => {
+    expect(isPublicShareMimeSafeInline(mimeType)).toBe(false);
+    const headers = applyPolicy(mimeType, "unknown.bin").headers;
+    expect(headers.get("content-disposition")).toBe(
+      "attachment; filename*=UTF-8''unknown.bin",
+    );
+    expect(headers.get("content-type")).toBe("application/octet-stream");
+  });
+
+  it("keeps only the documented exact allowlist inline", () => {
+    const safeInlineMimeTypes = [
+      "application/pdf",
+      "audio/flac",
+      "audio/mp4",
+      "audio/mpeg",
+      "audio/ogg",
+      "audio/wav",
+      "audio/webm",
+      "image/avif",
+      "image/bmp",
+      "image/gif",
+      "image/jpeg",
+      "image/png",
+      "image/webp",
+      "text/plain",
+      "video/mp4",
+      "video/ogg",
+      "video/webm",
+    ];
+
+    for (const mimeType of safeInlineMimeTypes) {
+      const headers = applyPolicy(mimeType, "safe.file").headers;
+      expect(headers.get("content-disposition")).toMatch(/^inline;/u);
+      expect(headers.get("content-type")).toBe(mimeType);
+      expect(headers.get("content-security-policy")).toBe(
+        "sandbox; default-src 'none'; form-action 'none'; base-uri 'none'",
+      );
+    }
+  });
+});

--- a/apps/web/server/media/public-share-content-policy.test.ts
+++ b/apps/web/server/media/public-share-content-policy.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyPublicShareContentPolicy,
   getPublicShareResponseMimeType,
-  isPublicShareMimeSafeInline,
+  isPublicShareFileNativeViewSafe,
 } from "./public-share-content-policy";
 
 const applyPolicy = (mimeType: string, fileName = "fixture.file") =>
@@ -22,7 +22,9 @@ describe("public share browser content policy", () => {
     expect(
       applyPolicy('text/plain; charset="utf-8"').headers.get("content-type"),
     ).toBe("text/plain");
-    expect(isPublicShareMimeSafeInline("VIDEO/MP4; codecs=avc1")).toBe(true);
+    expect(
+      applyPolicy("VIDEO/MP4; codecs=avc1").headers.get("content-disposition"),
+    ).toMatch(/^inline;/u);
   });
 
   it.each([
@@ -40,7 +42,6 @@ describe("public share browser content policy", () => {
   ])("forces active MIME %s to a non-executable attachment", (mimeType) => {
     const headers = applyPolicy(mimeType, "active file.html").headers;
 
-    expect(isPublicShareMimeSafeInline(mimeType)).toBe(false);
     expect(headers.get("content-disposition")).toBe(
       "attachment; filename*=UTF-8''active%20file.html",
     );
@@ -63,7 +64,6 @@ describe("public share browser content policy", () => {
     "image/png\r\ntext/html",
     "application/x-unknown",
   ])("fails closed for unknown, empty, or malformed MIME %j", (mimeType) => {
-    expect(isPublicShareMimeSafeInline(mimeType)).toBe(false);
     const headers = applyPolicy(mimeType, "unknown.bin").headers;
     expect(headers.get("content-disposition")).toBe(
       "attachment; filename*=UTF-8''unknown.bin",
@@ -100,5 +100,31 @@ describe("public share browser content policy", () => {
         "sandbox; default-src 'none'; form-action 'none'; base-uri 'none'",
       );
     }
+  });
+
+  it("models HEIC and HEIF as safe JPEG output without allowlisting raw MIME", () => {
+    for (const [mimeType, name] of [
+      ["image/heic", "photo.heic"],
+      ["image/heif", "photo.heif"],
+    ]) {
+      expect(applyPolicy(mimeType).headers.get("content-disposition")).toMatch(
+        /^attachment;/u,
+      );
+      expect(
+        isPublicShareFileNativeViewSafe({
+          mimeType,
+          name,
+          viewerKind: "image",
+        }),
+      ).toBe(true);
+    }
+
+    expect(
+      isPublicShareFileNativeViewSafe({
+        mimeType: "image/svg+xml",
+        name: "active.svg",
+        viewerKind: "image",
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/web/server/media/public-share-content-policy.ts
+++ b/apps/web/server/media/public-share-content-policy.ts
@@ -51,17 +51,32 @@ const normalizePublicShareMimeType = (mimeType: string): string | null => {
   return `${match[1].toLowerCase()}/${match[2].toLowerCase()}`;
 };
 
-const isPublicShareMimeSafeInline = (mimeType: string): boolean => {
+export const getPublicShareSafeInlineMimeType = (
+  mimeType: string,
+): string | null => {
   const normalized = normalizePublicShareMimeType(mimeType);
-  return normalized !== null && safeInlineMimeTypes.has(normalized);
+  return normalized !== null && safeInlineMimeTypes.has(normalized)
+    ? normalized
+    : null;
 };
+
+const isPublicShareMimeSafeInline = (mimeType: string): boolean =>
+  getPublicShareSafeInlineMimeType(mimeType) !== null;
 
 export const getPublicShareResponseMimeType = (mimeType: string): string =>
   normalizePublicShareMimeType(mimeType) ?? "application/octet-stream";
 
 export const isPublicShareFileNativeViewSafe = (
   file: Pick<FileSummary, "mimeType" | "name" | "viewerKind">,
+  preview?: { safeInlineMimeType: string | null } | null,
 ): boolean => {
+  if (file.viewerKind === "video" && preview) {
+    return (
+      preview.safeInlineMimeType !== null &&
+      isPublicShareMimeSafeInline(preview.safeInlineMimeType)
+    );
+  }
+
   const emittedMimeType =
     file.viewerKind === "image" && isHeicFile(file)
       ? "image/jpeg"
@@ -77,16 +92,15 @@ const createPublicShareContentHeaders = ({
   emittedMimeType: string;
   fileName: string;
 }) => {
-  const normalized = normalizePublicShareMimeType(emittedMimeType);
-  const safeInline = normalized !== null && safeInlineMimeTypes.has(normalized);
+  const safeInlineMimeType = getPublicShareSafeInlineMimeType(emittedMimeType);
 
   return {
     "content-disposition": buildContentDisposition(
-      safeInline ? "inline" : "attachment",
+      safeInlineMimeType ? "inline" : "attachment",
       fileName,
     ),
     "content-security-policy": PUBLIC_SHARE_CONTENT_SECURITY_POLICY,
-    "content-type": safeInline ? normalized : "application/octet-stream",
+    "content-type": safeInlineMimeType ?? "application/octet-stream",
     "x-content-type-options": "nosniff",
   };
 };

--- a/apps/web/server/media/public-share-content-policy.ts
+++ b/apps/web/server/media/public-share-content-policy.ts
@@ -1,3 +1,7 @@
+import type { FileSummary } from "@/server/files/types";
+
+import { isHeicFile } from "./heic-converter";
+
 const MIME_TOKEN = "[!#$%&'*+\\-.^_`|~0-9A-Za-z]+";
 const MIME_QUOTED_VALUE = '"(?:[\\t !#-\\[\\]-~]|\\\\[\\t !-~])*"';
 const MIME_TYPE_PATTERN = new RegExp(
@@ -47,13 +51,24 @@ const normalizePublicShareMimeType = (mimeType: string): string | null => {
   return `${match[1].toLowerCase()}/${match[2].toLowerCase()}`;
 };
 
-export const isPublicShareMimeSafeInline = (mimeType: string): boolean => {
+const isPublicShareMimeSafeInline = (mimeType: string): boolean => {
   const normalized = normalizePublicShareMimeType(mimeType);
   return normalized !== null && safeInlineMimeTypes.has(normalized);
 };
 
 export const getPublicShareResponseMimeType = (mimeType: string): string =>
   normalizePublicShareMimeType(mimeType) ?? "application/octet-stream";
+
+export const isPublicShareFileNativeViewSafe = (
+  file: Pick<FileSummary, "mimeType" | "name" | "viewerKind">,
+): boolean => {
+  const emittedMimeType =
+    file.viewerKind === "image" && isHeicFile(file)
+      ? "image/jpeg"
+      : getPublicShareResponseMimeType(file.mimeType);
+
+  return isPublicShareMimeSafeInline(emittedMimeType);
+};
 
 const createPublicShareContentHeaders = ({
   emittedMimeType,
@@ -92,3 +107,9 @@ export const applyPublicShareContentPolicy = (
 
   return response;
 };
+
+export const isPublicShareResponseAttachment = (response: Response): boolean =>
+  response.headers
+    .get("content-disposition")
+    ?.toLowerCase()
+    .startsWith("attachment;") ?? true;

--- a/apps/web/server/media/public-share-content-policy.ts
+++ b/apps/web/server/media/public-share-content-policy.ts
@@ -1,0 +1,94 @@
+const MIME_TOKEN = "[!#$%&'*+\\-.^_`|~0-9A-Za-z]+";
+const MIME_QUOTED_VALUE = '"(?:[\\t !#-\\[\\]-~]|\\\\[\\t !-~])*"';
+const MIME_TYPE_PATTERN = new RegExp(
+  `^(${MIME_TOKEN})/(${MIME_TOKEN})(?:[\\t ]*;[\\t ]*${MIME_TOKEN}[\\t ]*=[\\t ]*(?:${MIME_TOKEN}|${MIME_QUOTED_VALUE}))*[\\t ]*$`,
+);
+
+const PUBLIC_SHARE_CONTENT_SECURITY_POLICY =
+  "sandbox; default-src 'none'; form-action 'none'; base-uri 'none'";
+
+// PDF remains inline only under the mandatory bare sandbox above. No allow-*
+// sandbox permissions are granted to any public shared content response.
+const PUBLIC_SHARE_SAFE_INLINE_MIME_TYPES = [
+  "application/pdf",
+  "audio/flac",
+  "audio/mp4",
+  "audio/mpeg",
+  "audio/ogg",
+  "audio/wav",
+  "audio/webm",
+  "image/avif",
+  "image/bmp",
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "text/plain",
+  "video/mp4",
+  "video/ogg",
+  "video/webm",
+] as const;
+
+const safeInlineMimeTypes = new Set<string>(
+  PUBLIC_SHARE_SAFE_INLINE_MIME_TYPES,
+);
+
+const buildContentDisposition = (
+  disposition: "attachment" | "inline",
+  fileName: string,
+) => `${disposition}; filename*=UTF-8''${encodeURIComponent(fileName)}`;
+
+const normalizePublicShareMimeType = (mimeType: string): string | null => {
+  if (!mimeType || /[\r\n]/u.test(mimeType)) return null;
+
+  const match = MIME_TYPE_PATTERN.exec(mimeType.trim());
+  if (!match?.[1] || !match[2]) return null;
+
+  return `${match[1].toLowerCase()}/${match[2].toLowerCase()}`;
+};
+
+export const isPublicShareMimeSafeInline = (mimeType: string): boolean => {
+  const normalized = normalizePublicShareMimeType(mimeType);
+  return normalized !== null && safeInlineMimeTypes.has(normalized);
+};
+
+export const getPublicShareResponseMimeType = (mimeType: string): string =>
+  normalizePublicShareMimeType(mimeType) ?? "application/octet-stream";
+
+const createPublicShareContentHeaders = ({
+  emittedMimeType,
+  fileName,
+}: {
+  emittedMimeType: string;
+  fileName: string;
+}) => {
+  const normalized = normalizePublicShareMimeType(emittedMimeType);
+  const safeInline = normalized !== null && safeInlineMimeTypes.has(normalized);
+
+  return {
+    "content-disposition": buildContentDisposition(
+      safeInline ? "inline" : "attachment",
+      fileName,
+    ),
+    "content-security-policy": PUBLIC_SHARE_CONTENT_SECURITY_POLICY,
+    "content-type": safeInline ? normalized : "application/octet-stream",
+    "x-content-type-options": "nosniff",
+  };
+};
+
+export const applyPublicShareContentPolicy = (
+  response: Response,
+  fileName: string,
+): Response => {
+  const policyHeaders = createPublicShareContentHeaders({
+    emittedMimeType:
+      response.headers.get("content-type") ?? "application/octet-stream",
+    fileName,
+  });
+
+  for (const [name, value] of Object.entries(policyHeaders)) {
+    response.headers.set(name, value);
+  }
+
+  return response;
+};

--- a/apps/web/server/media/public-share-content-response.ts
+++ b/apps/web/server/media/public-share-content-response.ts
@@ -1,4 +1,5 @@
 import type { StoredFile } from "@/server/files/types";
+import { ShareError } from "@/server/sharing/errors";
 
 import {
   createInlineContentResponse,
@@ -7,14 +8,39 @@ import {
 import {
   applyPublicShareContentPolicy,
   getPublicShareResponseMimeType,
+  isPublicShareResponseAttachment,
 } from "./public-share-content-policy";
+
+const applyAndEnforcePublicShareContentPolicy = async ({
+  response,
+  fileName,
+  downloadDisabled,
+}: {
+  response: Response;
+  fileName: string;
+  downloadDisabled: boolean;
+}): Promise<Response> => {
+  const publicResponse = applyPublicShareContentPolicy(response, fileName);
+
+  if (downloadDisabled && isPublicShareResponseAttachment(publicResponse)) {
+    try {
+      await publicResponse.body?.cancel();
+    } finally {
+      throw new ShareError("SHARE_DOWNLOAD_DISABLED");
+    }
+  }
+
+  return publicResponse;
+};
 
 export const createPublicShareContentResponse = async ({
   request,
   file,
+  downloadDisabled,
 }: {
   request: Request;
   file: StoredFile;
+  downloadDisabled: boolean;
 }): Promise<Response> => {
   const publicFile = {
     ...file,
@@ -26,20 +52,31 @@ export const createPublicShareContentResponse = async ({
     file: publicFile,
   });
 
-  return applyPublicShareContentPolicy(response, file.name);
+  return applyAndEnforcePublicShareContentPolicy({
+    response,
+    fileName: file.name,
+    downloadDisabled,
+  });
 };
 
 export const createPublicReadyDerivativeContentResponse = async (
-  input: Parameters<typeof createReadyDerivativeContentResponse>[0],
+  input: Parameters<typeof createReadyDerivativeContentResponse>[0] & {
+    downloadDisabled: boolean;
+  },
 ): Promise<Response> => {
+  const { downloadDisabled, ...responseInput } = input;
   const response = await createReadyDerivativeContentResponse({
-    ...input,
+    ...responseInput,
     derivative: {
-      ...input.derivative,
+      ...responseInput.derivative,
       mimeType: getPublicShareResponseMimeType(
-        input.derivative.mimeType ?? "application/octet-stream",
+        responseInput.derivative.mimeType ?? "application/octet-stream",
       ),
     },
   });
-  return applyPublicShareContentPolicy(response, input.fileName);
+  return applyAndEnforcePublicShareContentPolicy({
+    response,
+    fileName: responseInput.fileName,
+    downloadDisabled,
+  });
 };

--- a/apps/web/server/media/public-share-content-response.ts
+++ b/apps/web/server/media/public-share-content-response.ts
@@ -1,0 +1,45 @@
+import type { StoredFile } from "@/server/files/types";
+
+import {
+  createInlineContentResponse,
+  createReadyDerivativeContentResponse,
+} from "./derivative-content-response";
+import {
+  applyPublicShareContentPolicy,
+  getPublicShareResponseMimeType,
+} from "./public-share-content-policy";
+
+export const createPublicShareContentResponse = async ({
+  request,
+  file,
+}: {
+  request: Request;
+  file: StoredFile;
+}): Promise<Response> => {
+  const publicFile = {
+    ...file,
+    mimeType: getPublicShareResponseMimeType(file.mimeType),
+    viewerKind: file.viewerKind ?? ("text" as const),
+  };
+  const response = await createInlineContentResponse({
+    request,
+    file: publicFile,
+  });
+
+  return applyPublicShareContentPolicy(response, file.name);
+};
+
+export const createPublicReadyDerivativeContentResponse = async (
+  input: Parameters<typeof createReadyDerivativeContentResponse>[0],
+): Promise<Response> => {
+  const response = await createReadyDerivativeContentResponse({
+    ...input,
+    derivative: {
+      ...input.derivative,
+      mimeType: getPublicShareResponseMimeType(
+        input.derivative.mimeType ?? "application/octet-stream",
+      ),
+    },
+  });
+  return applyPublicShareContentPolicy(response, input.fileName);
+};

--- a/apps/web/server/sharing.test.ts
+++ b/apps/web/server/sharing.test.ts
@@ -256,6 +256,38 @@ describe("folder public link behavior", () => {
     expect(markup).not.toMatch(/<(?:audio|embed|iframe|img|object|video)\b/u);
   });
 
+  it("does not fetch active text source when downloads are disabled", async () => {
+    const resolution: PublicShareResolution = {
+      ...lockedFileResolution,
+      share: {
+        ...lockedFileResolution.share,
+        hasPassword: false,
+        downloadDisabled: true,
+      },
+      access: {
+        requiresPassword: false,
+        isUnlocked: true,
+      },
+      file: {
+        ...lockedFileResolution.file,
+        name: "payload.html",
+        mimeType: "text/html",
+        viewerKind: "text",
+      },
+    };
+
+    const markup = await renderMarkup(
+      createElement(ShareView, {
+        resolution,
+        searchParams: {},
+        token: "token",
+      }),
+    );
+
+    expect(markup).not.toContain("Loading…");
+    expect(markup).not.toMatch(/<(?:audio|embed|iframe|img|object|video)\b/u);
+  });
+
   it("does not native-embed a shared SVG classified as an image", async () => {
     const resolution: PublicShareResolution = {
       ...lockedFileResolution,
@@ -315,5 +347,38 @@ describe("folder public link behavior", () => {
     );
 
     expect(markup).toContain('<img alt="safe.png" src="/s/token/content"');
+  });
+
+  it.each([
+    ["image/heic", "photo.heic"],
+    ["image/heif", "photo.heif"],
+  ])("keeps converted %s images native-inline", async (mimeType, name) => {
+    const resolution: PublicShareResolution = {
+      ...lockedFileResolution,
+      share: {
+        ...lockedFileResolution.share,
+        hasPassword: false,
+      },
+      access: {
+        requiresPassword: false,
+        isUnlocked: true,
+      },
+      file: {
+        ...lockedFileResolution.file,
+        name,
+        mimeType,
+        viewerKind: "image",
+      },
+    };
+
+    const markup = await renderMarkup(
+      createElement(ShareView, {
+        resolution,
+        searchParams: {},
+        token: "token",
+      }),
+    );
+
+    expect(markup).toContain(`<img alt="${name}" src="/s/token/content"`);
   });
 });

--- a/apps/web/server/sharing.test.ts
+++ b/apps/web/server/sharing.test.ts
@@ -224,4 +224,96 @@ describe("folder public link behavior", () => {
     expect(markup).not.toContain("2026");
     expect(markup).not.toContain("Breadcrumb");
   });
+
+  it("renders active HTML as fetched escaped-text UI, not a native embed", async () => {
+    const resolution: PublicShareResolution = {
+      ...lockedFileResolution,
+      share: {
+        ...lockedFileResolution.share,
+        hasPassword: false,
+      },
+      access: {
+        requiresPassword: false,
+        isUnlocked: true,
+      },
+      file: {
+        ...lockedFileResolution.file,
+        name: "payload.html",
+        mimeType: "text/html; charset=UTF-8",
+        viewerKind: "text",
+      },
+    };
+
+    const markup = await renderMarkup(
+      createElement(ShareView, {
+        resolution,
+        searchParams: {},
+        token: "token",
+      }),
+    );
+
+    expect(markup).toContain("Loading…");
+    expect(markup).not.toMatch(/<(?:audio|embed|iframe|img|object|video)\b/u);
+  });
+
+  it("does not native-embed a shared SVG classified as an image", async () => {
+    const resolution: PublicShareResolution = {
+      ...lockedFileResolution,
+      share: {
+        ...lockedFileResolution.share,
+        hasPassword: false,
+      },
+      access: {
+        requiresPassword: false,
+        isUnlocked: true,
+      },
+      file: {
+        ...lockedFileResolution.file,
+        name: "payload.svg",
+        mimeType: "image/svg+xml",
+        viewerKind: "image",
+      },
+    };
+
+    const markup = await renderMarkup(
+      createElement(ShareView, {
+        resolution,
+        searchParams: {},
+        token: "token",
+      }),
+    );
+
+    expect(markup).toContain("payload.svg");
+    expect(markup).not.toMatch(/<(?:audio|embed|iframe|img|object|video)\b/u);
+  });
+
+  it("keeps an allowlisted raster image native-inline", async () => {
+    const resolution: PublicShareResolution = {
+      ...lockedFileResolution,
+      share: {
+        ...lockedFileResolution.share,
+        hasPassword: false,
+      },
+      access: {
+        requiresPassword: false,
+        isUnlocked: true,
+      },
+      file: {
+        ...lockedFileResolution.file,
+        name: "safe.png",
+        mimeType: "image/png",
+        viewerKind: "image",
+      },
+    };
+
+    const markup = await renderMarkup(
+      createElement(ShareView, {
+        resolution,
+        searchParams: {},
+        token: "token",
+      }),
+    );
+
+    expect(markup).toContain('<img alt="safe.png" src="/s/token/content"');
+  });
 });

--- a/apps/web/server/sharing.test.ts
+++ b/apps/web/server/sharing.test.ts
@@ -143,6 +143,35 @@ const lockedFolderResolution: PublicShareResolution = {
   },
 };
 
+const makeUnlockedFileResolution = ({
+  downloadDisabled = false,
+  mimeType,
+  name,
+  viewerKind,
+}: {
+  downloadDisabled?: boolean;
+  mimeType: string;
+  name: string;
+  viewerKind: "audio" | "image" | "pdf" | "text" | "video" | null;
+}): PublicShareResolution => ({
+  ...lockedFileResolution,
+  share: {
+    ...lockedFileResolution.share,
+    hasPassword: false,
+    downloadDisabled,
+  },
+  access: {
+    requiresPassword: false,
+    isUnlocked: true,
+  },
+  file: {
+    ...lockedFileResolution.file,
+    mimeType,
+    name,
+    viewerKind,
+  },
+});
+
 describe("folder public link behavior", () => {
   it("allows traversal across the full linked subtree", () => {
     expect(
@@ -380,5 +409,117 @@ describe("folder public link behavior", () => {
     );
 
     expect(markup).toContain(`<img alt="${name}" src="/s/token/content"`);
+  });
+
+  it("renders a ready safe preview for a non-allowlisted original video", async () => {
+    const resolution = makeUnlockedFileResolution({
+      downloadDisabled: true,
+      mimeType: "video/quicktime",
+      name: "source.mov",
+      viewerKind: "video",
+    });
+
+    const markup = await renderMarkup(
+      createElement(ShareView, {
+        filePreview: { safeInlineMimeType: "video/mp4" },
+        resolution,
+        searchParams: {},
+        token: "token",
+      }),
+    );
+
+    expect(markup).toContain('<video controls="" playsInline=""');
+    expect(markup).toContain('src="/s/token/content"');
+    expect(markup).toContain("Downloads off");
+  });
+
+  it("does not native-embed a non-allowlisted video without a ready preview", async () => {
+    const markup = await renderMarkup(
+      createElement(ShareView, {
+        filePreview: null,
+        resolution: makeUnlockedFileResolution({
+          mimeType: "video/quicktime",
+          name: "source.mov",
+          viewerKind: "video",
+        }),
+        searchParams: {},
+        token: "token",
+      }),
+    );
+
+    expect(markup).not.toContain("<video");
+  });
+
+  it("does not native-embed an unsafe ready preview over a safe original", async () => {
+    const markup = await renderMarkup(
+      createElement(ShareView, {
+        filePreview: { safeInlineMimeType: null },
+        resolution: makeUnlockedFileResolution({
+          mimeType: "video/mp4",
+          name: "source.mp4",
+          viewerKind: "video",
+        }),
+        searchParams: {},
+        token: "token",
+      }),
+    );
+
+    expect(markup).not.toContain("<video");
+  });
+
+  it("keeps an allowlisted original MP4 native-inline", async () => {
+    const markup = await renderMarkup(
+      createElement(ShareView, {
+        resolution: makeUnlockedFileResolution({
+          mimeType: "video/mp4",
+          name: "source.mp4",
+          viewerKind: "video",
+        }),
+        searchParams: {},
+        token: "token",
+      }),
+    );
+
+    expect(markup).toContain('src="/s/token/content"');
+    expect(markup).toContain("<video");
+  });
+
+  it.each([
+    ["application/pdf", "document.pdf", "pdf", "<embed"],
+    ["text/plain", "notes.txt", "text", "Loading…"],
+    ["audio/mpeg", "track.mp3", "audio", "<audio"],
+  ] as const)(
+    "preserves native public rendering for %s",
+    async (mimeType, name, viewerKind, expectedMarkup) => {
+      const markup = await renderMarkup(
+        createElement(ShareView, {
+          resolution: makeUnlockedFileResolution({
+            mimeType,
+            name,
+            viewerKind,
+          }),
+          searchParams: {},
+          token: "token",
+        }),
+      );
+
+      expect(markup).toContain(expectedMarkup);
+    },
+  );
+
+  it("keeps an unknown file out of all native viewers", async () => {
+    const markup = await renderMarkup(
+      createElement(ShareView, {
+        resolution: makeUnlockedFileResolution({
+          mimeType: "application/x-unknown",
+          name: "unknown.bin",
+          viewerKind: null,
+        }),
+        searchParams: {},
+        token: "token",
+      }),
+    );
+
+    expect(markup).not.toMatch(/<(?:audio|embed|iframe|img|object|video)\b/u);
   });
 });

--- a/apps/web/server/sharing/poster-route.test.ts
+++ b/apps/web/server/sharing/poster-route.test.ts
@@ -108,6 +108,11 @@ describe("public share poster route", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toBe("image/jpeg");
     expect(response.headers.get("content-length")).toBe("12");
+    expect(response.headers.get("content-disposition")).toMatch(/^inline;/u);
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(response.headers.get("content-security-policy")).toBe(
+      "sandbox; default-src 'none'; form-action 'none'; base-uri 'none'",
+    );
     expect(await response.text()).toBe("poster-bytes");
   });
 

--- a/apps/web/server/sharing/public-content-route.test.ts
+++ b/apps/web/server/sharing/public-content-route.test.ts
@@ -1,0 +1,351 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import type { StoredFile } from "@/server/files/types";
+
+const PUBLIC_SHARE_CONTENT_SECURITY_POLICY =
+  "sandbox; default-src 'none'; form-action 'none'; base-uri 'none'";
+
+const mocks = vi.hoisted(() => ({
+  cookieGet: vi.fn(),
+  getSharedFileContent: vi.fn(),
+  getSharedNestedFileContent: vi.fn(),
+  getStoragePath: vi.fn(),
+  markFileStorageMissing: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({ get: mocks.cookieGet })),
+}));
+
+vi.mock("@/server/sharing/service", () => ({
+  sharingService: {
+    getSharedFileContent: mocks.getSharedFileContent,
+    getSharedNestedFileContent: mocks.getSharedNestedFileContent,
+  },
+}));
+
+vi.mock("@/server/storage", () => ({
+  getStoragePath: mocks.getStoragePath,
+}));
+
+vi.mock("@/server/files/repository", () => ({
+  prismaFilesRepository: {
+    markFileStorageMissing: mocks.markFileStorageMissing,
+  },
+}));
+
+const fixedNow = new Date("2026-07-20T12:00:00.000Z");
+
+const makeFile = (
+  overrides: Partial<StoredFile> & Pick<StoredFile, "mimeType" | "name">,
+): StoredFile => ({
+  id: "file-1",
+  ownerUserId: "member-1",
+  ownerStorageId: "member-1",
+  folderId: "folder-1",
+  sizeBytes: 0,
+  viewerKind: null,
+  deletedAt: null,
+  createdAt: fixedNow,
+  updatedAt: fixedNow,
+  storageKey: "fixture",
+  storageStatus: "available",
+  storageCheckedAt: null,
+  storageMissingAt: null,
+  contentChecksum: null,
+  ...overrides,
+});
+
+const expectPublicSecurityHeaders = (
+  response: Response,
+  {
+    disposition,
+    contentType,
+  }: { disposition: "attachment" | "inline"; contentType: string },
+) => {
+  expect(response.headers.get("content-disposition")).toMatch(
+    new RegExp(`^${disposition};`, "u"),
+  );
+  expect(response.headers.get("content-type")).toBe(contentType);
+  expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+  expect(response.headers.get("content-security-policy")).toBe(
+    PUBLIC_SHARE_CONTENT_SECURITY_POLICY,
+  );
+};
+
+describe("public share content routes", () => {
+  let tempDir = "";
+  const paths = new Map<string, string>();
+
+  beforeAll(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "staaash-public-content-"));
+    const fixtures = {
+      html: "<!doctype html><script>window.executed = true</script>",
+      svg: '<svg xmlns="http://www.w3.org/2000/svg"><script /></svg>',
+      png: "safe-png-bytes",
+      audio: "0123456789",
+      unknown: "unknown-bytes",
+    };
+
+    for (const [storageKey, bytes] of Object.entries(fixtures)) {
+      const fixturePath = path.join(tempDir, storageKey);
+      await writeFile(fixturePath, bytes, "utf8");
+      paths.set(storageKey, fixturePath);
+    }
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.cookieGet.mockReturnValue(null);
+    mocks.getStoragePath.mockImplementation((storageKey: string) =>
+      paths.get(storageKey),
+    );
+  });
+
+  afterAll(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("forces top-level shared HTML to attachment while preserving bytes", async () => {
+    const file = makeFile({
+      mimeType: "text/html",
+      name: "payload.html",
+      storageKey: "html",
+      viewerKind: "text",
+    });
+    mocks.getSharedFileContent.mockResolvedValue({ file });
+    const { GET } = await import("@/app/s/[token]/content/route");
+
+    const response = await GET(
+      new Request("http://localhost/s/token/content"),
+      {
+        params: Promise.resolve({ token: "token" }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expectPublicSecurityHeaders(response, {
+      disposition: "attachment",
+      contentType: "application/octet-stream",
+    });
+    expect(await response.text()).toBe(
+      "<!doctype html><script>window.executed = true</script>",
+    );
+  });
+
+  it("applies the same policy to nested shared SVG", async () => {
+    const file = makeFile({
+      id: "svg-1",
+      mimeType: "image/svg+xml",
+      name: "payload.svg",
+      storageKey: "svg",
+      viewerKind: "image",
+    });
+    mocks.getSharedNestedFileContent.mockResolvedValue({ file });
+    const { GET } =
+      await import("@/app/s/[token]/files/[fileId]/content/route");
+
+    const response = await GET(
+      new Request("http://localhost/s/token/files/svg-1/content"),
+      { params: Promise.resolve({ token: "token", fileId: "svg-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expectPublicSecurityHeaders(response, {
+      disposition: "attachment",
+      contentType: "application/octet-stream",
+    });
+    expect(await response.text()).toContain("<svg");
+  });
+
+  it("keeps public security headers on partial active content", async () => {
+    const file = makeFile({
+      mimeType: "TeXt/HtMl; charset=UTF-8",
+      name: "payload.html",
+      storageKey: "html",
+      viewerKind: "text",
+    });
+    mocks.getSharedFileContent.mockResolvedValue({ file });
+    const { GET } = await import("@/app/s/[token]/content/route");
+
+    const response = await GET(
+      new Request("http://localhost/s/token/content", {
+        headers: { range: "bytes=0-8" },
+      }),
+      { params: Promise.resolve({ token: "token" }) },
+    );
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("content-range")).toBe("bytes 0-8/54");
+    expect(response.headers.get("content-length")).toBe("9");
+    expectPublicSecurityHeaders(response, {
+      disposition: "attachment",
+      contentType: "application/octet-stream",
+    });
+    expect(await response.text()).toBe("<!doctype");
+  });
+
+  it("fails an unknown non-viewable MIME closed to attachment", async () => {
+    const file = makeFile({
+      mimeType: "application/x-unknown",
+      name: "unknown.bin",
+      storageKey: "unknown",
+      viewerKind: null,
+    });
+    mocks.getSharedFileContent.mockResolvedValue({ file });
+    const { GET } = await import("@/app/s/[token]/content/route");
+
+    const response = await GET(
+      new Request("http://localhost/s/token/content"),
+      {
+        params: Promise.resolve({ token: "token" }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expectPublicSecurityHeaders(response, {
+      disposition: "attachment",
+      contentType: "application/octet-stream",
+    });
+    expect(await response.text()).toBe("unknown-bytes");
+  });
+
+  it.each(["", "image/png; charset", "image/png\r\ntext/html"])(
+    "fails empty or malformed route MIME %j closed without emitting it",
+    async (mimeType) => {
+      const file = makeFile({
+        mimeType,
+        name: "malformed.bin",
+        storageKey: "unknown",
+        viewerKind: null,
+      });
+      mocks.getSharedFileContent.mockResolvedValue({ file });
+      const { GET } = await import("@/app/s/[token]/content/route");
+
+      const response = await GET(
+        new Request("http://localhost/s/token/content"),
+        { params: Promise.resolve({ token: "token" }) },
+      );
+
+      expect(response.status).toBe(200);
+      expectPublicSecurityHeaders(response, {
+        disposition: "attachment",
+        contentType: "application/octet-stream",
+      });
+      expect(await response.text()).toBe("unknown-bytes");
+    },
+  );
+
+  it("keeps an allowlisted raster image inline", async () => {
+    const file = makeFile({
+      mimeType: "image/png; charset=binary",
+      name: "safe.png",
+      storageKey: "png",
+      viewerKind: "image",
+    });
+    mocks.getSharedFileContent.mockResolvedValue({ file });
+    const { GET } = await import("@/app/s/[token]/content/route");
+
+    const response = await GET(
+      new Request("http://localhost/s/token/content"),
+      {
+        params: Promise.resolve({ token: "token" }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expectPublicSecurityHeaders(response, {
+      disposition: "inline",
+      contentType: "image/png",
+    });
+    expect(await response.text()).toBe("safe-png-bytes");
+  });
+
+  it("keeps allowlisted audio inline with byte-range behavior", async () => {
+    const file = makeFile({
+      id: "audio-1",
+      mimeType: "audio/mpeg",
+      name: "safe.mp3",
+      storageKey: "audio",
+      viewerKind: "audio",
+    });
+    mocks.getSharedNestedFileContent.mockResolvedValue({ file });
+    const { GET } =
+      await import("@/app/s/[token]/files/[fileId]/content/route");
+
+    const response = await GET(
+      new Request("http://localhost/s/token/files/audio-1/content", {
+        headers: { range: "bytes=2-5" },
+      }),
+      { params: Promise.resolve({ token: "token", fileId: "audio-1" }) },
+    );
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("content-range")).toBe("bytes 2-5/10");
+    expectPublicSecurityHeaders(response, {
+      disposition: "inline",
+      contentType: "audio/mpeg",
+    });
+    expect(await response.text()).toBe("2345");
+  });
+
+  it("redirects active public previews only to the fail-closed content route", async () => {
+    const file = makeFile({
+      mimeType: "text/html",
+      name: "payload.html",
+      storageKey: "html",
+      viewerKind: "text",
+    });
+    mocks.getSharedFileContent.mockResolvedValue({ file });
+    const { GET } = await import("@/app/s/[token]/preview/route");
+
+    const response = await GET(
+      new Request("http://localhost/s/token/preview"),
+      {
+        params: Promise.resolve({ token: "token" }),
+      },
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost/s/token/content",
+    );
+    expect(await response.text()).toBe("");
+  });
+
+  it("redirects nested active previews only to the nested fail-closed route", async () => {
+    const file = makeFile({
+      id: "svg-1",
+      mimeType: "image/svg+xml",
+      name: "payload.svg",
+      storageKey: "svg",
+      viewerKind: "image",
+    });
+    mocks.getSharedNestedFileContent.mockResolvedValue({ file });
+    const { GET } =
+      await import("@/app/s/[token]/files/[fileId]/preview/route");
+
+    const response = await GET(
+      new Request("http://localhost/s/token/files/svg-1/preview"),
+      { params: Promise.resolve({ token: "token", fileId: "svg-1" }) },
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost/s/token/files/svg-1/content",
+    );
+    expect(await response.text()).toBe("");
+  });
+});

--- a/apps/web/server/sharing/public-content-route.test.ts
+++ b/apps/web/server/sharing/public-content-route.test.ts
@@ -122,9 +122,6 @@ describe("public share content routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.cookieGet.mockReturnValue(null);
-    mocks.resolvePublicShare.mockResolvedValue({
-      share: { downloadDisabled: false },
-    });
     mocks.getStoragePath.mockImplementation((storageKey: string) =>
       paths.get(storageKey),
     );
@@ -141,7 +138,10 @@ describe("public share content routes", () => {
       storageKey: "html",
       viewerKind: "text",
     });
-    mocks.getSharedFileContent.mockResolvedValue({ file });
+    mocks.getSharedFileContent.mockResolvedValue({
+      file,
+      downloadDisabled: false,
+    });
     const { GET } = await import("@/app/s/[token]/content/route");
 
     const response = await GET(
@@ -159,6 +159,8 @@ describe("public share content routes", () => {
     expect(await response.text()).toBe(
       "<!doctype html><script>window.executed = true</script>",
     );
+    expect(mocks.getSharedFileContent).toHaveBeenCalledTimes(1);
+    expect(mocks.resolvePublicShare).not.toHaveBeenCalled();
   });
 
   it("applies the same policy to nested shared SVG", async () => {
@@ -169,7 +171,10 @@ describe("public share content routes", () => {
       storageKey: "svg",
       viewerKind: "image",
     });
-    mocks.getSharedNestedFileContent.mockResolvedValue({ file });
+    mocks.getSharedNestedFileContent.mockResolvedValue({
+      file,
+      downloadDisabled: false,
+    });
     const { GET } =
       await import("@/app/s/[token]/files/[fileId]/content/route");
 
@@ -184,6 +189,8 @@ describe("public share content routes", () => {
       contentType: "application/octet-stream",
     });
     expect(await response.text()).toContain("<svg");
+    expect(mocks.getSharedNestedFileContent).toHaveBeenCalledTimes(1);
+    expect(mocks.resolvePublicShare).not.toHaveBeenCalled();
   });
 
   it("keeps public security headers on partial active content", async () => {
@@ -193,7 +200,10 @@ describe("public share content routes", () => {
       storageKey: "html",
       viewerKind: "text",
     });
-    mocks.getSharedFileContent.mockResolvedValue({ file });
+    mocks.getSharedFileContent.mockResolvedValue({
+      file,
+      downloadDisabled: false,
+    });
     const { GET } = await import("@/app/s/[token]/content/route");
 
     const response = await GET(
@@ -220,7 +230,10 @@ describe("public share content routes", () => {
       storageKey: "unknown",
       viewerKind: null,
     });
-    mocks.getSharedFileContent.mockResolvedValue({ file });
+    mocks.getSharedFileContent.mockResolvedValue({
+      file,
+      downloadDisabled: false,
+    });
     const { GET } = await import("@/app/s/[token]/content/route");
 
     const response = await GET(
@@ -245,9 +258,9 @@ describe("public share content routes", () => {
       storageKey: "unknown",
       viewerKind: null,
     });
-    mocks.getSharedFileContent.mockResolvedValue({ file });
-    mocks.resolvePublicShare.mockResolvedValue({
-      share: { downloadDisabled: true },
+    mocks.getSharedFileContent.mockResolvedValue({
+      file,
+      downloadDisabled: true,
     });
     const { GET } = await import("@/app/s/[token]/content/route");
 
@@ -257,6 +270,7 @@ describe("public share content routes", () => {
     );
 
     await expectDownloadDisabledResponse(response);
+    expect(mocks.resolvePublicShare).not.toHaveBeenCalled();
   });
 
   it("blocks top-level active HTML bytes when downloads are disabled", async () => {
@@ -266,9 +280,9 @@ describe("public share content routes", () => {
       storageKey: "html",
       viewerKind: "text",
     });
-    mocks.getSharedFileContent.mockResolvedValue({ file });
-    mocks.resolvePublicShare.mockResolvedValue({
-      share: { downloadDisabled: true },
+    mocks.getSharedFileContent.mockResolvedValue({
+      file,
+      downloadDisabled: true,
     });
     const { GET } = await import("@/app/s/[token]/content/route");
 
@@ -288,9 +302,9 @@ describe("public share content routes", () => {
       storageKey: "svg",
       viewerKind: "image",
     });
-    mocks.getSharedNestedFileContent.mockResolvedValue({ file });
-    mocks.resolvePublicShare.mockResolvedValue({
-      share: { downloadDisabled: true },
+    mocks.getSharedNestedFileContent.mockResolvedValue({
+      file,
+      downloadDisabled: true,
     });
     const { GET } =
       await import("@/app/s/[token]/files/[fileId]/content/route");
@@ -312,7 +326,10 @@ describe("public share content routes", () => {
         storageKey: "unknown",
         viewerKind: null,
       });
-      mocks.getSharedFileContent.mockResolvedValue({ file });
+      mocks.getSharedFileContent.mockResolvedValue({
+        file,
+        downloadDisabled: false,
+      });
       const { GET } = await import("@/app/s/[token]/content/route");
 
       const response = await GET(
@@ -336,9 +353,9 @@ describe("public share content routes", () => {
       storageKey: "png",
       viewerKind: "image",
     });
-    mocks.getSharedFileContent.mockResolvedValue({ file });
-    mocks.resolvePublicShare.mockResolvedValue({
-      share: { downloadDisabled: true },
+    mocks.getSharedFileContent.mockResolvedValue({
+      file,
+      downloadDisabled: true,
     });
     const { GET } = await import("@/app/s/[token]/content/route");
 
@@ -365,9 +382,9 @@ describe("public share content routes", () => {
       storageKey: "audio",
       viewerKind: "audio",
     });
-    mocks.getSharedNestedFileContent.mockResolvedValue({ file });
-    mocks.resolvePublicShare.mockResolvedValue({
-      share: { downloadDisabled: true },
+    mocks.getSharedNestedFileContent.mockResolvedValue({
+      file,
+      downloadDisabled: true,
     });
     const { GET } =
       await import("@/app/s/[token]/files/[fileId]/content/route");
@@ -386,6 +403,8 @@ describe("public share content routes", () => {
       contentType: "audio/mpeg",
     });
     expect(await response.text()).toBe("2345");
+    expect(mocks.getSharedNestedFileContent).toHaveBeenCalledTimes(1);
+    expect(mocks.resolvePublicShare).not.toHaveBeenCalled();
   });
 
   it("redirects active public previews only to the fail-closed content route", async () => {
@@ -395,7 +414,10 @@ describe("public share content routes", () => {
       storageKey: "html",
       viewerKind: "text",
     });
-    mocks.getSharedFileContent.mockResolvedValue({ file });
+    mocks.getSharedFileContent.mockResolvedValue({
+      file,
+      downloadDisabled: false,
+    });
     const { GET } = await import("@/app/s/[token]/preview/route");
 
     const response = await GET(
@@ -420,7 +442,10 @@ describe("public share content routes", () => {
       storageKey: "svg",
       viewerKind: "image",
     });
-    mocks.getSharedNestedFileContent.mockResolvedValue({ file });
+    mocks.getSharedNestedFileContent.mockResolvedValue({
+      file,
+      downloadDisabled: false,
+    });
     const { GET } =
       await import("@/app/s/[token]/files/[fileId]/preview/route");
 

--- a/apps/web/server/sharing/public-content-route.test.ts
+++ b/apps/web/server/sharing/public-content-route.test.ts
@@ -13,6 +13,7 @@ import {
 } from "vitest";
 
 import type { StoredFile } from "@/server/files/types";
+import { ShareError, type ShareErrorCode } from "@/server/sharing/errors";
 
 const PUBLIC_SHARE_CONTENT_SECURITY_POLICY =
   "sandbox; default-src 'none'; form-action 'none'; base-uri 'none'";
@@ -21,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   cookieGet: vi.fn(),
   getSharedFileContent: vi.fn(),
   getSharedNestedFileContent: vi.fn(),
+  resolvePublicShare: vi.fn(),
   getStoragePath: vi.fn(),
   markFileStorageMissing: vi.fn(),
 }));
@@ -33,6 +35,7 @@ vi.mock("@/server/sharing/service", () => ({
   sharingService: {
     getSharedFileContent: mocks.getSharedFileContent,
     getSharedNestedFileContent: mocks.getSharedNestedFileContent,
+    resolvePublicShare: mocks.resolvePublicShare,
   },
 }));
 
@@ -85,6 +88,16 @@ const expectPublicSecurityHeaders = (
   );
 };
 
+const expectDownloadDisabledResponse = async (response: Response) => {
+  expect(response.status).toBe(403);
+  expect(response.headers.get("content-type")).toBe(
+    "text/plain; charset=utf-8",
+  );
+  expect(await response.text()).toBe(
+    "Downloads are disabled for this shared link.",
+  );
+};
+
 describe("public share content routes", () => {
   let tempDir = "";
   const paths = new Map<string, string>();
@@ -109,6 +122,9 @@ describe("public share content routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.cookieGet.mockReturnValue(null);
+    mocks.resolvePublicShare.mockResolvedValue({
+      share: { downloadDisabled: false },
+    });
     mocks.getStoragePath.mockImplementation((storageKey: string) =>
       paths.get(storageKey),
     );
@@ -222,6 +238,71 @@ describe("public share content routes", () => {
     expect(await response.text()).toBe("unknown-bytes");
   });
 
+  it("blocks top-level unknown attachment bytes when downloads are disabled", async () => {
+    const file = makeFile({
+      mimeType: "application/x-unknown",
+      name: "unknown.bin",
+      storageKey: "unknown",
+      viewerKind: null,
+    });
+    mocks.getSharedFileContent.mockResolvedValue({ file });
+    mocks.resolvePublicShare.mockResolvedValue({
+      share: { downloadDisabled: true },
+    });
+    const { GET } = await import("@/app/s/[token]/content/route");
+
+    const response = await GET(
+      new Request("http://localhost/s/token/content"),
+      { params: Promise.resolve({ token: "token" }) },
+    );
+
+    await expectDownloadDisabledResponse(response);
+  });
+
+  it("blocks top-level active HTML bytes when downloads are disabled", async () => {
+    const file = makeFile({
+      mimeType: "text/html",
+      name: "payload.html",
+      storageKey: "html",
+      viewerKind: "text",
+    });
+    mocks.getSharedFileContent.mockResolvedValue({ file });
+    mocks.resolvePublicShare.mockResolvedValue({
+      share: { downloadDisabled: true },
+    });
+    const { GET } = await import("@/app/s/[token]/content/route");
+
+    const response = await GET(
+      new Request("http://localhost/s/token/content"),
+      { params: Promise.resolve({ token: "token" }) },
+    );
+
+    await expectDownloadDisabledResponse(response);
+  });
+
+  it("blocks nested active SVG bytes when downloads are disabled", async () => {
+    const file = makeFile({
+      id: "svg-1",
+      mimeType: "image/svg+xml",
+      name: "payload.svg",
+      storageKey: "svg",
+      viewerKind: "image",
+    });
+    mocks.getSharedNestedFileContent.mockResolvedValue({ file });
+    mocks.resolvePublicShare.mockResolvedValue({
+      share: { downloadDisabled: true },
+    });
+    const { GET } =
+      await import("@/app/s/[token]/files/[fileId]/content/route");
+
+    const response = await GET(
+      new Request("http://localhost/s/token/files/svg-1/content"),
+      { params: Promise.resolve({ token: "token", fileId: "svg-1" }) },
+    );
+
+    await expectDownloadDisabledResponse(response);
+  });
+
   it.each(["", "image/png; charset", "image/png\r\ntext/html"])(
     "fails empty or malformed route MIME %j closed without emitting it",
     async (mimeType) => {
@@ -256,6 +337,9 @@ describe("public share content routes", () => {
       viewerKind: "image",
     });
     mocks.getSharedFileContent.mockResolvedValue({ file });
+    mocks.resolvePublicShare.mockResolvedValue({
+      share: { downloadDisabled: true },
+    });
     const { GET } = await import("@/app/s/[token]/content/route");
 
     const response = await GET(
@@ -282,6 +366,9 @@ describe("public share content routes", () => {
       viewerKind: "audio",
     });
     mocks.getSharedNestedFileContent.mockResolvedValue({ file });
+    mocks.resolvePublicShare.mockResolvedValue({
+      share: { downloadDisabled: true },
+    });
     const { GET } =
       await import("@/app/s/[token]/files/[fileId]/content/route");
 
@@ -347,5 +434,47 @@ describe("public share content routes", () => {
       "http://localhost/s/token/files/svg-1/content",
     );
     expect(await response.text()).toBe("");
+  });
+
+  it.each([
+    ["SHARE_PASSWORD_REQUIRED", 401],
+    ["SHARE_EXPIRED", 410],
+    ["SHARE_INVALID", 404],
+  ] satisfies Array<[ShareErrorCode, number]>)(
+    "preserves top-level %s resolution errors",
+    async (code, status) => {
+      mocks.getSharedFileContent.mockRejectedValue(new ShareError(code));
+      const { GET } = await import("@/app/s/[token]/content/route");
+
+      const response = await GET(
+        new Request("http://localhost/s/token/content"),
+        { params: Promise.resolve({ token: "token" }) },
+      );
+
+      expect(response.status).toBe(status);
+      expect(await response.text()).toBe(new ShareError(code).message);
+      expect(mocks.getStoragePath).not.toHaveBeenCalled();
+    },
+  );
+
+  it("preserves nested containment rejection", async () => {
+    mocks.getSharedNestedFileContent.mockRejectedValue(
+      new ShareError("SHARE_ACCESS_DENIED"),
+    );
+    const { GET } =
+      await import("@/app/s/[token]/files/[fileId]/content/route");
+
+    const response = await GET(
+      new Request("http://localhost/s/token/files/outside/content"),
+      {
+        params: Promise.resolve({ token: "token", fileId: "outside" }),
+      },
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe(
+      "That shared item is not available from this location.",
+    );
+    expect(mocks.getStoragePath).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/server/sharing/public-file-page.test.ts
+++ b/apps/web/server/sharing/public-file-page.test.ts
@@ -1,0 +1,192 @@
+import { createElement } from "react";
+import { renderToReadableStream } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { FileSummary, FolderSummary } from "@/server/files/types";
+import type { PublicShareResolution } from "@/server/sharing/types";
+
+const mocks = vi.hoisted(() => ({
+  getPublicShareFilePreview: vi.fn(),
+  getSharedNestedFileContent: vi.fn(),
+  resolvePublicShare: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({ get: () => undefined })),
+  headers: vi.fn(async () => new Headers()),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(() => {
+    throw new Error("not found");
+  }),
+}));
+
+vi.mock("@/server/auth/service", () => ({
+  authService: {
+    getSetupState: vi.fn().mockResolvedValue({ instanceName: "Staaash" }),
+  },
+}));
+
+vi.mock("@/server/sharing/metadata", () => ({
+  getSharePageMetadata: vi.fn(),
+}));
+
+vi.mock("@/server/sharing/public-file-preview", () => ({
+  getPublicShareFilePreview: mocks.getPublicShareFilePreview,
+}));
+
+vi.mock("@/server/sharing/service", () => ({
+  sharingService: {
+    getSharedNestedFileContent: mocks.getSharedNestedFileContent,
+    resolvePublicShare: mocks.resolvePublicShare,
+  },
+}));
+
+import SharedRootPage from "@/app/s/[token]/page";
+import SharedNestedFilePage from "@/app/s/[token]/files/[fileId]/page";
+
+const fixedNow = new Date("2026-07-20T12:00:00.000Z");
+
+const videoFile: FileSummary = {
+  id: "video-1",
+  ownerUserId: "member-1",
+  ownerStorageId: "member-1",
+  folderId: "folder-1",
+  name: "source.mov",
+  mimeType: "video/quicktime",
+  sizeBytes: 10,
+  viewerKind: "video",
+  deletedAt: null,
+  createdAt: fixedNow,
+  updatedAt: fixedNow,
+};
+
+const rootFolder: FolderSummary = {
+  id: "folder-1",
+  ownerUserId: "member-1",
+  ownerStorageId: "member-1",
+  parentId: "root",
+  name: "Shared",
+  isFilesRoot: false,
+  deletedAt: null,
+  createdAt: fixedNow,
+  updatedAt: fixedNow,
+};
+
+const share = {
+  id: "share-1",
+  createdByUserId: "member-1",
+  targetType: "file" as const,
+  fileId: videoFile.id,
+  folderId: null,
+  shareUrl: "https://example.test/s/token",
+  hasPassword: false,
+  downloadDisabled: false,
+  expiresAt: new Date("2026-08-20T12:00:00.000Z"),
+  revokedAt: null,
+  createdAt: fixedNow,
+  updatedAt: fixedNow,
+  status: "active" as const,
+  target: {
+    targetType: "file" as const,
+    id: videoFile.id,
+    ownerUserId: videoFile.ownerUserId,
+    ownerStorageId: videoFile.ownerStorageId,
+    name: videoFile.name,
+    folderId: videoFile.folderId,
+    mimeType: videoFile.mimeType,
+    sizeBytes: videoFile.sizeBytes,
+    pathLabel: "Files / source.mov",
+    deletedAt: null,
+  },
+};
+
+const directResolution: PublicShareResolution = {
+  kind: "file",
+  share,
+  access: { requiresPassword: false, isUnlocked: true },
+  file: videoFile,
+};
+
+const folderResolution: PublicShareResolution = {
+  kind: "folder",
+  share: {
+    ...share,
+    targetType: "folder",
+    fileId: null,
+    folderId: rootFolder.id,
+    downloadDisabled: true,
+    target: {
+      targetType: "folder",
+      id: rootFolder.id,
+      ownerUserId: rootFolder.ownerUserId,
+      ownerStorageId: rootFolder.ownerStorageId,
+      name: rootFolder.name,
+      parentId: rootFolder.parentId,
+      isFilesRoot: rootFolder.isFilesRoot,
+      pathLabel: "Files / Shared",
+      deletedAt: null,
+    },
+  },
+  access: { requiresPassword: false, isUnlocked: true },
+  listing: {
+    rootFolder,
+    currentFolder: rootFolder,
+    breadcrumbs: [
+      { id: rootFolder.id, name: rootFolder.name, href: "/s/token" },
+    ],
+    childFolders: [],
+    files: [videoFile],
+  },
+};
+
+async function renderMarkup(element: React.ReactElement): Promise<string> {
+  const stream = await renderToReadableStream(element);
+  await stream.allReady;
+  return new Response(stream).text();
+}
+
+describe("public shared file pages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getPublicShareFilePreview.mockResolvedValue({
+      safeInlineMimeType: "video/mp4",
+    });
+  });
+
+  it("passes ready safe video preview metadata to a direct file share", async () => {
+    mocks.resolvePublicShare.mockResolvedValue(directResolution);
+
+    const page = await SharedRootPage({
+      params: Promise.resolve({ token: "token" }),
+      searchParams: Promise.resolve({}),
+    });
+    const markup = await renderMarkup(createElement(() => page));
+
+    expect(mocks.getPublicShareFilePreview).toHaveBeenCalledWith(videoFile);
+    expect(markup).toContain("<video");
+    expect(markup).toContain('src="/s/token/content"');
+    expect(markup).not.toContain("derivatives/");
+  });
+
+  it("passes the same minimal metadata through a nested folder share", async () => {
+    mocks.resolvePublicShare.mockResolvedValue(folderResolution);
+    mocks.getSharedNestedFileContent.mockResolvedValue({
+      file: videoFile,
+      downloadDisabled: true,
+    });
+
+    const page = await SharedNestedFilePage({
+      params: Promise.resolve({ token: "token", fileId: videoFile.id }),
+      searchParams: Promise.resolve({}),
+    });
+    const markup = await renderMarkup(createElement(() => page));
+
+    expect(mocks.getPublicShareFilePreview).toHaveBeenCalledWith(videoFile);
+    expect(markup).toContain("<video");
+    expect(markup).toContain('src="/s/token/files/video-1/content"');
+    expect(markup).toContain("Downloads off");
+    expect(markup).not.toContain("derivatives/");
+  });
+});

--- a/apps/web/server/sharing/public-file-preview.test.ts
+++ b/apps/web/server/sharing/public-file-preview.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { MediaDerivativeRecord } from "@staaash/db/media-derivatives";
+
+import type { FileSummary } from "@/server/files/types";
+
+const mocks = vi.hoisted(() => ({
+  findReadyDerivative: vi.fn(),
+  getStoragePath: vi.fn(),
+  stat: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:fs/promises")>()),
+  stat: mocks.stat,
+}));
+
+vi.mock("@staaash/db/media-derivatives", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@staaash/db/media-derivatives")>()),
+  findReadyDerivative: mocks.findReadyDerivative,
+}));
+
+vi.mock("@/server/storage", () => ({
+  getStoragePath: mocks.getStoragePath,
+}));
+
+const fixedNow = new Date("2026-07-20T12:00:00.000Z");
+
+const videoFile: FileSummary = {
+  id: "video-1",
+  ownerUserId: "member-1",
+  ownerStorageId: "member-1",
+  folderId: "folder-1",
+  name: "source.mov",
+  mimeType: "video/quicktime",
+  sizeBytes: 10,
+  viewerKind: "video",
+  deletedAt: null,
+  createdAt: fixedNow,
+  updatedAt: fixedNow,
+};
+
+const makeDerivative = (
+  overrides: Partial<MediaDerivativeRecord> = {},
+): MediaDerivativeRecord => ({
+  id: "derivative-1",
+  fileId: videoFile.id,
+  kind: "preview",
+  profile: "preview-1080p",
+  status: "ready",
+  storageKey: "derivatives/member-1/video-1/preview-1080p.mp4",
+  mimeType: "video/mp4",
+  sizeBytes: 10n,
+  width: 1280,
+  height: 720,
+  durationSeconds: 2,
+  videoCodec: "h264",
+  audioCodec: "aac",
+  error: null,
+  pinnedByAdmin: false,
+  lastViewedAt: null,
+  lastSharedAt: null,
+  generatedAt: fixedNow,
+  createdAt: fixedNow,
+  updatedAt: fixedNow,
+  ...overrides,
+});
+
+describe("public share file preview metadata", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getStoragePath.mockReturnValue("C:\\temp\\preview.mp4");
+    mocks.stat.mockResolvedValue({ isFile: () => true });
+  });
+
+  it("exposes only a safe emitted MIME for a ready readable derivative", async () => {
+    mocks.findReadyDerivative.mockResolvedValue(
+      makeDerivative({ mimeType: "ViDeO/Mp4; codecs=avc1" }),
+    );
+    const { getPublicShareFilePreview } = await import("./public-file-preview");
+
+    const preview = await getPublicShareFilePreview(videoFile);
+
+    expect(preview).toEqual({ safeInlineMimeType: "video/mp4" });
+    expect(preview).not.toHaveProperty("storageKey");
+    expect(preview).not.toHaveProperty("id");
+  });
+
+  it.each(["failed", "queued", "processing", "stale"])(
+    "ignores a %s derivative record",
+    async (status) => {
+      mocks.findReadyDerivative.mockResolvedValue(makeDerivative({ status }));
+      const { getPublicShareFilePreview } =
+        await import("./public-file-preview");
+
+      await expect(getPublicShareFilePreview(videoFile)).resolves.toBeNull();
+    },
+  );
+
+  it.each([
+    ["missing record", null],
+    ["missing storage key", makeDerivative({ storageKey: null })],
+    ["missing size", makeDerivative({ sizeBytes: null })],
+  ])("ignores a %s", async (_label, derivative) => {
+    mocks.findReadyDerivative.mockResolvedValue(derivative);
+    const { getPublicShareFilePreview } = await import("./public-file-preview");
+
+    await expect(getPublicShareFilePreview(videoFile)).resolves.toBeNull();
+  });
+
+  it("ignores a derivative whose storage object is missing", async () => {
+    mocks.findReadyDerivative.mockResolvedValue(makeDerivative());
+    mocks.stat.mockRejectedValue(new Error("missing"));
+    const { getPublicShareFilePreview } = await import("./public-file-preview");
+
+    await expect(getPublicShareFilePreview(videoFile)).resolves.toBeNull();
+  });
+
+  it.each(["video/quicktime", "video/mp4; charset", ""])(
+    "marks ready MIME %j as not native-inline without exposing it",
+    async (mimeType) => {
+      mocks.findReadyDerivative.mockResolvedValue(makeDerivative({ mimeType }));
+      const { getPublicShareFilePreview } =
+        await import("./public-file-preview");
+
+      await expect(getPublicShareFilePreview(videoFile)).resolves.toEqual({
+        safeInlineMimeType: null,
+      });
+    },
+  );
+
+  it("does not query derivatives for other viewer kinds", async () => {
+    const { getPublicShareFilePreview } = await import("./public-file-preview");
+
+    await expect(
+      getPublicShareFilePreview({ ...videoFile, viewerKind: "image" }),
+    ).resolves.toBeNull();
+    expect(mocks.findReadyDerivative).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/server/sharing/public-file-preview.ts
+++ b/apps/web/server/sharing/public-file-preview.ts
@@ -1,0 +1,59 @@
+import { stat } from "node:fs/promises";
+
+import {
+  DERIVATIVE_STATUS_READY,
+  findReadyDerivative,
+  type MediaDerivativeRecord,
+} from "@staaash/db/media-derivatives";
+
+import type { FileSummary } from "@/server/files/types";
+import { getPublicShareSafeInlineMimeType } from "@/server/media/public-share-content-policy";
+import { getStoragePath } from "@/server/storage";
+
+import type { PublicShareFilePreview } from "./types";
+
+type StoredReadyDerivative = MediaDerivativeRecord & {
+  sizeBytes: bigint;
+  storageKey: string;
+};
+
+const findPreviewDerivative = async (
+  fileId: string,
+): Promise<MediaDerivativeRecord | null> => {
+  try {
+    return await findReadyDerivative(fileId);
+  } catch {
+    return null;
+  }
+};
+
+const isStoredReadyDerivative = (
+  derivative: MediaDerivativeRecord | null,
+): derivative is StoredReadyDerivative =>
+  derivative?.status === DERIVATIVE_STATUS_READY &&
+  Boolean(derivative.storageKey) &&
+  derivative.sizeBytes !== null;
+
+const isReadableDerivativeFile = async (storageKey: string) => {
+  try {
+    return (await stat(getStoragePath(storageKey))).isFile();
+  } catch {
+    return false;
+  }
+};
+
+export const getPublicShareFilePreview = async (
+  file: FileSummary,
+): Promise<PublicShareFilePreview | null> => {
+  if (file.viewerKind !== "video") return null;
+
+  const derivative = await findPreviewDerivative(file.id);
+  if (!isStoredReadyDerivative(derivative)) return null;
+  if (!(await isReadableDerivativeFile(derivative.storageKey))) return null;
+
+  return {
+    safeInlineMimeType: getPublicShareSafeInlineMimeType(
+      derivative.mimeType ?? "",
+    ),
+  };
+};

--- a/apps/web/server/sharing/service.test.ts
+++ b/apps/web/server/sharing/service.test.ts
@@ -464,6 +464,86 @@ describe("sharing service", () => {
     });
   });
 
+  it("preserves content password, expiry, revocation, and containment checks", async () => {
+    const passwordRepo = createFakeSharingRepository();
+    const passwordService = createSharingService({
+      repo: passwordRepo.repo,
+      filesRepo: fakeFilesRepo,
+      now: () => fixedNow,
+    });
+    const passwordShare = await passwordService.createOrReissueShare({
+      actorUserId: "user-1",
+      actorRole: "member",
+      targetType: "file",
+      fileId: sharedFile.id,
+      expiresAt: addDays(5),
+      password: "secret-pass",
+    });
+    await expect(
+      passwordService.getSharedFileContent({ token: passwordShare.token }),
+    ).rejects.toMatchObject({ code: "SHARE_PASSWORD_REQUIRED" });
+
+    const expiredRepo = createFakeSharingRepository();
+    const expiredService = createSharingService({
+      repo: expiredRepo.repo,
+      filesRepo: fakeFilesRepo,
+      now: () => fixedNow,
+    });
+    const expiredShare = await expiredService.createOrReissueShare({
+      actorUserId: "user-1",
+      actorRole: "member",
+      targetType: "file",
+      fileId: sharedFile.id,
+      expiresAt: addDays(1),
+    });
+    expiredRepo.state[0]!.expiresAt = fixedNow;
+    await expect(
+      expiredService.getSharedFileContent({ token: expiredShare.token }),
+    ).rejects.toMatchObject({ code: "SHARE_EXPIRED" });
+
+    const revokedRepo = createFakeSharingRepository();
+    const revokedService = createSharingService({
+      repo: revokedRepo.repo,
+      filesRepo: fakeFilesRepo,
+      now: () => fixedNow,
+    });
+    const revokedShare = await revokedService.createOrReissueShare({
+      actorUserId: "user-1",
+      actorRole: "member",
+      targetType: "file",
+      fileId: sharedFile.id,
+      expiresAt: addDays(5),
+    });
+    await revokedService.revokeShare({
+      actorUserId: "user-1",
+      actorRole: "member",
+      shareId: revokedShare.share.id,
+    });
+    await expect(
+      revokedService.getSharedFileContent({ token: revokedShare.token }),
+    ).rejects.toMatchObject({ code: "SHARE_INVALID" });
+
+    const containmentRepo = createFakeSharingRepository();
+    const containmentService = createSharingService({
+      repo: containmentRepo.repo,
+      filesRepo: fakeFilesRepo,
+      now: () => fixedNow,
+    });
+    const containmentShare = await containmentService.createOrReissueShare({
+      actorUserId: "user-1",
+      actorRole: "member",
+      targetType: "folder",
+      folderId: sharedFolder.id,
+      expiresAt: addDays(5),
+    });
+    await expect(
+      containmentService.getSharedNestedFileContent({
+        token: containmentShare.token,
+        fileId: "outside-file",
+      }),
+    ).rejects.toMatchObject({ code: "SHARE_ACCESS_DENIED" });
+  });
+
   it("schedules a social poster for small shared videos below preview threshold", async () => {
     const sharingRepo = createFakeSharingRepository();
     const videoFilesRepo = {

--- a/apps/web/server/sharing/service.test.ts
+++ b/apps/web/server/sharing/service.test.ts
@@ -544,6 +544,90 @@ describe("sharing service", () => {
     ).rejects.toMatchObject({ code: "SHARE_ACCESS_DENIED" });
   });
 
+  it("returns top-level content policy from its single share resolution", async () => {
+    const sharingRepo = createFakeSharingRepository();
+    const service = createSharingService({
+      repo: sharingRepo.repo,
+      filesRepo: fakeFilesRepo,
+      now: () => fixedNow,
+    });
+    const created = await service.createOrReissueShare({
+      actorUserId: "user-1",
+      actorRole: "member",
+      targetType: "file",
+      fileId: sharedFile.id,
+      expiresAt: addDays(5),
+      downloadDisabled: true,
+    });
+    const resolveSpy = vi.spyOn(service, "resolvePublicShare");
+
+    const result = await service.getSharedFileContent({
+      token: created.token,
+    });
+
+    expect(resolveSpy).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ file: sharedFile, downloadDisabled: true });
+  });
+
+  it("returns nested content policy from its single share resolution", async () => {
+    const sharingRepo = createFakeSharingRepository();
+    const service = createSharingService({
+      repo: sharingRepo.repo,
+      filesRepo: fakeFilesRepo,
+      now: () => fixedNow,
+    });
+    const created = await service.createOrReissueShare({
+      actorUserId: "user-1",
+      actorRole: "member",
+      targetType: "folder",
+      folderId: sharedFolder.id,
+      expiresAt: addDays(5),
+      downloadDisabled: true,
+    });
+    const resolveSpy = vi.spyOn(service, "resolvePublicShare");
+
+    const result = await service.getSharedNestedFileContent({
+      token: created.token,
+      fileId: childFile.id,
+    });
+
+    expect(resolveSpy).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ file: childFile, downloadDisabled: true });
+  });
+
+  it("preserves unavailable-target rejection for public content", async () => {
+    const sharingRepo = createFakeSharingRepository();
+    let targetAvailable = true;
+    const filesRepo = {
+      ...fakeFilesRepo,
+      async findFileById(fileId: string) {
+        if (fileId === sharedFile.id && !targetAvailable) return null;
+        return fakeFilesRepo.findFileById(fileId);
+      },
+      async listFilesByOwner() {
+        return targetAvailable ? [sharedFile, childFile] : [childFile];
+      },
+    } as unknown as FilesRepository;
+    const service = createSharingService({
+      repo: sharingRepo.repo,
+      filesRepo,
+      now: () => fixedNow,
+    });
+    const created = await service.createOrReissueShare({
+      actorUserId: "user-1",
+      actorRole: "member",
+      targetType: "file",
+      fileId: sharedFile.id,
+      expiresAt: addDays(5),
+    });
+
+    targetAvailable = false;
+
+    await expect(
+      service.getSharedFileContent({ token: created.token }),
+    ).rejects.toMatchObject({ code: "SHARE_TARGET_UNAVAILABLE" });
+  });
+
   it("schedules a social poster for small shared videos below preview threshold", async () => {
     const sharingRepo = createFakeSharingRepository();
     const videoFilesRepo = {

--- a/apps/web/server/sharing/service.ts
+++ b/apps/web/server/sharing/service.ts
@@ -1205,7 +1205,7 @@ export const createSharingService = ({
     }: {
       token: string;
       shareAccessCookieValue?: string | null;
-    }): Promise<{ file: StoredFile }> {
+    }): Promise<{ file: StoredFile; downloadDisabled: boolean }> {
       const resolved = await this.resolvePublicShare({
         token,
         shareAccessCookieValue,
@@ -1225,7 +1225,7 @@ export const createSharingService = ({
         await resolveFilesRepo()
       ).findFileById(resolved.file.id))!;
 
-      return { file };
+      return { file, downloadDisabled: resolved.share.downloadDisabled };
     },
 
     async getSharedNestedFileContent({
@@ -1236,7 +1236,7 @@ export const createSharingService = ({
       token: string;
       fileId: string;
       shareAccessCookieValue?: string | null;
-    }): Promise<{ file: StoredFile }> {
+    }): Promise<{ file: StoredFile; downloadDisabled: boolean }> {
       const resolved = await this.resolvePublicShare({
         token,
         shareAccessCookieValue,
@@ -1274,7 +1274,7 @@ export const createSharingService = ({
         throw new ShareError("SHARE_ACCESS_DENIED");
       }
 
-      return { file };
+      return { file, downloadDisabled: resolved.share.downloadDisabled };
     },
   };
 };

--- a/apps/web/server/sharing/types.ts
+++ b/apps/web/server/sharing/types.ts
@@ -94,6 +94,10 @@ export type PublicShareResolution =
       listing: SharedFolderListing;
     };
 
+export type PublicShareFilePreview = {
+  safeInlineMimeType: string | null;
+};
+
 export type ShareFilesLookup = {
   currentFolderShare: ShareLinkSummary | null;
   sharesByFolderId: Record<string, ShareLinkSummary>;


### PR DESCRIPTION
## 🚀 Summary

Fixes audit finding SEC-01 by enforcing one centralized browser-content policy for public share responses.

Publicly shared files use an exact safe-inline MIME allowlist. Active, malformed, unknown, and non-allowlisted MIME types are served as attachments with `application/octet-stream`. Every successful public content response also receives a restrictive bare sandbox CSP and `nosniff`.

The review follow-ups enforce `downloadDisabled` after the final emitted response policy is known, carry that policy from the same authorization snapshot, and keep ready safe video derivatives visible without trusting unsupported original MIME metadata.

## 📊 Impacts and Changes

- Prevents member-controlled HTML, XHTML, SVG, XML, JavaScript, and other active or unknown content from executing as same-origin Staaash documents.
- Applies the policy to top-level and nested public content routes, ready derivatives, original fallbacks, posters, and both `200` and `206` responses.
- Rejects final attachment responses when a share disables downloads, including active and unsupported files reached through `/content`.
- Cancels blocked response bodies and closes original/derivative streams and file handles.
- Returns `file` and `downloadDisabled` from one validated content-service resolution; content routes no longer resolve the owner library twice per request or range.
- Evaluates actual emitted MIME, including HEIC/HEIF converted to JPEG and generated derivatives.
- Exposes only `{ safeInlineMimeType }` preview metadata to public pages. No derivative IDs, storage keys, paths, job IDs, or private records reach the client.
- Renders a non-allowlisted original video only when a ready, readable derivative emits an allowlisted MIME such as `video/mp4`; the source remains the hardened public `/content` route.
- Treats unsafe or malformed ready derivative MIME as present but non-embeddable, preventing fallback trust in the original MIME.
- Keeps allowlisted raster images, audio, video, plain text, sandboxed PDF, and converted HEIC/HEIF inline.
- Stops the public share UI from native-embedding unsafe content; escaped active text source is only fetched when downloads are allowed.
- Preserves private authenticated viewing, range streaming, passwords, expiry, revocation, containment, explicit downloads, and archives.
- Schema: none.
- Auth/session behavior: none.
- Storage layout and restore behavior: none.

Root cause: upload MIME metadata is client-controlled, while broad viewer classification previously allowed public routes to emit browser-active content inline from the authenticated application origin.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

Additional validation:

- Focused SEC-01 Vitest suite — 7 files, 95 tests
- `pnpm --filter web typecheck`
- `pnpm --filter web test` — 64 files, 375 tests
- Targeted isolated Playwright SEC-01 spec — 1 passed on clean rerun
- `pnpm format:check`
- `pnpm quality:fallow` — passed; 7 existing clone groups remain warnings
- `git diff --check`

The Playwright run used a unique disposable PostgreSQL database, fresh server port, and disposable storage root with matching `FILES_ROOT` and `UPLOAD_LOCATION`; all database, storage, download, trace, and test-result artifacts were removed afterward.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

The browser regression uses inert fixtures in Chromium. Existing unrelated `/home` hydration and Three.js deprecation warnings remain outside SEC-01 scope.

## 🔗 Linked Issues

None.