### PR TITLE
fix(worker): protect active resumable staging

### DIFF
--- a/apps/worker/src/handlers/staging-cleanup.test.ts
+++ b/apps/worker/src/handlers/staging-cleanup.test.ts
@@ -1,0 +1,249 @@
+import os from "node:os";
+import path from "node:path";
+import { access, lstat, mkdir, rm, utimes, writeFile } from "node:fs/promises";
+
+import {
+  STAGING_CLEANUP_JOB_KIND,
+  type BackgroundJobRecord,
+} from "@staaash/db/jobs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getPrismaMock = vi.fn();
+
+vi.mock("@staaash/db/client", () => ({
+  getPrisma: getPrismaMock,
+}));
+
+type TestUploadSession = {
+  id: string;
+  status: string;
+  expiresAt: Date;
+  tmpPath: string;
+};
+
+type ActiveSessionQuery = {
+  where: {
+    status: { in: string[] };
+    expiresAt: { gt: Date };
+  };
+  select: { tmpPath: true };
+};
+
+const fixedNow = new Date("2026-04-06T12:00:00.000Z");
+const stagingTtlMs = 2 * 60 * 60 * 1000;
+
+const createTempRoot = () =>
+  path.join(os.tmpdir(), `staaash-staging-${Date.now()}-${Math.random()}`);
+
+const createJob = (): BackgroundJobRecord => ({
+  id: "job-1",
+  kind: STAGING_CLEANUP_JOB_KIND,
+  status: "queued",
+  payloadJson: {},
+  dedupeKey: null,
+  runAt: fixedNow,
+  lockedAt: null,
+  lockedBy: null,
+  attemptCount: 0,
+  maxAttempts: 5,
+  lastError: null,
+  createdAt: fixedNow,
+  updatedAt: fixedNow,
+});
+
+const createSessionClient = (sessions: TestUploadSession[]) => {
+  const findMany = vi.fn(async (query: ActiveSessionQuery) => {
+    const activeStatuses = new Set(query.where.status.in);
+    return sessions
+      .filter(
+        (session) =>
+          activeStatuses.has(session.status) &&
+          session.expiresAt > query.where.expiresAt.gt,
+      )
+      .map((session) => ({ tmpPath: session.tmpPath }));
+  });
+
+  return {
+    client: { uploadSession: { findMany } },
+    findMany,
+  };
+};
+
+const expectPathToExist = async (filePath: string) => {
+  await expect(access(filePath)).resolves.toBeUndefined();
+};
+
+const expectPathToBeMissing = async (filePath: string) => {
+  await expect(access(filePath)).rejects.toBeDefined();
+};
+
+describe("staging cleanup handler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(fixedNow);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    getPrismaMock.mockReset();
+    vi.resetModules();
+  });
+
+  it("keeps stale bytes for active unexpired sessions and cleans unprotected files", async () => {
+    const filesRoot = createTempRoot();
+    const tmpRoot = path.join(filesRoot, "tmp");
+    await mkdir(tmpRoot, { recursive: true });
+
+    const filePaths = {
+      created: path.join(tmpRoot, "rs-created.upload"),
+      receiving: path.join(tmpRoot, "rs-receiving.upload"),
+      persistedCustom: path.join(tmpRoot, "persisted-custom.upload"),
+      expired: path.join(tmpRoot, "rs-expired.upload"),
+      boundary: path.join(tmpRoot, "rs-boundary.upload"),
+      completed: path.join(tmpRoot, "rs-completed.upload"),
+      cancelled: path.join(tmpRoot, "rs-cancelled.upload"),
+      failed: path.join(tmpRoot, "rs-failed.upload"),
+      prefixOnlyOrphan: path.join(tmpRoot, "rs-orphan.upload"),
+      freshOrdinary: path.join(tmpRoot, "fresh.upload"),
+    };
+    await Promise.all(
+      Object.values(filePaths).map((filePath) =>
+        writeFile(filePath, "staged bytes", "utf8"),
+      ),
+    );
+
+    const staleTime = new Date(fixedNow.getTime() - stagingTtlMs - 1);
+    const stalePaths = Object.entries(filePaths)
+      .filter(([name]) => name !== "freshOrdinary")
+      .map(([, filePath]) => filePath);
+    await Promise.all(
+      stalePaths.map((filePath) => utimes(filePath, staleTime, staleTime)),
+    );
+
+    const futureExpiry = new Date(fixedNow.getTime() + 21 * 60 * 60 * 1000);
+    const sessions: TestUploadSession[] = [
+      {
+        id: "created",
+        status: "created",
+        expiresAt: futureExpiry,
+        tmpPath: filePaths.created,
+      },
+      {
+        id: "receiving",
+        status: "receiving",
+        expiresAt: futureExpiry,
+        tmpPath: filePaths.receiving,
+      },
+      {
+        id: "persisted-custom",
+        status: "created",
+        expiresAt: futureExpiry,
+        tmpPath: filePaths.persistedCustom,
+      },
+      {
+        id: "expired",
+        status: "created",
+        expiresAt: new Date(fixedNow.getTime() - 1),
+        tmpPath: filePaths.expired,
+      },
+      {
+        id: "boundary",
+        status: "receiving",
+        expiresAt: fixedNow,
+        tmpPath: filePaths.boundary,
+      },
+      {
+        id: "completed",
+        status: "completed",
+        expiresAt: futureExpiry,
+        tmpPath: filePaths.completed,
+      },
+      {
+        id: "cancelled",
+        status: "cancelled",
+        expiresAt: futureExpiry,
+        tmpPath: filePaths.cancelled,
+      },
+      {
+        id: "failed",
+        status: "failed",
+        expiresAt: futureExpiry,
+        tmpPath: filePaths.failed,
+      },
+    ];
+    const { client, findMany } = createSessionClient(sessions);
+    getPrismaMock.mockReturnValue(client);
+
+    const createdStats = await lstat(filePaths.created);
+    expect(futureExpiry > fixedNow).toBe(true);
+    expect(fixedNow.getTime() - createdStats.mtime.getTime()).toBeGreaterThan(
+      stagingTtlMs,
+    );
+
+    const { handleStagingCleanup } = await import("./staging-cleanup.js");
+    await handleStagingCleanup(createJob(), {
+      filesRoot,
+      tmpRoot,
+      heartbeatPath: path.join(tmpRoot, "worker-heartbeat.json"),
+      pendingDeleteRoot: path.join(tmpRoot, "pending-delete"),
+      uploadStagingTtlMs: stagingTtlMs,
+    });
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: {
+        status: { in: ["created", "receiving"] },
+        expiresAt: { gt: fixedNow },
+      },
+      select: { tmpPath: true },
+    });
+    await expectPathToExist(filePaths.created);
+    await expectPathToExist(filePaths.receiving);
+    await expectPathToExist(filePaths.persistedCustom);
+    await expectPathToExist(filePaths.freshOrdinary);
+    await expectPathToBeMissing(filePaths.expired);
+    await expectPathToBeMissing(filePaths.boundary);
+    await expectPathToBeMissing(filePaths.completed);
+    await expectPathToBeMissing(filePaths.cancelled);
+    await expectPathToBeMissing(filePaths.failed);
+    await expectPathToBeMissing(filePaths.prefixOnlyOrphan);
+    expect(
+      sessions.some(
+        (session) =>
+          session.id === "created" &&
+          ["created", "receiving"].includes(session.status) &&
+          session.expiresAt > fixedNow,
+      ),
+    ).toBe(true);
+
+    await rm(filesRoot, { recursive: true, force: true });
+  });
+
+  it("fails before deletion when active-session lookup fails", async () => {
+    const filesRoot = createTempRoot();
+    const tmpRoot = path.join(filesRoot, "tmp");
+    const staleUpload = path.join(tmpRoot, "stale.upload");
+    await mkdir(tmpRoot, { recursive: true });
+    await writeFile(staleUpload, "keep on db failure", "utf8");
+    const staleTime = new Date(fixedNow.getTime() - stagingTtlMs - 1);
+    await utimes(staleUpload, staleTime, staleTime);
+    getPrismaMock.mockReturnValue({
+      uploadSession: {
+        findMany: vi.fn().mockRejectedValue(new Error("session lookup failed")),
+      },
+    });
+
+    const { handleStagingCleanup } = await import("./staging-cleanup.js");
+    await expect(
+      handleStagingCleanup(createJob(), {
+        filesRoot,
+        tmpRoot,
+        heartbeatPath: path.join(tmpRoot, "worker-heartbeat.json"),
+        pendingDeleteRoot: path.join(tmpRoot, "pending-delete"),
+        uploadStagingTtlMs: stagingTtlMs,
+      }),
+    ).rejects.toThrow("session lookup failed");
+    await expectPathToExist(staleUpload);
+
+    await rm(filesRoot, { recursive: true, force: true });
+  });
+});

--- a/apps/worker/src/handlers/staging-cleanup.ts
+++ b/apps/worker/src/handlers/staging-cleanup.ts
@@ -1,13 +1,54 @@
 import type { BackgroundJobRecord } from "@staaash/db/jobs";
+import { getPrisma } from "@staaash/db/client";
 import { cleanupExpiredStagingFiles } from "../storage-maintenance.js";
 import type { WorkerStoragePaths } from "../storage-maintenance.js";
+
+const ACTIVE_RESUMABLE_SESSION_STATUSES = ["created", "receiving"];
+
+type ResumableSessionPathClient = {
+  uploadSession: {
+    findMany(args: {
+      where: {
+        status: { in: string[] };
+        expiresAt: { gt: Date };
+      };
+      select: { tmpPath: true };
+    }): Promise<Array<{ tmpPath: string }>>;
+  };
+};
+
+const findProtectedResumableUploadPaths = async ({
+  client,
+  now,
+}: {
+  client: ResumableSessionPathClient;
+  now: Date;
+}) => {
+  const sessions = await client.uploadSession.findMany({
+    where: {
+      status: { in: ACTIVE_RESUMABLE_SESSION_STATUSES },
+      expiresAt: { gt: now },
+    },
+    select: { tmpPath: true },
+  });
+
+  return sessions.map((session) => session.tmpPath);
+};
 
 export const handleStagingCleanup = async (
   job: BackgroundJobRecord,
   storagePaths: WorkerStoragePaths,
 ): Promise<void> => {
+  const now = new Date();
+  const protectedPaths = await findProtectedResumableUploadPaths({
+    client: getPrisma() as unknown as ResumableSessionPathClient,
+    now,
+  });
+
   await cleanupExpiredStagingFiles({
     tmpRoot: storagePaths.tmpRoot,
     ttlMs: storagePaths.uploadStagingTtlMs,
+    protectedPaths,
+    now,
   });
 };

--- a/apps/worker/src/storage-maintenance.test.ts
+++ b/apps/worker/src/storage-maintenance.test.ts
@@ -14,7 +14,6 @@ import { describe, expect, it } from "vitest";
 import {
   cleanupExpiredStagingFiles,
   recoverPendingDeletes,
-  shouldCleanupStagedUpload,
 } from "./storage-maintenance.js";
 
 const createTempRoot = () =>
@@ -51,29 +50,90 @@ describe("worker storage maintenance", () => {
       new Date(now.getTime() - ttlMs + 1),
     );
 
-    expect(
-      shouldCleanupStagedUpload(
-        new Date(now.getTime() - ttlMs - 1),
-        ttlMs,
-        now,
-      ),
-    ).toBe(true);
-    expect(
-      shouldCleanupStagedUpload(
-        new Date(now.getTime() - ttlMs + 1),
-        ttlMs,
-        now,
-      ),
-    ).toBe(false);
-
     await cleanupExpiredStagingFiles({
       tmpRoot,
       ttlMs,
+      protectedPaths: [],
       now,
     });
 
     await expect(access(staleUpload)).rejects.toBeDefined();
     await expect(access(activeUpload)).resolves.toBeUndefined();
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("protects canonical persisted paths while deleting prefix-only orphans", async () => {
+    const tmpRoot = createTempRoot();
+    await mkdir(tmpRoot, { recursive: true });
+    const protectedUpload = path.join(tmpRoot, "custom-session-name.upload");
+    const prefixOnlyOrphan = path.join(tmpRoot, "rs-no-session.upload");
+    await writeFile(protectedUpload, "protected", "utf8");
+    await writeFile(prefixOnlyOrphan, "orphan", "utf8");
+
+    const now = new Date("2026-04-01T12:00:00.000Z");
+    const ttlMs = 60_000;
+    const staleTime = new Date(now.getTime() - ttlMs - 1);
+    await utimes(protectedUpload, staleTime, staleTime);
+    await utimes(prefixOnlyOrphan, staleTime, staleTime);
+
+    await cleanupExpiredStagingFiles({
+      tmpRoot,
+      ttlMs,
+      protectedPaths: [
+        path.join(tmpRoot, "nested", "..", "custom-session-name.upload"),
+      ],
+      now,
+    });
+
+    await expect(access(protectedUpload)).resolves.toBeUndefined();
+    await expect(access(prefixOnlyOrphan)).rejects.toBeDefined();
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("leaves non-staging and nested maintenance data untouched", async () => {
+    const tmpRoot = createTempRoot();
+    const heartbeatPath = path.join(tmpRoot, "worker-heartbeat.json");
+    const lockPath = path.join(tmpRoot, "locks", "upload.lock");
+    const pendingDeletePath = path.join(
+      tmpRoot,
+      "pending-delete",
+      "stale.upload",
+    );
+    const derivativePath = path.join(tmpRoot, "derivatives", "stale.upload");
+    const ordinaryFile = path.join(tmpRoot, "ordinary.tmp");
+    const uploadDirectory = path.join(tmpRoot, "directory.upload");
+    const filesToKeep = [
+      heartbeatPath,
+      lockPath,
+      pendingDeletePath,
+      derivativePath,
+      ordinaryFile,
+    ];
+    await mkdir(path.dirname(lockPath), { recursive: true });
+    await mkdir(path.dirname(pendingDeletePath), { recursive: true });
+    await mkdir(path.dirname(derivativePath), { recursive: true });
+    await mkdir(uploadDirectory);
+    await Promise.all(
+      filesToKeep.map((filePath) => writeFile(filePath, "keep", "utf8")),
+    );
+
+    const now = new Date("2026-04-01T12:00:00.000Z");
+    const ttlMs = 60_000;
+    const staleTime = new Date(now.getTime() - ttlMs - 1);
+    await Promise.all(
+      filesToKeep.map((filePath) => utimes(filePath, staleTime, staleTime)),
+    );
+
+    await cleanupExpiredStagingFiles({
+      tmpRoot,
+      ttlMs,
+      protectedPaths: [],
+      now,
+    });
+
+    for (const filePath of [...filesToKeep, uploadDirectory]) {
+      await expect(access(filePath)).resolves.toBeUndefined();
+    }
     await rm(tmpRoot, { recursive: true, force: true });
   });
 

--- a/apps/worker/src/storage-maintenance.ts
+++ b/apps/worker/src/storage-maintenance.ts
@@ -1,11 +1,11 @@
 import path from "node:path";
 import {
+  lstat,
   mkdir,
   opendir,
   readFile,
   rename,
   rm,
-  stat,
   writeFile,
 } from "node:fs/promises";
 import { z } from "zod";
@@ -93,31 +93,84 @@ export const writeHeartbeat = async (
   );
 };
 
-export const shouldCleanupStagedUpload = (
+const shouldCleanupStagedUpload = (
   createdAt: Date,
   ttlMs: number,
   now = new Date(),
 ) => now.getTime() - createdAt.getTime() >= ttlMs;
 
+const canonicalStoragePath = (candidatePath: string) => {
+  const resolvedPath = path.resolve(candidatePath);
+  return process.platform === "win32"
+    ? resolvedPath.toLowerCase()
+    : resolvedPath;
+};
+
+const isPathInsideRoot = (rootPath: string, candidatePath: string) => {
+  const relativePath = path.relative(rootPath, candidatePath);
+  return (
+    relativePath !== "" &&
+    !relativePath.startsWith("..") &&
+    !path.isAbsolute(relativePath)
+  );
+};
+
+const getStagingCleanupCandidate = ({
+  tmpRoot,
+  entryName,
+  protectedPaths,
+}: {
+  tmpRoot: string;
+  entryName: string;
+  protectedPaths: Set<string>;
+}) => {
+  const absolutePath = path.resolve(tmpRoot, entryName);
+  if (!isPathInsideRoot(tmpRoot, absolutePath)) {
+    return null;
+  }
+  if (protectedPaths.has(canonicalStoragePath(absolutePath))) {
+    return null;
+  }
+  return absolutePath;
+};
+
 export const cleanupExpiredStagingFiles = async ({
   tmpRoot,
   ttlMs,
+  protectedPaths,
   now = new Date(),
 }: {
   tmpRoot: string;
   ttlMs: number;
+  protectedPaths: Iterable<string>;
   now?: Date;
 }) => {
-  await mkdir(tmpRoot, { recursive: true });
-  const directory = await opendir(tmpRoot);
+  const resolvedTmpRoot = path.resolve(tmpRoot);
+  const canonicalProtectedPaths = new Set(
+    Array.from(protectedPaths, canonicalStoragePath),
+  );
+
+  await mkdir(resolvedTmpRoot, { recursive: true });
+  const directory = await opendir(resolvedTmpRoot);
 
   for await (const entry of directory) {
     if (!entry.isFile() || !entry.name.endsWith(".upload")) {
       continue;
     }
 
-    const absolutePath = path.join(tmpRoot, entry.name);
-    const stats = await stat(absolutePath);
+    const absolutePath = getStagingCleanupCandidate({
+      tmpRoot: resolvedTmpRoot,
+      entryName: entry.name,
+      protectedPaths: canonicalProtectedPaths,
+    });
+    if (!absolutePath) {
+      continue;
+    }
+
+    const stats = await lstat(absolutePath);
+    if (!stats.isFile()) {
+      continue;
+    }
 
     if (!shouldCleanupStagedUpload(stats.mtime, ttlMs, now)) {
       continue;


### PR DESCRIPTION
## 🚀 Summary

Fix audit finding `UPL-02`: worker staging cleanup can no longer delete bytes for a resumable upload session that remains active and unexpired.

Root cause: cleanup used only filesystem mtime and staging retention, while resumable sessions remain valid under separate persisted session expiry.

## 📊 Impacts and Changes

- Query `UploadSession` for `created` or `receiving` sessions with `expiresAt > now` before cleanup.
- Protect scanned files by canonical comparison with persisted `tmpPath`.
- Preserve mtime-based cleanup for stale orphan, expired, or inactive staging files.
- Abort before deletion when protected session paths cannot be read from the database, allowing the existing worker retry policy to handle failure.
- Keep scanning limited to direct regular `tmp/*.upload` entries; nested maintenance data, directories, and symlinks remain untouched.
- No schema, auth, restore, session TTL, staging-retention, dependency, or generated-file changes.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

Additional validation:

- `pnpm --filter worker exec vitest run src/storage-maintenance.test.ts`
- `pnpm --filter worker exec vitest run src/handlers/staging-cleanup.test.ts`
- `pnpm --filter worker typecheck`
- `pnpm --filter worker test`
- `pnpm format:check`
- `pnpm quality:fallow`
- `git diff --check`

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

None.

## 🔗 Linked Issues

None.