### PR TITLE
fix(release): enforce artifact integrity

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -1,6 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
-  "entry": ["apps/web/vitest.postgres.config.ts"],
+  "entry": [
+    "apps/web/vitest.postgres.config.ts",
+    "packages/config/src/release.ts",
+    "scripts/release/index.mjs",
+  ],
   "dynamicallyLoaded": [
     "apps/web/vitest.postgres.global.ts",
     "apps/web/vitest.postgres.setup.ts",

--- a/.github/README.md
+++ b/.github/README.md
@@ -55,8 +55,8 @@ Requirements: [Docker](https://docs.docker.com/get-docker/) with the Compose plu
 
 ### Windows and Linux
 
-1. Go to the [releases page](https://github.com/itsmeares/staaash/releases) and download `docker-compose.yml` and `example.env` into the same folder. Use the latest release, or pick a specific version if you need one. Files on `main` may include unreleased changes.
-2. Rename `example.env` to `.env`, open it, set `DB_PASSWORD` to a secure value (you can use something like pwgen), and change any other values you want.
+1. Go to the [releases page](https://github.com/itsmeares/staaash/releases) and download `docker-compose.yml`, `example.env`, `release-manifest.json`, and `SHA256SUMS` into the same folder. Use the latest release, or pick a specific version if you need one. Release files pin Staaash to that release's verified image digest; files on `main` may include unreleased changes.
+2. Verify the downloaded files against `SHA256SUMS`. Rename `example.env` to `.env`, open it, set `DB_PASSWORD` to a secure value (you can use something like pwgen), and change any other values you want. Keep the release-provided `STAAASH_VERSION` value unless you intentionally select another image.
 3. Run:
 
    ```console
@@ -79,12 +79,14 @@ Use one public address consistently. Loading the app from `https://staaash.examp
 
 ### Upgrading
 
+Download and verify the target release's new `docker-compose.yml`, `example.env`, `release-manifest.json`, and `SHA256SUMS`. Replace your Compose file, then copy the target release's `STAAASH_VERSION` value from `example.env` into your existing `.env` without overwriting your password or other settings.
+
 ```console
 docker compose pull
 docker compose up -d
 ```
 
-Migrations run automatically on startup. These commands support upgrades between compatible releases in the Postgres 18 RC/current release line.
+Migrations run automatically on startup. These commands support upgrades between compatible releases in the Postgres 18 RC/current release line. The digest-pinned `STAAASH_VERSION` ensures the image pulled matches the selected GitHub Release.
 
 > [!WARNING]
 > Alpha and beta releases cannot be upgraded to the RC or v1 release line. Use a fresh installation of the current release. Do not reuse an alpha/beta deployment's internal database or storage directories as the data directories for the current installation.

--- a/.github/README.md
+++ b/.github/README.md
@@ -55,9 +55,10 @@ Requirements: [Docker](https://docs.docker.com/get-docker/) with the Compose plu
 
 ### Windows and Linux
 
-1. Go to the [releases page](https://github.com/itsmeares/staaash/releases) and download `docker-compose.yml`, `example.env`, `release-manifest.json`, and `SHA256SUMS` into the same folder. Use the latest release, or pick a specific version if you need one. Release files pin Staaash to that release's verified image digest; files on `main` may include unreleased changes.
-2. Verify the downloaded files against `SHA256SUMS`. Rename `example.env` to `.env`, open it, set `DB_PASSWORD` to a secure value (you can use something like pwgen), and change any other values you want. Keep the release-provided `STAAASH_VERSION` value unless you intentionally select another image.
-3. Run:
+1. Go to the [releases page](https://github.com/itsmeares/staaash/releases) and download `docker-compose.yml` and `example.env` from the release you want into the same folder. Release files select that exact version tag; files on `main` may include unreleased changes.
+2. Rename `example.env` to `.env`.
+3. Open `.env`, set `DB_PASSWORD` to a secure value (you can use something like pwgen), and change any other settings you want.
+4. Run:
 
    ```console
    docker compose up -d
@@ -66,6 +67,12 @@ Requirements: [Docker](https://docs.docker.com/get-docker/) with the Compose plu
 Staaash is now running at `http://localhost:2113`.
 
 The first account you register becomes the owner. Subsequent accounts require an invite from the owner.
+
+### Optional release verification
+
+Advanced users can also download `release-manifest.json` and `SHA256SUMS` from the same release to verify the files. The manifest records the workflow-verified immutable image reference. To pin that digest, set `STAAASH_VERSION` to its `v1.2.3@sha256:...` value instead of the normal `v1.2.3` tag.
+
+If you use CasaOS or another container UI, select the same readable release normally, for example `ghcr.io/itsmeares/staaash:v1.2.3`.
 
 ### Reverse proxies
 
@@ -79,14 +86,21 @@ Use one public address consistently. Loading the app from `https://staaash.examp
 
 ### Upgrading
 
-Download and verify the target release's new `docker-compose.yml`, `example.env`, `release-manifest.json`, and `SHA256SUMS`. Replace your Compose file, then copy the target release's `STAAASH_VERSION` value from `example.env` into your existing `.env` without overwriting your password or other settings.
+Change the exact release tag in your existing `.env`:
+
+```diff
+- STAAASH_VERSION=v1.2.3
++ STAAASH_VERSION=v1.2.4
+```
+
+Then run:
 
 ```console
 docker compose pull
 docker compose up -d
 ```
 
-Migrations run automatically on startup. These commands support upgrades between compatible releases in the Postgres 18 RC/current release line. The digest-pinned `STAAASH_VERSION` ensures the image pulled matches the selected GitHub Release.
+Replace or update `docker-compose.yml` only when the target release notes say its Compose definition changed. Migrations run automatically on startup. These commands support upgrades between compatible releases in the Postgres 18 RC/current release line.
 
 > [!WARNING]
 > Alpha and beta releases cannot be upgraded to the RC or v1 release line. Use a fresh installation of the current release. Do not reuse an alpha/beta deployment's internal database or storage directories as the data directories for the current installation.

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -33,7 +33,7 @@ Alpha and beta releases remain unsupported development history. Their prerelease
 8. Publish the GitHub Release after every exact artifact check passes.
 9. For stable releases only, copy the verified OCI index digest to `latest` without rebuilding, verify it, then mark the same GitHub Release as latest.
 
-Every SemVer prerelease skips both latest-channel mutations. A stable release is complete and installable through its digest-pinned assets before `latest` promotion starts.
+Every SemVer prerelease skips both latest-channel mutations. A stable release is complete and installable through exact-tag assets before `latest` promotion starts; its verified digest remains recorded in manifest and provenance metadata.
 
 ## Recovery
 
@@ -64,19 +64,19 @@ Do not use asset clobbering, force-push tags, delete releases, or overwrite imag
 - Image build/push failure: draft remains hidden; retry inspects whether the exact tag is absent, matching, or conflicting.
 - Asset failure: exact image may be pullable, but release remains a draft and `latest` cannot change.
 - Publication failure: complete draft remains retryable; `latest` cannot change.
-- Stable `latest` failure: exact GitHub Release remains complete and digest-pinned. Retry performs verification and pending promotion without rebuilding.
+- Stable `latest` failure: exact GitHub Release remains complete, tag-selected, and digest-verified. Retry performs verification and pending promotion without rebuilding.
 
 Each failed workflow writes retry and investigation guidance to its job summary.
 
 ## Release assets
 
-Release-generated Compose and env files both select:
+Release-generated Compose and env files select the exact readable tag:
 
 ```text
-ghcr.io/itsmeares/staaash:<tag>@sha256:<OCI-index-digest>
+ghcr.io/itsmeares/staaash:<tag>
 ```
 
-`release-manifest.json` records tag object, commit SHA, image repository, index digest, immutable reference, platform, and OCI labels. `SHA256SUMS` covers Compose, env, and manifest files. Source files on `main` remain templates and are never uploaded directly as release assets.
+`release-manifest.json` records tag object, commit SHA, image repository, verified OCI index digest, full immutable reference, platform, and OCI labels. `SHA256SUMS` covers Compose, env, and manifest files. The workflow validates both the normal tag selection and an optional `STAAASH_VERSION=<tag>@sha256:<digest>` override. Source files on `main` remain templates and are never uploaded directly as release assets.
 
 ## Controlled rehearsal
 

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -1,0 +1,85 @@
+# Releasing Staaash
+
+The release workflow treats a Git tag, exact commit, package versions, validated CI run, GHCR image, OCI index digest, GitHub Release, and installation assets as one release identity.
+
+## Prerequisites
+
+Before creating a release tag:
+
+1. Merge the release commit to `main`.
+2. Set the same normalized version in:
+   - `package.json`
+   - `apps/web/package.json`
+   - `apps/worker/package.json`
+   - `packages/config/package.json`
+   - `packages/db/package.json`
+3. Wait for the `CI` workflow on that exact `main` SHA to pass. A tag created while CI is running waits for the exact run; no release state is written first.
+4. Use a canonical tag: `v<major>.<minor>.<patch>` with an optional SemVer prerelease suffix. Build metadata is not supported because it cannot be represented unchanged as an OCI tag.
+5. Ensure the repository ruleset for `refs/tags/v*` blocks tag updates and deletion.
+
+Alpha and beta releases remain unsupported development history. Their prerelease classification does not restore an upgrade path. Users must start a fresh current installation and must not reuse alpha/beta internal database or storage directories.
+
+## Automated sequence
+
+`.github/workflows/release.yml` globally queues releases and performs:
+
+1. Resolve the tag object and peeled commit; require the commit on current `main`.
+2. Verify all package versions and a successful exact-SHA `CI` main-push run.
+3. Create or verify a hidden draft GitHub Release with generated notes and managed provenance.
+4. Build the exact versioned image once, or reuse a matching existing image.
+5. Capture and remotely verify the top-level OCI index digest, OCI labels, and final web/worker runtime versions.
+6. Generate release-specific `docker-compose.yml`, `example.env`, `release-manifest.json`, and `SHA256SUMS`.
+7. Reconcile missing draft assets without overwriting mismatched assets.
+8. Publish the GitHub Release after every exact artifact check passes.
+9. For stable releases only, copy the verified OCI index digest to `latest` without rebuilding, verify it, then mark the same GitHub Release as latest.
+
+Every SemVer prerelease skips both latest-channel mutations. A stable release is complete and installable through its digest-pinned assets before `latest` promotion starts.
+
+## Recovery
+
+Use **Actions → Release → Run workflow** with the same existing tag. Never move or recreate the tag to retry.
+
+Matching partial state is resumed:
+
+- Matching draft: continue.
+- Matching exact image: reuse its digest; do not rebuild.
+- Missing draft assets: upload only missing assets.
+- Matching published release: verify and continue only a pending stable `latest` promotion.
+- Matching `latest`: no-op.
+
+Conflicting state fails closed:
+
+- Tag object or commit changed.
+- Exact image digest, labels, or runtime versions differ.
+- Managed release provenance differs or is malformed.
+- Required asset has a different digest.
+- Published release is incomplete or mismatched.
+- `latest` has the same version but another digest/revision.
+
+Do not use asset clobbering, force-push tags, delete releases, or overwrite image tags as routine recovery. Preserve conflicting state for investigation. Any destructive cleanup needs an explicit maintainer decision after expected and actual SHA/digest values are compared.
+
+## Failure boundaries
+
+- Validation or draft creation failure: no image or `latest` change.
+- Image build/push failure: draft remains hidden; retry inspects whether the exact tag is absent, matching, or conflicting.
+- Asset failure: exact image may be pullable, but release remains a draft and `latest` cannot change.
+- Publication failure: complete draft remains retryable; `latest` cannot change.
+- Stable `latest` failure: exact GitHub Release remains complete and digest-pinned. Retry performs verification and pending promotion without rebuilding.
+
+Each failed workflow writes retry and investigation guidance to its job summary.
+
+## Release assets
+
+Release-generated Compose and env files both select:
+
+```text
+ghcr.io/itsmeares/staaash:<tag>@sha256:<OCI-index-digest>
+```
+
+`release-manifest.json` records tag object, commit SHA, image repository, index digest, immutable reference, platform, and OCI labels. `SHA256SUMS` covers Compose, env, and manifest files. Source files on `main` remain templates and are never uploaded directly as release assets.
+
+## Controlled rehearsal
+
+Before first production release using this workflow, run the full publication and recovery matrix in a disposable repository and separate GHCR package. Cover stable, RC, beta, CI failure, draft failure, image failure, partial assets, publication failure, promotion failure, matching/conflicting image, matching/conflicting release, tag movement, idempotent rerun, and prerelease-after-stable behavior.
+
+Do not create rehearsal tags, images, or releases in `itsmeares/staaash`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,42 +4,112 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to verify or resume
+        required: true
+        type: string
+
+concurrency:
+  group: staaash-release
+  queue: max
+
 jobs:
-  build-and-push:
+  preflight:
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     permissions:
-      contents: write
-      packages: write
+      actions: read
+      contents: read
+    outputs:
+      tag: ${{ steps.preflight.outputs.tag }}
+      version: ${{ steps.preflight.outputs.version }}
+      prerelease: ${{ steps.preflight.outputs.prerelease }}
+      release_sha: ${{ steps.preflight.outputs.release_sha }}
+      tag_object: ${{ steps.preflight.outputs.tag_object }}
+      tag_type: ${{ steps.preflight.outputs.tag_type }}
+      image_repository: ${{ steps.preflight.outputs.image_repository }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+      EXPECTED_RELEASE_SHA: ${{ github.event_name == 'push' && github.sha || '' }}
+      EXPECTED_TAG_OBJECT: ${{ github.event_name == 'push' && github.event.after || '' }}
+      CI_WAIT_SECONDS: "1800"
+      CI_POLL_SECONDS: "15"
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ env.RELEASE_TAG }}
 
-      - name: Verify release versions
-        shell: bash
-        run: |
-          node <<'NODE'
-          const fs = require("node:fs");
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24.18.0
 
-          const tagVersion = process.env.GITHUB_REF_NAME.replace(/^v/, "");
-          const packageFiles = [
-            "package.json",
-            "apps/web/package.json",
-            "apps/worker/package.json",
-            "packages/config/package.json",
-            "packages/db/package.json",
-          ];
-          const mismatches = packageFiles.flatMap((file) => {
-            const version = JSON.parse(fs.readFileSync(file, "utf8")).version;
-            return version === tagVersion
-              ? []
-              : [`${file} has ${version}; expected ${tagVersion}`];
-          });
+      - name: Enable Corepack
+        run: corepack enable
 
-          if (mismatches.length > 0) {
-            console.error(mismatches.join("\n"));
-            process.exit(1);
-          }
-          NODE
+      - name: Install pinned pnpm
+        run: corepack install
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build release policy
+        run: pnpm --filter @staaash/config build
+
+      - name: Verify tag, packages, and exact CI
+        id: preflight
+        run: node scripts/release/index.mjs preflight
+
+  publish:
+    needs: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      actions: read
+      contents: write
+      packages: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_TAG: ${{ needs.preflight.outputs.tag }}
+      RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
+      RELEASE_PRERELEASE: ${{ needs.preflight.outputs.prerelease }}
+      RELEASE_SHA: ${{ needs.preflight.outputs.release_sha }}
+      TAG_OBJECT_SHA: ${{ needs.preflight.outputs.tag_object }}
+      TAG_TYPE: ${{ needs.preflight.outputs.tag_type }}
+      IMAGE_REPOSITORY: ${{ needs.preflight.outputs.image_repository }}
+      ASSET_DIR: .release-assets
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ env.RELEASE_TAG }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24.18.0
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install pinned pnpm
+        run: corepack install
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build release policy
+        run: pnpm --filter @staaash/config build
+
+      - name: Recheck immutable tag identity
+        run: node scripts/release/index.mjs verify-tag
+
+      - name: Create or verify draft release
+        run: node scripts/release/index.mjs ensure-draft
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -51,42 +121,77 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ghcr.io/itsmeares/staaash
-          flavor: |
-            latest=false
-          tags: |
-            type=ref,event=tag
-            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+      - name: Inspect existing versioned image
+        id: image
+        run: node scripts/release/index.mjs inspect-image
 
-      - name: Build and push
+      - name: Build and push exact versioned image
+        id: build
+        if: steps.image.outputs.exists != 'true'
         uses: docker/build-push-action@v7
         with:
           context: .
           push: true
           platforms: linux/amd64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ env.IMAGE_REPOSITORY }}:${{ env.RELEASE_TAG }}
+          labels: |
+            org.opencontainers.image.title=staaash
+            org.opencontainers.image.description=Self-hosted personal cloud drive built with Next.js, Prisma, PostgreSQL, and a worker runtime.
+            org.opencontainers.image.licenses=AGPL-3.0-only
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ env.RELEASE_TAG }}
+            org.opencontainers.image.revision=${{ env.RELEASE_SHA }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Create GitHub Release
+      - name: Select immutable image digest
+        id: digest
+        shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXISTING_DIGEST: ${{ steps.image.outputs.digest }}
+          BUILT_DIGEST: ${{ steps.build.outputs.digest }}
         run: |
-          TAG="${{ github.ref_name }}"
-          PRERELEASE_FLAG=""
-          if [[ "$TAG" == *"-alpha"* ]] || [[ "$TAG" == *"-beta"* ]] || [[ "$TAG" == *"-rc"* ]]; then
-            PRERELEASE_FLAG="--prerelease"
+          DIGEST="${EXISTING_DIGEST:-$BUILT_DIGEST}"
+          if [[ ! "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Missing or invalid OCI index digest: $DIGEST" >&2
+            exit 1
           fi
-          gh release view "$TAG" >/dev/null 2>&1 && echo "Release already exists, skipping." || \
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --generate-notes \
-            --draft \
-            $PRERELEASE_FLAG \
-            docker-compose.yml \
-            example.env
+          echo "value=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Verify exact image digest and runtime versions
+        env:
+          IMAGE_DIGEST: ${{ steps.digest.outputs.value }}
+        run: node scripts/release/index.mjs verify-image
+
+      - name: Generate release-specific installation assets
+        env:
+          IMAGE_DIGEST: ${{ steps.digest.outputs.value }}
+        run: node scripts/release/index.mjs generate-assets
+
+      - name: Reconcile draft notes and assets
+        env:
+          IMAGE_DIGEST: ${{ steps.digest.outputs.value }}
+        run: node scripts/release/index.mjs reconcile-release
+
+      - name: Publish verified GitHub Release
+        env:
+          IMAGE_DIGEST: ${{ steps.digest.outputs.value }}
+        run: node scripts/release/index.mjs publish
+
+      - name: Promote stable digest to latest
+        env:
+          IMAGE_DIGEST: ${{ steps.digest.outputs.value }}
+        run: node scripts/release/index.mjs promote-latest
+
+      - name: Clean runner release assets
+        if: always()
+        shell: bash
+        run: rm -rf .release-assets
+
+      - name: Write retry and investigation summary
+        if: always()
+        continue-on-error: true
+        env:
+          RELEASE_RESULT: ${{ job.status }}
+        run: node scripts/release/index.mjs summary

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "dev": "next dev",
     "e2e:prepare": "node scripts/e2e-bootstrap.mjs",
     "build": "next build",
+    "postbuild": "node scripts/check-built-runtime.mjs",
     "start": "next start",
     "lint": "tsc --noEmit --incremental false -p tsconfig.json",
     "typecheck": "tsc --noEmit --incremental false -p tsconfig.json",

--- a/apps/web/scripts/check-built-runtime.mjs
+++ b/apps/web/scripts/check-built-runtime.mjs
@@ -1,0 +1,17 @@
+import { readFile } from "node:fs/promises";
+
+import packageMetadata from "../package.json" with { type: "json" };
+
+const builtPackageUrl = new URL(
+  "../.next/standalone/apps/web/package.json",
+  import.meta.url,
+);
+const builtPackage = JSON.parse(await readFile(builtPackageUrl, "utf8"));
+
+if (builtPackage.version !== packageMetadata.version) {
+  throw new Error(
+    `Built web package has ${builtPackage.version}; expected ${packageMetadata.version}.`,
+  );
+}
+
+console.info(`[web] Runtime version smoke passed (${builtPackage.version}).`);

--- a/apps/web/scripts/check-built-runtime.mjs
+++ b/apps/web/scripts/check-built-runtime.mjs
@@ -2,10 +2,15 @@ import { readFile } from "node:fs/promises";
 
 import packageMetadata from "../package.json" with { type: "json" };
 
-const builtPackageUrl = new URL(
-  "../.next/standalone/apps/web/package.json",
-  import.meta.url,
-);
+const builtPackagePath = [
+  "..",
+  ".next",
+  "standalone",
+  "apps",
+  "web",
+  "package.json",
+].join("/");
+const builtPackageUrl = new URL(builtPackagePath, import.meta.url);
 const builtPackage = JSON.parse(await readFile(builtPackageUrl, "utf8"));
 
 if (builtPackage.version !== packageMetadata.version) {

--- a/packages/config/src/release.ts
+++ b/packages/config/src/release.ts
@@ -1,0 +1,696 @@
+import { createHash } from "node:crypto";
+
+import {
+  compareSemanticVersions,
+  isPrereleaseVersion,
+  parseSemanticVersion,
+} from "./version.js";
+
+export const RELEASE_PROVENANCE_START =
+  "<!-- staaash:release-provenance:start -->";
+export const RELEASE_PROVENANCE_END = "<!-- staaash:release-provenance:end -->";
+
+const SHA256_PATTERN = /^sha256:[0-9a-f]{64}$/u;
+const RELEASE_IMAGE_FALLBACK_PATTERN =
+  /ghcr\.io\/itsmeares\/staaash:\$\{STAAASH_VERSION:-latest\}/gu;
+const RELEASE_ENV_VERSION_PATTERN = /^STAAASH_VERSION=latest$/gmu;
+
+export type ReleaseTag = {
+  tag: string;
+  version: string;
+  prerelease: boolean;
+};
+
+export type ReleaseManifest = {
+  schemaVersion: 1;
+  tag: string;
+  version: string;
+  prerelease: boolean;
+  source: {
+    repository: string;
+    commit: string;
+    tagObject: string;
+    tagType: "annotated" | "lightweight";
+  };
+  image: {
+    repository: string;
+    tag: string;
+    indexDigest: string;
+    immutableReference: string;
+    platforms: ["linux/amd64"];
+    labels: {
+      version: string;
+      revision: string;
+      source: string;
+    };
+  };
+};
+
+export type ReleaseProvenance = {
+  schemaVersion: 1;
+  tag: string;
+  commit: string;
+  tagObject: string;
+  imageDigest: string | "pending";
+  immutableImage: string | "pending";
+  assetChecksums: Record<string, string> | null;
+};
+
+export type WorkflowRun = {
+  id: number;
+  run_attempt?: number;
+  event: string;
+  head_branch: string | null;
+  head_sha: string;
+  status: string | null;
+  conclusion: string | null;
+};
+
+export type ExactCiState =
+  | { status: "success"; run: WorkflowRun }
+  | { status: "pending"; run: WorkflowRun }
+  | { status: "failure"; run: WorkflowRun }
+  | { status: "missing" };
+
+export type ObservedImage = {
+  digest: string;
+  version: string | null;
+  revision: string | null;
+  source: string | null;
+  webVersion: string | null;
+  workerVersion: string | null;
+};
+
+export type ExpectedImage = {
+  digest?: string;
+  version: string;
+  revision: string;
+  source: string;
+};
+
+export type ImageState =
+  | { status: "missing" }
+  | { status: "matching"; image: ObservedImage }
+  | { status: "conflict"; reasons: string[] };
+
+export type ImageIndexDescriptor = {
+  mediaType?: string;
+  digest?: string;
+  platform?: {
+    os?: string;
+    architecture?: string;
+  };
+  annotations?: Record<string, string>;
+};
+
+export type ImageIndex = {
+  mediaType?: string;
+  manifests?: ImageIndexDescriptor[];
+};
+
+export type ReleaseAsset = {
+  name: string;
+  digest: string | null;
+};
+
+export type AssetPlan = {
+  upload: string[];
+  matching: string[];
+  conflicts: string[];
+};
+
+export type LatestImage = {
+  digest: string;
+  version: string | null;
+  revision: string | null;
+};
+
+export type LatestPlan =
+  | { action: "skip-prerelease" }
+  | { action: "promote"; reason: "missing" | "older" }
+  | { action: "noop"; reason: "matching" }
+  | { action: "superseded"; reason: "newer-version" }
+  | { action: "conflict"; reason: string };
+
+export const hashReleaseContent = (content: string | Uint8Array) =>
+  `sha256:${createHash("sha256").update(content).digest("hex")}`;
+
+const countMatches = (value: string, pattern: RegExp) =>
+  Array.from(value.matchAll(pattern)).length;
+
+export const isSha256Digest = (value: string): boolean =>
+  SHA256_PATTERN.test(value);
+
+export const parseReleaseTag = (tag: string): ReleaseTag | null => {
+  if (!tag.startsWith("v") || tag.startsWith("V") || tag.includes("+")) {
+    return null;
+  }
+
+  const parsed = parseSemanticVersion(tag);
+  if (!parsed || tag !== `v${parsed.normalized}`) return null;
+
+  return {
+    tag,
+    version: parsed.normalized,
+    prerelease: parsed.prerelease.length > 0,
+  };
+};
+
+export const findCanonicalReleaseVersionErrors = ({
+  tag,
+  packageVersions,
+}: {
+  tag: string;
+  packageVersions: Record<string, string>;
+}): string[] => {
+  const release = parseReleaseTag(tag);
+  if (!release)
+    return [`release tag "${tag}" is not canonical OCI-safe SemVer`];
+
+  return Object.entries(packageVersions)
+    .filter(([, packageVersion]) => packageVersion !== release.version)
+    .map(
+      ([packageName, packageVersion]) =>
+        `${packageName} has ${packageVersion}; expected ${release.version}`,
+    );
+};
+
+export const selectExactCiState = ({
+  runs,
+  releaseSha,
+}: {
+  runs: WorkflowRun[];
+  releaseSha: string;
+}): ExactCiState => {
+  const exactRuns = runs
+    .filter(
+      (run) =>
+        run.event === "push" &&
+        run.head_branch === "main" &&
+        run.head_sha === releaseSha,
+    )
+    .sort((left, right) => {
+      const executionComparison = right.id - left.id;
+      return executionComparison !== 0
+        ? executionComparison
+        : (right.run_attempt ?? 1) - (left.run_attempt ?? 1);
+    });
+
+  const run = exactRuns[0];
+  if (!run) return { status: "missing" };
+  if (run.status !== "completed") return { status: "pending", run };
+  if (run.conclusion === "success") return { status: "success", run };
+  return { status: "failure", run };
+};
+
+const getImageDigestReasons = (
+  observed: ObservedImage,
+  expected: ExpectedImage,
+) => {
+  const reasons: string[] = [];
+  if (!isSha256Digest(observed.digest)) {
+    reasons.push(`image digest is invalid: ${observed.digest}`);
+  }
+  if (expected.digest && observed.digest !== expected.digest) {
+    reasons.push(
+      `image digest is ${observed.digest}; expected ${expected.digest}`,
+    );
+  }
+  return reasons;
+};
+
+const getImageLabelReasons = (
+  observed: ObservedImage,
+  expected: ExpectedImage,
+) => {
+  const reasons: string[] = [];
+  if (observed.version !== expected.version) {
+    reasons.push(
+      `image version is ${observed.version ?? "missing"}; expected ${expected.version}`,
+    );
+  }
+  if (observed.revision !== expected.revision) {
+    reasons.push(
+      `image revision is ${observed.revision ?? "missing"}; expected ${expected.revision}`,
+    );
+  }
+  if (observed.source !== expected.source) {
+    reasons.push(
+      `image source is ${observed.source ?? "missing"}; expected ${expected.source}`,
+    );
+  }
+  return reasons;
+};
+
+const getImageRuntimeReasons = (
+  observed: ObservedImage,
+  expected: ExpectedImage,
+) => {
+  const expectedRuntime = expected.version.replace(/^v/u, "");
+  const reasons: string[] = [];
+  if (observed.webVersion !== expectedRuntime) {
+    reasons.push(
+      `web runtime version is ${observed.webVersion ?? "missing"}; expected ${expectedRuntime}`,
+    );
+  }
+  if (observed.workerVersion !== expectedRuntime) {
+    reasons.push(
+      `worker runtime version is ${observed.workerVersion ?? "missing"}; expected ${expectedRuntime}`,
+    );
+  }
+  return reasons;
+};
+
+export const classifyImageState = ({
+  observed,
+  expected,
+}: {
+  observed: ObservedImage | null;
+  expected: ExpectedImage;
+}): ImageState => {
+  if (!observed) return { status: "missing" };
+
+  const reasons = [
+    ...getImageDigestReasons(observed, expected),
+    ...getImageLabelReasons(observed, expected),
+    ...getImageRuntimeReasons(observed, expected),
+  ];
+  return reasons.length === 0
+    ? { status: "matching", image: observed }
+    : { status: "conflict", reasons };
+};
+
+const OCI_IMAGE_INDEX_MEDIA_TYPE = "application/vnd.oci.image.index.v1+json";
+const ATTESTATION_REFERENCE_TYPE = "attestation-manifest";
+
+const isAttestationDescriptor = (descriptor: ImageIndexDescriptor) =>
+  descriptor.annotations?.["vnd.docker.reference.type"] ===
+    ATTESTATION_REFERENCE_TYPE &&
+  descriptor.platform?.os === "unknown" &&
+  descriptor.platform?.architecture === "unknown";
+
+const isLinuxAmd64Descriptor = (descriptor: ImageIndexDescriptor) =>
+  descriptor.platform?.os === "linux" &&
+  descriptor.platform?.architecture === "amd64";
+
+export const findReleaseImageIndexErrors = (index: ImageIndex): string[] => {
+  const errors: string[] = [];
+  if (index.mediaType !== OCI_IMAGE_INDEX_MEDIA_TYPE) {
+    errors.push(
+      `image media type is ${index.mediaType ?? "missing"}; expected OCI index`,
+    );
+  }
+
+  const descriptors = index.manifests ?? [];
+  const runnable = descriptors.filter(
+    (descriptor) => !isAttestationDescriptor(descriptor),
+  );
+  if (runnable.length !== 1) {
+    errors.push(
+      `image index has ${runnable.length} runnable manifests; expected 1`,
+    );
+  } else if (!isLinuxAmd64Descriptor(runnable[0]!)) {
+    errors.push("image index runnable manifest is not linux/amd64");
+  }
+  return errors;
+};
+
+export const buildImmutableImageReference = ({
+  imageRepository,
+  tag,
+  digest,
+}: {
+  imageRepository: string;
+  tag: string;
+  digest: string;
+}) => {
+  if (!parseReleaseTag(tag)) throw new Error(`Invalid release tag: ${tag}`);
+  if (!isSha256Digest(digest))
+    throw new Error(`Invalid image digest: ${digest}`);
+  return `${imageRepository}:${tag}@${digest}`;
+};
+
+export const renderReleaseCompose = ({
+  source,
+  imageRepository,
+  versionReference,
+}: {
+  source: string;
+  imageRepository: string;
+  versionReference: string;
+}) => {
+  const count = countMatches(source, RELEASE_IMAGE_FALLBACK_PATTERN);
+  if (count !== 2) {
+    throw new Error(
+      `Expected 2 Staaash image fallbacks in Compose source; found ${count}.`,
+    );
+  }
+
+  return source.replaceAll(
+    "ghcr.io/itsmeares/staaash:${STAAASH_VERSION:-latest}",
+    `${imageRepository}:\${STAAASH_VERSION:-${versionReference}}`,
+  );
+};
+
+export const renderReleaseEnv = ({
+  source,
+  versionReference,
+}: {
+  source: string;
+  versionReference: string;
+}) => {
+  const count = countMatches(source, RELEASE_ENV_VERSION_PATTERN);
+  if (count !== 1) {
+    throw new Error(
+      `Expected 1 STAAASH_VERSION=latest entry in env source; found ${count}.`,
+    );
+  }
+
+  return source.replace(
+    RELEASE_ENV_VERSION_PATTERN,
+    `STAAASH_VERSION=${versionReference}`,
+  );
+};
+
+export const buildReleaseManifest = ({
+  release,
+  repository,
+  commit,
+  tagObject,
+  tagType,
+  imageRepository,
+  imageDigest,
+}: {
+  release: ReleaseTag;
+  repository: string;
+  commit: string;
+  tagObject: string;
+  tagType: "annotated" | "lightweight";
+  imageRepository: string;
+  imageDigest: string;
+}): ReleaseManifest => {
+  const immutableReference = buildImmutableImageReference({
+    imageRepository,
+    tag: release.tag,
+    digest: imageDigest,
+  });
+  const source = `https://github.com/${repository}`;
+
+  return {
+    schemaVersion: 1,
+    tag: release.tag,
+    version: release.version,
+    prerelease: release.prerelease,
+    source: {
+      repository,
+      commit,
+      tagObject,
+      tagType,
+    },
+    image: {
+      repository: imageRepository,
+      tag: release.tag,
+      indexDigest: imageDigest,
+      immutableReference,
+      platforms: ["linux/amd64"],
+      labels: {
+        version: release.tag,
+        revision: commit,
+        source,
+      },
+    },
+  };
+};
+
+export const serializeReleaseManifest = (manifest: ReleaseManifest) =>
+  `${JSON.stringify(manifest, null, 2)}\n`;
+
+export const buildAssetChecksums = (assets: Record<string, string>) =>
+  Object.fromEntries(
+    Object.entries(assets)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([name, content]) => [name, hashReleaseContent(content)]),
+  );
+
+export const serializeSha256Sums = (checksums: Record<string, string>) =>
+  `${Object.entries(checksums)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, digest]) => `${digest.replace(/^sha256:/u, "")}  ${name}`)
+    .join("\n")}\n`;
+
+export const buildReleaseProvenance = ({
+  tag,
+  commit,
+  tagObject,
+  imageDigest = "pending",
+  immutableImage = "pending",
+  assetChecksums = null,
+}: Omit<ReleaseProvenance, "schemaVersion">): ReleaseProvenance => ({
+  schemaVersion: 1,
+  tag,
+  commit,
+  tagObject,
+  imageDigest,
+  immutableImage,
+  assetChecksums,
+});
+
+export const serializeReleaseProvenanceBlock = (
+  provenance: ReleaseProvenance,
+) =>
+  `${RELEASE_PROVENANCE_START}\n<!-- ${JSON.stringify(provenance)} -->\n${RELEASE_PROVENANCE_END}`;
+
+type ParsedReleaseProvenance =
+  | { status: "absent" }
+  | { status: "valid"; provenance: ReleaseProvenance; block: string }
+  | { status: "malformed"; reason: string };
+
+const findReleaseProvenanceBlock = (
+  body: string,
+):
+  | { status: "absent" }
+  | { status: "valid"; block: string }
+  | {
+      status: "malformed";
+      reason: string;
+    } => {
+  const startCount = body.split(RELEASE_PROVENANCE_START).length - 1;
+  const endCount = body.split(RELEASE_PROVENANCE_END).length - 1;
+  if (startCount === 0 && endCount === 0) return { status: "absent" };
+  if (startCount !== 1 || endCount !== 1) {
+    return { status: "malformed", reason: "duplicate or unbalanced markers" };
+  }
+
+  const start = body.indexOf(RELEASE_PROVENANCE_START);
+  const end = body.indexOf(RELEASE_PROVENANCE_END, start);
+  if (end < start) {
+    return { status: "malformed", reason: "markers are reversed" };
+  }
+  return {
+    status: "valid",
+    block: body.slice(start, end + RELEASE_PROVENANCE_END.length),
+  };
+};
+
+const hasReleaseProvenanceStrings = (provenance: Partial<ReleaseProvenance>) =>
+  ["tag", "commit", "tagObject", "imageDigest", "immutableImage"].every(
+    (key) => typeof provenance[key as keyof ReleaseProvenance] === "string",
+  );
+
+const hasReleaseAssetChecksums = (
+  value: ReleaseProvenance["assetChecksums"] | undefined,
+) => {
+  if (value === null) return true;
+  if (!value || typeof value !== "object") return false;
+  return Object.values(value).every((digest) => typeof digest === "string");
+};
+
+const isReleaseProvenance = (
+  provenance: Partial<ReleaseProvenance>,
+): provenance is ReleaseProvenance =>
+  provenance.schemaVersion === 1 &&
+  hasReleaseProvenanceStrings(provenance) &&
+  hasReleaseAssetChecksums(provenance.assetChecksums);
+
+const parseReleaseProvenanceBlock = (
+  block: string,
+): ParsedReleaseProvenance => {
+  const payload = block
+    .slice(RELEASE_PROVENANCE_START.length, -RELEASE_PROVENANCE_END.length)
+    .trim();
+  const match = /^<!-- (\{.*\}) -->$/su.exec(payload);
+  if (!match) return { status: "malformed", reason: "payload is not JSON" };
+
+  try {
+    const provenance = JSON.parse(match[1]!) as Partial<ReleaseProvenance>;
+    return isReleaseProvenance(provenance)
+      ? { status: "valid", provenance, block }
+      : { status: "malformed", reason: "payload shape is invalid" };
+  } catch {
+    return { status: "malformed", reason: "payload JSON is invalid" };
+  }
+};
+
+export const parseReleaseProvenance = (
+  body: string,
+): ParsedReleaseProvenance => {
+  const located = findReleaseProvenanceBlock(body);
+  return located.status === "valid"
+    ? parseReleaseProvenanceBlock(located.block)
+    : located;
+};
+
+export const appendReleaseProvenance = ({
+  body,
+  provenance,
+}: {
+  body: string;
+  provenance: ReleaseProvenance;
+}) => {
+  const parsed = parseReleaseProvenance(body);
+  if (parsed.status !== "absent") {
+    throw new Error("Release provenance already exists or is malformed.");
+  }
+
+  const separator = body.trim().length > 0 ? "\n\n" : "";
+  return `${body.trimEnd()}${separator}${serializeReleaseProvenanceBlock(provenance)}\n`;
+};
+
+export const replaceReleaseProvenance = ({
+  body,
+  expected,
+  next,
+}: {
+  body: string;
+  expected: ReleaseProvenance;
+  next: ReleaseProvenance;
+}) => {
+  const parsed = parseReleaseProvenance(body);
+  if (parsed.status !== "valid") {
+    throw new Error("Release provenance is missing or malformed.");
+  }
+  if (JSON.stringify(parsed.provenance) !== JSON.stringify(expected)) {
+    throw new Error("Release provenance does not match expected state.");
+  }
+
+  return body.replace(parsed.block, serializeReleaseProvenanceBlock(next));
+};
+
+export const planReleaseAssets = ({
+  expected,
+  observed,
+  published,
+}: {
+  expected: Record<string, string>;
+  observed: ReleaseAsset[];
+  published: boolean;
+}): AssetPlan => {
+  const observedByName = new Map(observed.map((asset) => [asset.name, asset]));
+  const upload: string[] = [];
+  const matching: string[] = [];
+  const conflicts: string[] = [];
+
+  for (const [name, digest] of Object.entries(expected).sort(
+    ([left], [right]) => left.localeCompare(right),
+  )) {
+    const asset = observedByName.get(name);
+    if (!asset) {
+      if (published)
+        conflicts.push(`${name} is missing from published release`);
+      else upload.push(name);
+      continue;
+    }
+    if (asset.digest !== digest) {
+      conflicts.push(
+        `${name} has ${asset.digest ?? "unknown digest"}; expected ${digest}`,
+      );
+      continue;
+    }
+    matching.push(name);
+  }
+
+  return { upload, matching, conflicts };
+};
+
+const planMatchingLatestDigest = ({
+  candidateRevision,
+  latest,
+}: {
+  candidateRevision: string;
+  latest: LatestImage;
+}): LatestPlan =>
+  latest.revision === candidateRevision
+    ? { action: "noop", reason: "matching" }
+    : {
+        action: "conflict",
+        reason: "latest digest matches but revision differs",
+      };
+
+const planDifferentLatestDigest = ({
+  candidateVersion,
+  latest,
+}: {
+  candidateVersion: string;
+  latest: LatestImage;
+}): LatestPlan => {
+  if (!latest.version || !parseSemanticVersion(latest.version)) {
+    return { action: "conflict", reason: "latest version metadata is invalid" };
+  }
+
+  const comparison = compareSemanticVersions(latest.version, candidateVersion);
+  if (comparison > 0) {
+    return { action: "superseded", reason: "newer-version" };
+  }
+  return comparison === 0
+    ? {
+        action: "conflict",
+        reason: "latest has same version but a different digest",
+      }
+    : { action: "promote", reason: "older" };
+};
+
+const planExistingLatest = ({
+  candidateVersion,
+  candidateDigest,
+  candidateRevision,
+  latest,
+}: {
+  candidateVersion: string;
+  candidateDigest: string;
+  candidateRevision: string;
+  latest: LatestImage;
+}): LatestPlan => {
+  if (!isSha256Digest(latest.digest)) {
+    return { action: "conflict", reason: "latest digest is invalid" };
+  }
+  return latest.digest === candidateDigest
+    ? planMatchingLatestDigest({ candidateRevision, latest })
+    : planDifferentLatestDigest({ candidateVersion, latest });
+};
+
+export const planLatestPromotion = ({
+  candidateVersion,
+  candidateDigest,
+  candidateRevision,
+  latest,
+}: {
+  candidateVersion: string;
+  candidateDigest: string;
+  candidateRevision: string;
+  latest: LatestImage | null;
+}): LatestPlan => {
+  if (isPrereleaseVersion(candidateVersion)) {
+    return { action: "skip-prerelease" };
+  }
+  if (!isSha256Digest(candidateDigest)) {
+    return { action: "conflict", reason: "candidate digest is invalid" };
+  }
+  return latest
+    ? planExistingLatest({
+        candidateVersion,
+        candidateDigest,
+        candidateRevision,
+        latest,
+      })
+    : { action: "promote", reason: "missing" };
+};

--- a/packages/config/src/release.ts
+++ b/packages/config/src/release.ts
@@ -330,15 +330,22 @@ export const buildImmutableImageReference = ({
   return `${imageRepository}:${tag}@${digest}`;
 };
 
+const requireReleaseTag = (releaseTag: string) => {
+  if (!parseReleaseTag(releaseTag)) {
+    throw new Error(`Invalid generated release tag: ${releaseTag}`);
+  }
+};
+
 export const renderReleaseCompose = ({
   source,
   imageRepository,
-  versionReference,
+  releaseTag,
 }: {
   source: string;
   imageRepository: string;
-  versionReference: string;
+  releaseTag: string;
 }) => {
+  requireReleaseTag(releaseTag);
   const count = countMatches(source, RELEASE_IMAGE_FALLBACK_PATTERN);
   if (count !== 2) {
     throw new Error(
@@ -348,17 +355,18 @@ export const renderReleaseCompose = ({
 
   return source.replaceAll(
     "ghcr.io/itsmeares/staaash:${STAAASH_VERSION:-latest}",
-    `${imageRepository}:\${STAAASH_VERSION:-${versionReference}}`,
+    `${imageRepository}:\${STAAASH_VERSION:-${releaseTag}}`,
   );
 };
 
 export const renderReleaseEnv = ({
   source,
-  versionReference,
+  releaseTag,
 }: {
   source: string;
-  versionReference: string;
+  releaseTag: string;
 }) => {
+  requireReleaseTag(releaseTag);
   const count = countMatches(source, RELEASE_ENV_VERSION_PATTERN);
   if (count !== 1) {
     throw new Error(
@@ -368,8 +376,25 @@ export const renderReleaseEnv = ({
 
   return source.replace(
     RELEASE_ENV_VERSION_PATTERN,
-    `STAAASH_VERSION=${versionReference}`,
+    `STAAASH_VERSION=${releaseTag}`,
   );
+};
+
+export const findResolvedReleaseImageErrors = ({
+  images,
+  expectedReference,
+}: {
+  images: string[];
+  expectedReference: string;
+}): string[] => {
+  if (images.length !== 2) {
+    return [`resolved ${images.length} Staaash images; expected 2`];
+  }
+  return images.every((image) => image === expectedReference)
+    ? []
+    : [
+        `resolved Staaash images ${images.join(", ")}; expected ${expectedReference}`,
+      ];
 };
 
 export const buildReleaseManifest = ({

--- a/packages/config/test/release.test.ts
+++ b/packages/config/test/release.test.ts
@@ -1,0 +1,473 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  appendReleaseProvenance,
+  buildAssetChecksums,
+  buildImmutableImageReference,
+  buildReleaseManifest,
+  buildReleaseProvenance,
+  classifyImageState,
+  findCanonicalReleaseVersionErrors,
+  findReleaseImageIndexErrors,
+  parseReleaseProvenance,
+  parseReleaseTag,
+  planLatestPromotion,
+  planReleaseAssets,
+  renderReleaseCompose,
+  renderReleaseEnv,
+  replaceReleaseProvenance,
+  selectExactCiState,
+  serializeReleaseManifest,
+  serializeSha256Sums,
+} from "../src/release.js";
+
+const DIGEST_A = `sha256:${"a".repeat(64)}`;
+const DIGEST_B = `sha256:${"b".repeat(64)}`;
+const RELEASE_SHA = "1".repeat(40);
+const TAG_OBJECT_SHA = "2".repeat(40);
+const IMAGE_REPOSITORY = "ghcr.io/itsmeares/staaash";
+const SOURCE_URL = "https://github.com/itsmeares/staaash";
+
+const matchingImage = {
+  digest: DIGEST_A,
+  version: "v1.2.3",
+  revision: RELEASE_SHA,
+  source: SOURCE_URL,
+  webVersion: "1.2.3",
+  workerVersion: "1.2.3",
+};
+
+describe("release policy", () => {
+  it.each([
+    ["v1.2.3", "1.2.3", false],
+    ["v1.2.3-rc.1", "1.2.3-rc.1", true],
+    ["v1.2.3-beta.1", "1.2.3-beta.1", true],
+    ["v1.2.3-alpha.1", "1.2.3-alpha.1", true],
+  ])("parses canonical release tag %s", (tag, version, prerelease) => {
+    expect(parseReleaseTag(tag)).toEqual({ tag, version, prerelease });
+  });
+
+  it.each([
+    "V1.2.3",
+    "v1.2",
+    "v01.2.3",
+    "v1.2.3-rc.01",
+    "v1.2.3+build.1",
+    "latest",
+    " v1.2.3",
+  ])("rejects noncanonical release tag %s", (tag) => {
+    expect(parseReleaseTag(tag)).toBeNull();
+  });
+
+  it("requires exact versions in every package", () => {
+    expect(
+      findCanonicalReleaseVersionErrors({
+        tag: "v1.2.3-rc.1",
+        packageVersions: {
+          root: "1.2.3-rc.1",
+          web: "1.2.3-rc.1",
+          worker: "1.2.3-rc.0",
+          config: "v1.2.3-rc.1",
+          db: "1.2.3-rc.1",
+        },
+      }),
+    ).toEqual([
+      "worker has 1.2.3-rc.0; expected 1.2.3-rc.1",
+      "config has v1.2.3-rc.1; expected 1.2.3-rc.1",
+    ]);
+  });
+
+  it("selects only newest exact main-push CI attempt", () => {
+    const state = selectExactCiState({
+      releaseSha: RELEASE_SHA,
+      runs: [
+        {
+          id: 1,
+          event: "pull_request",
+          head_branch: "feature",
+          head_sha: RELEASE_SHA,
+          status: "completed",
+          conclusion: "success",
+        },
+        {
+          id: 2,
+          run_attempt: 1,
+          event: "push",
+          head_branch: "main",
+          head_sha: RELEASE_SHA,
+          status: "completed",
+          conclusion: "failure",
+        },
+        {
+          id: 2,
+          run_attempt: 2,
+          event: "push",
+          head_branch: "main",
+          head_sha: RELEASE_SHA,
+          status: "completed",
+          conclusion: "success",
+        },
+      ],
+    });
+
+    expect(state.status).toBe("success");
+    expect(state.status === "success" && state.run.run_attempt).toBe(2);
+  });
+
+  it("prefers a newer CI execution over an older rerun attempt", () => {
+    const state = selectExactCiState({
+      releaseSha: RELEASE_SHA,
+      runs: [
+        {
+          id: 10,
+          run_attempt: 2,
+          event: "push",
+          head_branch: "main",
+          head_sha: RELEASE_SHA,
+          status: "completed",
+          conclusion: "success",
+        },
+        {
+          id: 11,
+          run_attempt: 1,
+          event: "push",
+          head_branch: "main",
+          head_sha: RELEASE_SHA,
+          status: "completed",
+          conclusion: "failure",
+        },
+      ],
+    });
+
+    expect(state.status).toBe("failure");
+    expect(state.status === "failure" && state.run.id).toBe(11);
+  });
+
+  it("distinguishes missing, pending, and failed exact CI", () => {
+    expect(selectExactCiState({ runs: [], releaseSha: RELEASE_SHA })).toEqual({
+      status: "missing",
+    });
+
+    const pendingRun = {
+      id: 3,
+      event: "push",
+      head_branch: "main",
+      head_sha: RELEASE_SHA,
+      status: "in_progress",
+      conclusion: null,
+    };
+    expect(
+      selectExactCiState({ runs: [pendingRun], releaseSha: RELEASE_SHA }),
+    ).toEqual({ status: "pending", run: pendingRun });
+
+    const failedRun = {
+      ...pendingRun,
+      status: "completed",
+      conclusion: "cancelled",
+    };
+    expect(
+      selectExactCiState({ runs: [failedRun], releaseSha: RELEASE_SHA }),
+    ).toEqual({ status: "failure", run: failedRun });
+  });
+
+  it("classifies matching and conflicting immutable images", () => {
+    expect(
+      classifyImageState({
+        observed: matchingImage,
+        expected: {
+          digest: DIGEST_A,
+          version: "v1.2.3",
+          revision: RELEASE_SHA,
+          source: SOURCE_URL,
+        },
+      }),
+    ).toEqual({ status: "matching", image: matchingImage });
+
+    const conflict = classifyImageState({
+      observed: { ...matchingImage, digest: DIGEST_B, workerVersion: "1.2.2" },
+      expected: {
+        digest: DIGEST_A,
+        version: "v1.2.3",
+        revision: RELEASE_SHA,
+        source: SOURCE_URL,
+      },
+    });
+    expect(conflict.status).toBe("conflict");
+    expect(conflict.status === "conflict" && conflict.reasons).toEqual([
+      `image digest is ${DIGEST_B}; expected ${DIGEST_A}`,
+      "worker runtime version is 1.2.2; expected 1.2.3",
+    ]);
+  });
+
+  it("accepts only one linux/amd64 runnable image plus attestations", () => {
+    const amd64 = {
+      platform: { os: "linux", architecture: "amd64" },
+    };
+    const attestation = {
+      platform: { os: "unknown", architecture: "unknown" },
+      annotations: { "vnd.docker.reference.type": "attestation-manifest" },
+    };
+
+    expect(
+      findReleaseImageIndexErrors({
+        mediaType: "application/vnd.oci.image.index.v1+json",
+        manifests: [amd64, attestation],
+      }),
+    ).toEqual([]);
+    expect(
+      findReleaseImageIndexErrors({
+        mediaType: "application/vnd.oci.image.index.v1+json",
+        manifests: [
+          amd64,
+          { platform: { os: "linux", architecture: "arm64" } },
+        ],
+      }),
+    ).toEqual(["image index has 2 runnable manifests; expected 1"]);
+    expect(
+      findReleaseImageIndexErrors({
+        mediaType: "application/vnd.oci.image.manifest.v1+json",
+      }),
+    ).toEqual([
+      "image media type is application/vnd.oci.image.manifest.v1+json; expected OCI index",
+      "image index has 0 runnable manifests; expected 1",
+    ]);
+  });
+
+  it("builds tag-plus-index-digest image references", () => {
+    expect(
+      buildImmutableImageReference({
+        imageRepository: IMAGE_REPOSITORY,
+        tag: "v1.2.3-rc.1",
+        digest: DIGEST_A,
+      }),
+    ).toBe(`${IMAGE_REPOSITORY}:v1.2.3-rc.1@${DIGEST_A}`);
+  });
+
+  it("generates exact Compose and env assets for both services", () => {
+    const composeSource = [
+      "services:",
+      "  web:",
+      "    image: ghcr.io/itsmeares/staaash:${STAAASH_VERSION:-latest}",
+      "  worker:",
+      "    image: ghcr.io/itsmeares/staaash:${STAAASH_VERSION:-latest}",
+      "",
+    ].join("\n");
+    const envSource = "DB_PASSWORD=change-me\nSTAAASH_VERSION=latest\n";
+    const versionReference = `v1.2.3-rc.1@${DIGEST_A}`;
+
+    const compose = renderReleaseCompose({
+      source: composeSource,
+      imageRepository: "ghcr.io/scratch/staaash",
+      versionReference,
+    });
+    const env = renderReleaseEnv({ source: envSource, versionReference });
+
+    expect(compose.match(/v1\.2\.3-rc\.1@sha256:/gu)).toHaveLength(2);
+    expect(compose).not.toContain("latest");
+    expect(compose).toContain("ghcr.io/scratch/staaash:${STAAASH_VERSION:-");
+    expect(env).toContain(`STAAASH_VERSION=${versionReference}`);
+    expect(env).not.toContain("STAAASH_VERSION=latest");
+  });
+
+  it("renders the repository release templates before publication", async () => {
+    const versionReference = `v1.2.3@${DIGEST_A}`;
+    const compose = renderReleaseCompose({
+      source: await readFile(
+        new URL("../../../docker-compose.yml", import.meta.url),
+        "utf8",
+      ),
+      imageRepository: IMAGE_REPOSITORY,
+      versionReference,
+    });
+    const environment = renderReleaseEnv({
+      source: await readFile(
+        new URL("../../../example.env", import.meta.url),
+        "utf8",
+      ),
+      versionReference,
+    });
+
+    expect(compose.match(/v1\.2\.3@sha256:/gu)).toHaveLength(2);
+    expect(compose).not.toContain("${STAAASH_VERSION:-latest}");
+    expect(environment).toContain(`STAAASH_VERSION=${versionReference}`);
+  });
+
+  it("fails closed when source asset anchors drift", () => {
+    expect(() =>
+      renderReleaseCompose({
+        source: "services: {}\n",
+        imageRepository: IMAGE_REPOSITORY,
+        versionReference: `v1.2.3@${DIGEST_A}`,
+      }),
+    ).toThrow("Expected 2 Staaash image fallbacks");
+    expect(() =>
+      renderReleaseEnv({
+        source: "STAAASH_VERSION=v1.2.2\n",
+        versionReference: `v1.2.3@${DIGEST_A}`,
+      }),
+    ).toThrow("Expected 1 STAAASH_VERSION=latest entry");
+  });
+
+  it("serializes deterministic manifest and checksums", () => {
+    const release = parseReleaseTag("v1.2.3")!;
+    const manifest = buildReleaseManifest({
+      release,
+      repository: "itsmeares/staaash",
+      commit: RELEASE_SHA,
+      tagObject: TAG_OBJECT_SHA,
+      tagType: "annotated",
+      imageRepository: IMAGE_REPOSITORY,
+      imageDigest: DIGEST_A,
+    });
+    const serialized = serializeReleaseManifest(manifest);
+    const checksums = buildAssetChecksums({
+      "example.env": "env\n",
+      "docker-compose.yml": "compose\n",
+      "release-manifest.json": serialized,
+    });
+
+    expect(manifest.image.indexDigest).toBe(DIGEST_A);
+    expect(manifest.image.immutableReference).toBe(
+      `${IMAGE_REPOSITORY}:v1.2.3@${DIGEST_A}`,
+    );
+    expect(serialized).not.toContain("runId");
+    expect(Object.keys(checksums)).toEqual([
+      "docker-compose.yml",
+      "example.env",
+      "release-manifest.json",
+    ]);
+    expect(serializeSha256Sums(checksums)).toMatch(
+      /^[0-9a-f]{64}  docker-compose\.yml\n[0-9a-f]{64}  example\.env\n[0-9a-f]{64}  release-manifest\.json\n$/u,
+    );
+  });
+
+  it("preserves notes outside managed provenance block", () => {
+    const pending = buildReleaseProvenance({
+      tag: "v1.2.3",
+      commit: RELEASE_SHA,
+      tagObject: TAG_OBJECT_SHA,
+      imageDigest: "pending",
+      immutableImage: "pending",
+      assetChecksums: null,
+    });
+    const complete = buildReleaseProvenance({
+      ...pending,
+      imageDigest: DIGEST_A,
+      immutableImage: `${IMAGE_REPOSITORY}:v1.2.3@${DIGEST_A}`,
+      assetChecksums: { "example.env": DIGEST_B },
+    });
+
+    const withPending = appendReleaseProvenance({
+      body: "Generated notes stay here.\n",
+      provenance: pending,
+    });
+    const withComplete = replaceReleaseProvenance({
+      body: withPending,
+      expected: pending,
+      next: complete,
+    });
+
+    expect(withComplete).toContain("Generated notes stay here.");
+    expect(parseReleaseProvenance(withComplete)).toEqual(
+      expect.objectContaining({ status: "valid", provenance: complete }),
+    );
+    expect(() =>
+      appendReleaseProvenance({ body: withPending, provenance: pending }),
+    ).toThrow("already exists or is malformed");
+  });
+
+  it("plans idempotent draft assets without clobbering", () => {
+    const expected = {
+      "docker-compose.yml": DIGEST_A,
+      "example.env": DIGEST_B,
+    };
+    const observed = [
+      { name: "docker-compose.yml", digest: DIGEST_A },
+      { name: "extra.txt", digest: DIGEST_A },
+    ];
+
+    expect(planReleaseAssets({ expected, observed, published: false })).toEqual(
+      {
+        upload: ["example.env"],
+        matching: ["docker-compose.yml"],
+        conflicts: [],
+      },
+    );
+    expect(planReleaseAssets({ expected, observed, published: true })).toEqual({
+      upload: [],
+      matching: ["docker-compose.yml"],
+      conflicts: ["example.env is missing from published release"],
+    });
+    expect(
+      planReleaseAssets({
+        expected,
+        observed: [{ name: "docker-compose.yml", digest: DIGEST_B }],
+        published: false,
+      }).conflicts,
+    ).toContain(`docker-compose.yml has ${DIGEST_B}; expected ${DIGEST_A}`);
+  });
+
+  it("isolates prerelease and promotes stable latest monotonically", () => {
+    expect(
+      planLatestPromotion({
+        candidateVersion: "1.2.3-beta.1",
+        candidateDigest: DIGEST_A,
+        candidateRevision: RELEASE_SHA,
+        latest: null,
+      }),
+    ).toEqual({ action: "skip-prerelease" });
+
+    expect(
+      planLatestPromotion({
+        candidateVersion: "1.2.3",
+        candidateDigest: DIGEST_A,
+        candidateRevision: RELEASE_SHA,
+        latest: null,
+      }),
+    ).toEqual({ action: "promote", reason: "missing" });
+
+    expect(
+      planLatestPromotion({
+        candidateVersion: "1.2.3",
+        candidateDigest: DIGEST_A,
+        candidateRevision: RELEASE_SHA,
+        latest: {
+          digest: DIGEST_A,
+          version: "v1.2.3",
+          revision: RELEASE_SHA,
+        },
+      }),
+    ).toEqual({ action: "noop", reason: "matching" });
+
+    expect(
+      planLatestPromotion({
+        candidateVersion: "1.2.3",
+        candidateDigest: DIGEST_A,
+        candidateRevision: RELEASE_SHA,
+        latest: {
+          digest: DIGEST_B,
+          version: "v1.3.0",
+          revision: "3".repeat(40),
+        },
+      }),
+    ).toEqual({ action: "superseded", reason: "newer-version" });
+
+    expect(
+      planLatestPromotion({
+        candidateVersion: "1.2.3",
+        candidateDigest: DIGEST_A,
+        candidateRevision: RELEASE_SHA,
+        latest: {
+          digest: DIGEST_B,
+          version: "v1.2.3",
+          revision: RELEASE_SHA,
+        },
+      }),
+    ).toEqual({
+      action: "conflict",
+      reason: "latest has same version but a different digest",
+    });
+  });
+});

--- a/packages/config/test/release.test.ts
+++ b/packages/config/test/release.test.ts
@@ -11,6 +11,7 @@ import {
   classifyImageState,
   findCanonicalReleaseVersionErrors,
   findReleaseImageIndexErrors,
+  findResolvedReleaseImageErrors,
   parseReleaseProvenance,
   parseReleaseTag,
   planLatestPromotion,
@@ -245,69 +246,105 @@ describe("release policy", () => {
     ).toBe(`${IMAGE_REPOSITORY}:v1.2.3-rc.1@${DIGEST_A}`);
   });
 
-  it("generates exact Compose and env assets for both services", () => {
-    const composeSource = [
-      "services:",
-      "  web:",
-      "    image: ghcr.io/itsmeares/staaash:${STAAASH_VERSION:-latest}",
-      "  worker:",
-      "    image: ghcr.io/itsmeares/staaash:${STAAASH_VERSION:-latest}",
-      "",
-    ].join("\n");
-    const envSource = "DB_PASSWORD=change-me\nSTAAASH_VERSION=latest\n";
-    const versionReference = `v1.2.3-rc.1@${DIGEST_A}`;
+  it.each(["v1.2.3", "v1.2.3-rc.1", "v1.2.3-beta.1"])(
+    "generates readable %s Compose and env defaults",
+    (releaseTag) => {
+      const composeSource = [
+        "services:",
+        "  web:",
+        "    image: ghcr.io/itsmeares/staaash:${STAAASH_VERSION:-latest}",
+        "  worker:",
+        "    image: ghcr.io/itsmeares/staaash:${STAAASH_VERSION:-latest}",
+        "",
+      ].join("\n");
+      const envSource = "DB_PASSWORD=change-me\nSTAAASH_VERSION=latest\n";
 
-    const compose = renderReleaseCompose({
-      source: composeSource,
-      imageRepository: "ghcr.io/scratch/staaash",
-      versionReference,
-    });
-    const env = renderReleaseEnv({ source: envSource, versionReference });
+      const compose = renderReleaseCompose({
+        source: composeSource,
+        imageRepository: "ghcr.io/scratch/staaash",
+        releaseTag,
+      });
+      const environment = renderReleaseEnv({ source: envSource, releaseTag });
 
-    expect(compose.match(/v1\.2\.3-rc\.1@sha256:/gu)).toHaveLength(2);
-    expect(compose).not.toContain("latest");
-    expect(compose).toContain("ghcr.io/scratch/staaash:${STAAASH_VERSION:-");
-    expect(env).toContain(`STAAASH_VERSION=${versionReference}`);
-    expect(env).not.toContain("STAAASH_VERSION=latest");
-  });
+      expect(compose.match(new RegExp(releaseTag, "gu"))).toHaveLength(2);
+      expect(compose).toContain(
+        `ghcr.io/scratch/staaash:\${STAAASH_VERSION:-${releaseTag}}`,
+      );
+      expect(environment).toContain(`STAAASH_VERSION=${releaseTag}`);
+      expect(compose).not.toContain("latest");
+      expect(environment).not.toContain("STAAASH_VERSION=latest");
+      expect(compose).not.toContain("@sha256:");
+      expect(environment).not.toContain("@sha256:");
+    },
+  );
 
   it("renders the repository release templates before publication", async () => {
-    const versionReference = `v1.2.3@${DIGEST_A}`;
+    const releaseTag = "v1.2.3";
     const compose = renderReleaseCompose({
       source: await readFile(
         new URL("../../../docker-compose.yml", import.meta.url),
         "utf8",
       ),
       imageRepository: IMAGE_REPOSITORY,
-      versionReference,
+      releaseTag,
     });
     const environment = renderReleaseEnv({
       source: await readFile(
         new URL("../../../example.env", import.meta.url),
         "utf8",
       ),
-      versionReference,
+      releaseTag,
     });
 
-    expect(compose.match(/v1\.2\.3@sha256:/gu)).toHaveLength(2);
+    expect(compose.match(/v1\.2\.3/gu)).toHaveLength(2);
     expect(compose).not.toContain("${STAAASH_VERSION:-latest}");
-    expect(environment).toContain(`STAAASH_VERSION=${versionReference}`);
+    expect(compose).not.toContain("@sha256:");
+    expect(environment).toContain(`STAAASH_VERSION=${releaseTag}`);
   });
 
-  it("fails closed when source asset anchors drift", () => {
+  it("accepts normal tags and optional immutable Compose resolutions", () => {
+    const tagReference = `${IMAGE_REPOSITORY}:v1.2.3`;
+    const immutableReference = `${tagReference}@${DIGEST_A}`;
+    expect(
+      findResolvedReleaseImageErrors({
+        images: [tagReference, tagReference],
+        expectedReference: tagReference,
+      }),
+    ).toEqual([]);
+    expect(
+      findResolvedReleaseImageErrors({
+        images: [immutableReference, immutableReference],
+        expectedReference: immutableReference,
+      }),
+    ).toEqual([]);
+  });
+
+  it("fails closed when generated tags or source anchors drift", () => {
     expect(() =>
       renderReleaseCompose({
         source: "services: {}\n",
         imageRepository: IMAGE_REPOSITORY,
-        versionReference: `v1.2.3@${DIGEST_A}`,
+        releaseTag: "v1.2.3",
       }),
     ).toThrow("Expected 2 Staaash image fallbacks");
     expect(() =>
       renderReleaseEnv({
         source: "STAAASH_VERSION=v1.2.2\n",
-        versionReference: `v1.2.3@${DIGEST_A}`,
+        releaseTag: "v1.2.3",
       }),
     ).toThrow("Expected 1 STAAASH_VERSION=latest entry");
+    expect(() =>
+      renderReleaseEnv({
+        source: "STAAASH_VERSION=latest\n",
+        releaseTag: "latest",
+      }),
+    ).toThrow("Invalid generated release tag");
+    expect(() =>
+      renderReleaseEnv({
+        source: "STAAASH_VERSION=latest\n",
+        releaseTag: `v1.2.3@${DIGEST_A}`,
+      }),
+    ).toThrow("Invalid generated release tag");
   });
 
   it("serializes deterministic manifest and checksums", () => {

--- a/scripts/release/index.mjs
+++ b/scripts/release/index.mjs
@@ -14,6 +14,7 @@ import {
   classifyImageState,
   findCanonicalReleaseVersionErrors,
   findReleaseImageIndexErrors,
+  findResolvedReleaseImageErrors,
   hashReleaseContent,
   parseReleaseProvenance,
   parseReleaseTag,
@@ -58,11 +59,17 @@ const optionalEnv = (name) => process.env[name]?.trim() ?? "";
 const run = (
   command,
   args,
-  { allowFailure = false, cwd = ROOT, input, encoding = "utf8" } = {},
+  {
+    allowFailure = false,
+    cwd = ROOT,
+    input,
+    encoding = "utf8",
+    environment = process.env,
+  } = {},
 ) => {
   const result = spawnSync(command, args, {
     cwd,
-    env: process.env,
+    env: environment,
     encoding,
     input,
     maxBuffer: 20 * 1024 * 1024,
@@ -538,34 +545,85 @@ const expectedAssetDigests = (assets) =>
     ]),
   );
 
+const withoutStaaashVersion = () =>
+  Object.fromEntries(
+    Object.entries(process.env).filter(
+      ([name]) => name.toUpperCase() !== "STAAASH_VERSION",
+    ),
+  );
+
+const resolveComposeImages = ({ directory, environment }) => {
+  const result = run(
+    "docker",
+    [
+      "compose",
+      "--env-file",
+      path.join(directory, "example.env"),
+      "-f",
+      path.join(directory, "docker-compose.yml"),
+      "config",
+      "--images",
+    ],
+    { environment },
+  );
+  return result.stdout
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean);
+};
+
+const requireResolvedReleaseImages = ({
+  images,
+  imageRepository,
+  expectedReference,
+  mode,
+}) => {
+  const applicationImages = images.filter((image) =>
+    image.startsWith(`${imageRepository}:`),
+  );
+  const errors = findResolvedReleaseImageErrors({
+    images: applicationImages,
+    expectedReference,
+  });
+  if (errors.length > 0) {
+    throw new Error(
+      `Generated Compose ${mode} resolution failed:\n${errors.join("\n")}`,
+    );
+  }
+};
+
 const validateRenderedAssets = ({
   directory,
   imageRepository,
+  releaseTag,
   immutableReference,
 }) => {
-  const composePath = path.join(directory, "docker-compose.yml");
-  const envPath = path.join(directory, "example.env");
-  const result = run("docker", [
-    "compose",
-    "--env-file",
-    envPath,
-    "-f",
-    composePath,
-    "config",
-    "--images",
-  ]);
-  const applicationImages = result.stdout
-    .split(/\r?\n/u)
-    .map((line) => line.trim())
-    .filter((line) => line.startsWith(`${imageRepository}:`));
-  if (
-    applicationImages.length !== 2 ||
-    applicationImages.some((image) => image !== immutableReference)
-  ) {
-    throw new Error(
-      `Generated Compose resolves unexpected Staaash images: ${applicationImages.join(", ")}`,
-    );
-  }
+  const baseEnvironment = withoutStaaashVersion();
+  requireResolvedReleaseImages({
+    images: resolveComposeImages({
+      directory,
+      environment: baseEnvironment,
+    }),
+    imageRepository,
+    expectedReference: `${imageRepository}:${releaseTag}`,
+    mode: "tag default",
+  });
+
+  const immutableVersion = immutableReference.slice(
+    `${imageRepository}:`.length,
+  );
+  requireResolvedReleaseImages({
+    images: resolveComposeImages({
+      directory,
+      environment: {
+        ...baseEnvironment,
+        STAAASH_VERSION: immutableVersion,
+      },
+    }),
+    imageRepository,
+    expectedReference: immutableReference,
+    mode: "immutable override",
+  });
 };
 
 const fetchAssetBytes = async (asset) => {
@@ -643,11 +701,12 @@ const verifyRemoteAssets = async ({ context, release, localAssets }) => {
         );
       }
     }
+    const manifest = JSON.parse(downloaded["release-manifest.json"]);
     validateRenderedAssets({
       directory: temporaryDirectory,
       imageRepository: context.imageRepository,
-      immutableReference: JSON.parse(downloaded["release-manifest.json"]).image
-        .immutableReference,
+      releaseTag: manifest.tag,
+      immutableReference: manifest.image.immutableReference,
     });
   } finally {
     await rm(temporaryDirectory, { recursive: true, force: true });
@@ -788,27 +847,25 @@ const commandGenerateAssets = async () => {
   await rm(directory, { recursive: true, force: true });
   await mkdir(directory, { recursive: true });
 
-  const versionReference = `${context.release.tag}@${imageDigest}`;
   const compose = renderReleaseCompose({
     source: await readFile(path.join(ROOT, "docker-compose.yml"), "utf8"),
     imageRepository: context.imageRepository,
-    versionReference,
+    releaseTag: context.release.tag,
   });
   const environment = renderReleaseEnv({
     source: await readFile(path.join(ROOT, "example.env"), "utf8"),
-    versionReference,
+    releaseTag: context.release.tag,
   });
-  const manifest = serializeReleaseManifest(
-    buildReleaseManifest({
-      release: context.release,
-      repository: context.repository,
-      commit: context.releaseSha,
-      tagObject: context.tagObject,
-      tagType: context.tagType,
-      imageRepository: context.imageRepository,
-      imageDigest,
-    }),
-  );
+  const manifestObject = buildReleaseManifest({
+    release: context.release,
+    repository: context.repository,
+    commit: context.releaseSha,
+    tagObject: context.tagObject,
+    tagType: context.tagType,
+    imageRepository: context.imageRepository,
+    imageDigest,
+  });
+  const manifest = serializeReleaseManifest(manifestObject);
   const checksums = buildAssetChecksums({
     "docker-compose.yml": compose,
     "example.env": environment,
@@ -825,10 +882,16 @@ const commandGenerateAssets = async () => {
   validateRenderedAssets({
     directory,
     imageRepository: context.imageRepository,
-    immutableReference: `${context.imageRepository}:${versionReference}`,
+    releaseTag: context.release.tag,
+    immutableReference: manifestObject.image.immutableReference,
   });
-  if (compose.includes(`${context.imageRepository}:latest`)) {
-    throw new Error("Generated Compose contains mutable latest image.");
+  if (
+    compose.includes("${STAAASH_VERSION:-latest}") ||
+    environment.includes("STAAASH_VERSION=latest")
+  ) {
+    throw new Error(
+      "Generated release assets contain mutable latest defaults.",
+    );
   }
 };
 

--- a/scripts/release/index.mjs
+++ b/scripts/release/index.mjs
@@ -1,0 +1,1120 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import {
+  appendReleaseProvenance,
+  buildAssetChecksums,
+  buildReleaseManifest,
+  buildReleaseProvenance,
+  classifyImageState,
+  findCanonicalReleaseVersionErrors,
+  findReleaseImageIndexErrors,
+  hashReleaseContent,
+  parseReleaseProvenance,
+  parseReleaseTag,
+  planLatestPromotion,
+  planReleaseAssets,
+  renderReleaseCompose,
+  renderReleaseEnv,
+  replaceReleaseProvenance,
+  selectExactCiState,
+  serializeReleaseManifest,
+  serializeSha256Sums,
+} from "../../packages/config/dist/release.js";
+
+const ROOT = fileURLToPath(new URL("../../", import.meta.url));
+const PACKAGE_FILES = {
+  root: "package.json",
+  web: "apps/web/package.json",
+  worker: "apps/worker/package.json",
+  config: "packages/config/package.json",
+  db: "packages/db/package.json",
+};
+const REQUIRED_ASSET_NAMES = [
+  "docker-compose.yml",
+  "example.env",
+  "release-manifest.json",
+  "SHA256SUMS",
+];
+const MISSING_IMAGE_PATTERN =
+  /manifest unknown|not found|no such manifest|does not exist/iu;
+
+const sleep = (milliseconds) =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+const requiredEnv = (name) => {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required.`);
+  return value;
+};
+
+const optionalEnv = (name) => process.env[name]?.trim() ?? "";
+
+const run = (
+  command,
+  args,
+  { allowFailure = false, cwd = ROOT, input, encoding = "utf8" } = {},
+) => {
+  const result = spawnSync(command, args, {
+    cwd,
+    env: process.env,
+    encoding,
+    input,
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0 && !allowFailure) {
+    const detail = String(result.stderr || result.stdout || "").trim();
+    throw new Error(
+      `${command} ${args.join(" ")} failed${detail ? `: ${detail}` : "."}`,
+    );
+  }
+  return result;
+};
+
+const git = (...args) => run("git", args).stdout.trim();
+
+const ghApi = (endpoint, { method = "GET", input } = {}) => {
+  const args = ["api", endpoint, "--method", method];
+  if (input !== undefined) args.push("--input", "-");
+  const result = run("gh", args, {
+    input: input === undefined ? undefined : JSON.stringify(input),
+  });
+  const output = result.stdout.trim();
+  return output ? JSON.parse(output) : null;
+};
+
+const ghApiPaginated = (endpoint) => {
+  const result = run("gh", ["api", "--paginate", "--slurp", endpoint]);
+  const pages = JSON.parse(result.stdout);
+  return pages.flat();
+};
+
+const writeOutput = async (name, value) => {
+  const outputPath = optionalEnv("GITHUB_OUTPUT");
+  if (!outputPath) {
+    console.info(`${name}=${String(value)}`);
+    return;
+  }
+  await writeFile(outputPath, `${name}=${String(value)}\n`, { flag: "a" });
+};
+
+const writeOutputs = async (entries) => {
+  for (const [name, value] of entries) await writeOutput(name, value);
+};
+
+const writeSummary = async (content) => {
+  const summaryPath = optionalEnv("GITHUB_STEP_SUMMARY");
+  if (!summaryPath) return;
+  await writeFile(summaryPath, `${content.trim()}\n`, { flag: "a" });
+};
+
+const sha256 = (content) =>
+  `sha256:${createHash("sha256").update(content).digest("hex")}`;
+
+const releaseContextFromEnv = () => {
+  const tag = requiredEnv("RELEASE_TAG");
+  const release = parseReleaseTag(tag);
+  if (!release) throw new Error(`Invalid release tag: ${tag}`);
+  const repository = requiredEnv("GITHUB_REPOSITORY");
+  const imageRepository =
+    optionalEnv("IMAGE_REPOSITORY") || `ghcr.io/${repository.toLowerCase()}`;
+
+  return {
+    release,
+    repository,
+    imageRepository,
+    sourceUrl: `https://github.com/${repository}`,
+    releaseSha: requiredEnv("RELEASE_SHA"),
+    tagObject: requiredEnv("TAG_OBJECT_SHA"),
+    tagType: requiredEnv("TAG_TYPE"),
+  };
+};
+
+const readPackageVersions = async () =>
+  Object.fromEntries(
+    await Promise.all(
+      Object.entries(PACKAGE_FILES).map(async ([name, file]) => {
+        const metadata = JSON.parse(
+          await readFile(path.join(ROOT, file), "utf8"),
+        );
+        return [name, metadata.version];
+      }),
+    ),
+  );
+
+const readRemoteTagObject = (tag) => {
+  const result = run("git", ["ls-remote", "origin", `refs/tags/${tag}`]);
+  const line = result.stdout.trim();
+  if (!line) throw new Error(`Remote tag ${tag} does not exist.`);
+  const [objectSha] = line.split(/\s+/u);
+  return objectSha;
+};
+
+const resolveTagIdentity = (tag) => {
+  const tagObject = git("rev-parse", `refs/tags/${tag}`);
+  const releaseSha = git("rev-parse", `refs/tags/${tag}^{commit}`);
+  const objectType = git("cat-file", "-t", tagObject);
+  return {
+    tagObject,
+    releaseSha,
+    tagType: objectType === "tag" ? "annotated" : "lightweight",
+  };
+};
+
+const verifyRemoteTagIdentity = (tag, identity) => {
+  const remoteTagObject = readRemoteTagObject(tag);
+  if (remoteTagObject !== identity.tagObject) {
+    throw new Error(
+      `Remote tag object changed: expected ${identity.tagObject}; found ${remoteTagObject}.`,
+    );
+  }
+};
+
+const normalizeExpectedTagIdentity = (value) =>
+  /^[0-9a-f]{40}$/u.test(value) && !/^0{40}$/u.test(value) ? value : "";
+
+const verifyExpectedTagIdentity = ({
+  identity,
+  expectedReleaseSha,
+  expectedTagObject,
+}) => {
+  const expectedObject = normalizeExpectedTagIdentity(expectedTagObject);
+  if (
+    expectedObject &&
+    identity.tagObject !== expectedObject &&
+    identity.releaseSha !== expectedObject
+  ) {
+    throw new Error(
+      `Tag event identity is ${expectedObject}; current tag is ${identity.tagObject} at ${identity.releaseSha}.`,
+    );
+  }
+  if (
+    expectedReleaseSha &&
+    identity.releaseSha !== expectedReleaseSha &&
+    identity.tagObject !== expectedReleaseSha
+  ) {
+    throw new Error(
+      `Tag event SHA is ${expectedReleaseSha}; current tag is ${identity.tagObject} at ${identity.releaseSha}.`,
+    );
+  }
+};
+
+const verifyCheckedOutTag = (releaseSha) => {
+  const head = git("rev-parse", "HEAD");
+  if (head !== releaseSha) {
+    throw new Error(`Checked-out HEAD is ${head}; expected ${releaseSha}.`);
+  }
+};
+
+const verifyMainAncestry = (releaseSha) => {
+  run("git", ["fetch", "--no-tags", "origin", "main:refs/remotes/origin/main"]);
+  const ancestry = run(
+    "git",
+    ["merge-base", "--is-ancestor", releaseSha, "origin/main"],
+    { allowFailure: true },
+  );
+  if (ancestry.status !== 0) {
+    throw new Error(`Release commit ${releaseSha} is not on current main.`);
+  }
+};
+
+const inspectTagIdentity = ({
+  tag,
+  expectedReleaseSha = "",
+  expectedTagObject = "",
+  requireHead = true,
+}) => {
+  const identity = resolveTagIdentity(tag);
+  verifyRemoteTagIdentity(tag, identity);
+  verifyExpectedTagIdentity({
+    identity,
+    expectedReleaseSha,
+    expectedTagObject,
+  });
+  if (requireHead) verifyCheckedOutTag(identity.releaseSha);
+  verifyMainAncestry(identity.releaseSha);
+  return identity;
+};
+
+const verifyRecordedTagIdentity = (context) => {
+  const identity = inspectTagIdentity({
+    tag: context.release.tag,
+    expectedReleaseSha: context.releaseSha,
+    expectedTagObject: context.tagObject,
+  });
+  if (identity.tagType !== context.tagType) {
+    throw new Error(
+      `Tag type changed: expected ${context.tagType}; found ${identity.tagType}.`,
+    );
+  }
+};
+
+const getExactCiRuns = (repository, releaseSha) => {
+  const response = ghApi(
+    `repos/${repository}/actions/workflows/ci.yml/runs?head_sha=${releaseSha}&event=push&per_page=100`,
+  );
+  return response?.workflow_runs ?? [];
+};
+
+const evaluateExactCiState = ({ state, releaseSha, deadline }) => {
+  if (state.status === "success") return state.run;
+  if (state.status === "failure") {
+    throw new Error(
+      `Exact CI run ${state.run.id} completed with ${state.run.conclusion}.`,
+    );
+  }
+  if (Date.now() >= deadline) {
+    throw new Error(
+      `No successful exact main-push CI run for ${releaseSha} before timeout.`,
+    );
+  }
+  console.info(
+    state.status === "missing"
+      ? `Exact CI run for ${releaseSha} not visible yet.`
+      : `Exact CI run ${state.run.id} is ${state.run.status}.`,
+  );
+  return null;
+};
+
+const waitForExactCi = async ({ repository, releaseSha }) => {
+  const timeoutSeconds = Number.parseInt(
+    optionalEnv("CI_WAIT_SECONDS") || "1800",
+    10,
+  );
+  const pollSeconds = Number.parseInt(
+    optionalEnv("CI_POLL_SECONDS") || "15",
+    10,
+  );
+  const deadline = Date.now() + timeoutSeconds * 1000;
+
+  while (true) {
+    const state = selectExactCiState({
+      runs: getExactCiRuns(repository, releaseSha),
+      releaseSha,
+    });
+    const completedRun = evaluateExactCiState({ state, releaseSha, deadline });
+    if (completedRun) return completedRun;
+    await sleep(pollSeconds * 1000);
+  }
+};
+
+const getReleases = (repository) =>
+  ghApiPaginated(`repos/${repository}/releases?per_page=100`);
+
+const getRelease = (repository, tag) => {
+  const releases = getReleases(repository).filter(
+    (release) => release.tag_name === tag,
+  );
+  if (releases.length > 1) {
+    throw new Error(`Multiple GitHub Releases exist for ${tag}.`);
+  }
+  return releases[0] ?? null;
+};
+
+const getReleaseAssets = (repository, releaseId) =>
+  ghApiPaginated(
+    `repos/${repository}/releases/${releaseId}/assets?per_page=100`,
+  );
+
+const verifyReleaseMetadata = ({ release, context }) => {
+  if (release.tag_name !== context.release.tag) {
+    throw new Error(
+      `Release tag is ${release.tag_name}; expected ${context.release.tag}.`,
+    );
+  }
+  if (Boolean(release.prerelease) !== context.release.prerelease) {
+    throw new Error(
+      `Release prerelease flag is ${String(release.prerelease)}; expected ${String(context.release.prerelease)}.`,
+    );
+  }
+};
+
+const requireReleaseProvenance = (body) => {
+  const parsed = parseReleaseProvenance(body ?? "");
+  if (parsed.status === "valid") return parsed;
+  const detail = parsed.status === "malformed" ? `: ${parsed.reason}` : ".";
+  throw new Error(`Release provenance is ${parsed.status}${detail}`);
+};
+
+const verifyReleaseProvenanceIdentity = ({ provenance, context }) => {
+  const matches =
+    provenance.tag === context.release.tag &&
+    provenance.commit === context.releaseSha &&
+    provenance.tagObject === context.tagObject;
+  if (!matches) {
+    throw new Error(
+      "Release provenance tag identity conflicts with current tag.",
+    );
+  }
+};
+
+const validateReleaseIdentity = ({ release, context }) => {
+  verifyReleaseMetadata({ release, context });
+  const parsed = requireReleaseProvenance(release.body);
+  verifyReleaseProvenanceIdentity({ provenance: parsed.provenance, context });
+  if (!release.draft && parsed.provenance.imageDigest === "pending") {
+    throw new Error("Published release still has pending image provenance.");
+  }
+  return { parsed, provenance: parsed.provenance };
+};
+
+const generateReleaseNotes = (repository, tag) =>
+  ghApi(`repos/${repository}/releases/generate-notes`, {
+    method: "POST",
+    input: { tag_name: tag },
+  });
+
+const createDraft = ({ context, provenance }) => {
+  const generated = generateReleaseNotes(
+    context.repository,
+    context.release.tag,
+  );
+  const body = appendReleaseProvenance({
+    body: generated.body ?? "",
+    provenance,
+  });
+  return ghApi(`repos/${context.repository}/releases`, {
+    method: "POST",
+    input: {
+      tag_name: context.release.tag,
+      name: generated.name || context.release.tag,
+      body,
+      draft: true,
+      prerelease: context.release.prerelease,
+      make_latest: "false",
+    },
+  });
+};
+
+const patchRelease = (repository, releaseId, input) =>
+  ghApi(`repos/${repository}/releases/${releaseId}`, {
+    method: "PATCH",
+    input,
+  });
+
+const runImageInspection = (reference, allowMissing) => {
+  const result = run(
+    "docker",
+    ["buildx", "imagetools", "inspect", reference, "--format", "{{json .}}"],
+    { allowFailure: allowMissing },
+  );
+  if (result.status === 0) return result.stdout;
+
+  const detail = `${result.stderr}\n${result.stdout}`;
+  if (allowMissing && MISSING_IMAGE_PATTERN.test(detail)) return null;
+  throw new Error(`Unable to inspect image ${reference}: ${detail.trim()}`);
+};
+
+const getInspectionManifest = (inspected) =>
+  inspected.manifest ?? { digest: null, mediaType: null, manifests: [] };
+
+const getInspectionConfig = (inspected) =>
+  inspected.image?.config ?? { Labels: {}, Env: [] };
+
+const parseImageInspection = (reference, output) => {
+  const inspected = JSON.parse(output);
+  const manifest = getInspectionManifest(inspected);
+  const config = getInspectionConfig(inspected);
+  const indexErrors = findReleaseImageIndexErrors(manifest);
+  if (indexErrors.length > 0) {
+    throw new Error(
+      `${reference} has invalid image index:\n${indexErrors.join("\n")}`,
+    );
+  }
+  return {
+    digest: manifest.digest,
+    labels: config.Labels ?? {},
+    environment: config.Env ?? [],
+  };
+};
+
+const inspectImage = (reference, { allowMissing = false } = {}) => {
+  const output = runImageInspection(reference, allowMissing);
+  return output === null ? null : parseImageInspection(reference, output);
+};
+
+const inspectRuntimeVersions = (reference) => {
+  const program = [
+    'const fs = require("node:fs");',
+    'const webVersion = JSON.parse(fs.readFileSync("/app/apps/web/package.json", "utf8")).version;',
+    'const workerVersion = JSON.parse(fs.readFileSync("/worker/package.json", "utf8")).version;',
+    'import("file:///worker/dist/runtime-version.js")',
+    "  .then(({ resolveWorkerVersion }) => {",
+    "    const resolvedWorkerVersion = resolveWorkerVersion(null);",
+    "    process.stdout.write(JSON.stringify({ webVersion, workerVersion, resolvedWorkerVersion }));",
+    "  })",
+    "  .catch((error) => { console.error(error); process.exit(1); });",
+  ].join("\n");
+  const result = run("docker", [
+    "run",
+    "--rm",
+    "--pull=always",
+    "--entrypoint",
+    "node",
+    reference,
+    "-e",
+    program,
+  ]);
+  return JSON.parse(result.stdout);
+};
+
+const readObservedImage = (reference) => {
+  const inspected = inspectImage(reference);
+  if (
+    inspected.environment.some(
+      (entry) => entry === "APP_VERSION" || entry.startsWith("APP_VERSION="),
+    )
+  ) {
+    throw new Error(`${reference} defines APP_VERSION in image config.`);
+  }
+  const runtime = inspectRuntimeVersions(reference);
+  if (runtime.workerVersion !== runtime.resolvedWorkerVersion) {
+    throw new Error(
+      `Worker package version ${runtime.workerVersion} resolves as ${runtime.resolvedWorkerVersion}.`,
+    );
+  }
+
+  return {
+    digest: inspected.digest,
+    version: inspected.labels["org.opencontainers.image.version"] ?? null,
+    revision: inspected.labels["org.opencontainers.image.revision"] ?? null,
+    source: inspected.labels["org.opencontainers.image.source"] ?? null,
+    webVersion: runtime.webVersion,
+    workerVersion: runtime.resolvedWorkerVersion,
+  };
+};
+
+const verifyImage = ({ context, digest }) => {
+  const exactReference = `${context.imageRepository}:${context.release.tag}`;
+  const immutableReference = `${exactReference}@${digest}`;
+  const observed = readObservedImage(immutableReference);
+  const state = classifyImageState({
+    observed,
+    expected: {
+      digest,
+      version: context.release.tag,
+      revision: context.releaseSha,
+      source: context.sourceUrl,
+    },
+  });
+  if (state.status !== "matching") {
+    throw new Error(`Image conflict:\n${state.reasons.join("\n")}`);
+  }
+
+  const exactInspected = inspectImage(exactReference);
+  if (exactInspected.digest !== digest) {
+    throw new Error(
+      `Exact tag resolves to ${exactInspected.digest}; expected ${digest}.`,
+    );
+  }
+  return { observed, immutableReference };
+};
+
+const assetDirectory = () =>
+  path.resolve(ROOT, optionalEnv("ASSET_DIR") || ".release-assets");
+
+const generatedAssets = async () => {
+  const directory = assetDirectory();
+  const entries = await Promise.all(
+    REQUIRED_ASSET_NAMES.map(async (name) => [
+      name,
+      await readFile(path.join(directory, name), "utf8"),
+    ]),
+  );
+  return Object.fromEntries(entries);
+};
+
+const expectedAssetDigests = (assets) =>
+  Object.fromEntries(
+    Object.entries(assets).map(([name, content]) => [
+      name,
+      hashReleaseContent(content),
+    ]),
+  );
+
+const validateRenderedAssets = ({
+  directory,
+  imageRepository,
+  immutableReference,
+}) => {
+  const composePath = path.join(directory, "docker-compose.yml");
+  const envPath = path.join(directory, "example.env");
+  const result = run("docker", [
+    "compose",
+    "--env-file",
+    envPath,
+    "-f",
+    composePath,
+    "config",
+    "--images",
+  ]);
+  const applicationImages = result.stdout
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith(`${imageRepository}:`));
+  if (
+    applicationImages.length !== 2 ||
+    applicationImages.some((image) => image !== immutableReference)
+  ) {
+    throw new Error(
+      `Generated Compose resolves unexpected Staaash images: ${applicationImages.join(", ")}`,
+    );
+  }
+};
+
+const fetchAssetBytes = async (asset) => {
+  const token = requiredEnv("GH_TOKEN");
+  const response = await fetch(asset.url, {
+    headers: {
+      Accept: "application/octet-stream",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Downloading release asset ${asset.name} failed: ${response.status} ${response.statusText}`,
+    );
+  }
+  return Buffer.from(await response.arrayBuffer());
+};
+
+const observedAssetsWithDigests = async (repository, releaseId) => {
+  const assets = getReleaseAssets(repository, releaseId);
+  return Promise.all(
+    assets.map(async (asset) => ({
+      ...asset,
+      digest: asset.digest || sha256(await fetchAssetBytes(asset)),
+    })),
+  );
+};
+
+const verifyRemoteAssets = async ({ context, release, localAssets }) => {
+  const expected = expectedAssetDigests(localAssets);
+  const observed = await observedAssetsWithDigests(
+    context.repository,
+    release.id,
+  );
+  const plan = planReleaseAssets({
+    expected,
+    observed,
+    published: !release.draft,
+  });
+  if (plan.upload.length > 0 || plan.conflicts.length > 0) {
+    throw new Error(
+      `Release assets are incomplete:\n${[
+        ...plan.upload.map((name) => `${name} is missing`),
+        ...plan.conflicts,
+      ].join("\n")}`,
+    );
+  }
+
+  const temporaryDirectory = await mkdtemp(
+    path.join(os.tmpdir(), "staaash-release-assets-"),
+  );
+  try {
+    for (const name of REQUIRED_ASSET_NAMES) {
+      const asset = observed.find((candidate) => candidate.name === name);
+      if (!asset) throw new Error(`Release asset ${name} is missing.`);
+      await writeFile(
+        path.join(temporaryDirectory, name),
+        await fetchAssetBytes(asset),
+      );
+    }
+
+    const downloaded = Object.fromEntries(
+      await Promise.all(
+        REQUIRED_ASSET_NAMES.map(async (name) => [
+          name,
+          await readFile(path.join(temporaryDirectory, name), "utf8"),
+        ]),
+      ),
+    );
+    for (const name of REQUIRED_ASSET_NAMES) {
+      if (downloaded[name] !== localAssets[name]) {
+        throw new Error(
+          `Downloaded release asset ${name} differs from generated file.`,
+        );
+      }
+    }
+    validateRenderedAssets({
+      directory: temporaryDirectory,
+      imageRepository: context.imageRepository,
+      immutableReference: JSON.parse(downloaded["release-manifest.json"]).image
+        .immutableReference,
+    });
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+};
+
+const expectedCompleteProvenance = ({ context, imageDigest, assets }) => {
+  const assetChecksums = expectedAssetDigests(assets);
+  return buildReleaseProvenance({
+    tag: context.release.tag,
+    commit: context.releaseSha,
+    tagObject: context.tagObject,
+    imageDigest,
+    immutableImage: `${context.imageRepository}:${context.release.tag}@${imageDigest}`,
+    assetChecksums,
+  });
+};
+
+const commandPreflight = async () => {
+  const tag = requiredEnv("RELEASE_TAG");
+  const repository = requiredEnv("GITHUB_REPOSITORY");
+  const identity = inspectTagIdentity({
+    tag,
+    expectedReleaseSha: optionalEnv("EXPECTED_RELEASE_SHA"),
+    expectedTagObject: optionalEnv("EXPECTED_TAG_OBJECT"),
+  });
+  const packageVersions = await readPackageVersions();
+  const errors = findCanonicalReleaseVersionErrors({ tag, packageVersions });
+  if (errors.length > 0) throw new Error(errors.join("\n"));
+  const release = parseReleaseTag(tag);
+  const ciRun = await waitForExactCi({
+    repository,
+    releaseSha: identity.releaseSha,
+  });
+  const imageRepository = `ghcr.io/${repository.toLowerCase()}`;
+
+  await writeOutputs([
+    ["tag", release.tag],
+    ["version", release.version],
+    ["prerelease", release.prerelease],
+    ["release_sha", identity.releaseSha],
+    ["tag_object", identity.tagObject],
+    ["tag_type", identity.tagType],
+    ["image_repository", imageRepository],
+    ["ci_run_id", ciRun.id],
+  ]);
+  await writeSummary(
+    `## REL-01 preflight\n\n- Tag: \`${release.tag}\`\n- Commit: \`${identity.releaseSha}\`\n- Exact CI run: \`${ciRun.id}\`\n- Channel: ${release.prerelease ? "prerelease" : "stable"}`,
+  );
+};
+
+const commandVerifyTag = async () => {
+  verifyRecordedTagIdentity(releaseContextFromEnv());
+};
+
+const commandEnsureDraft = async () => {
+  const context = releaseContextFromEnv();
+  verifyRecordedTagIdentity(context);
+  const pending = buildReleaseProvenance({
+    tag: context.release.tag,
+    commit: context.releaseSha,
+    tagObject: context.tagObject,
+    imageDigest: "pending",
+    immutableImage: "pending",
+    assetChecksums: null,
+  });
+  let release = getRelease(context.repository, context.release.tag);
+  if (!release) release = createDraft({ context, provenance: pending });
+  const { provenance } = validateReleaseIdentity({ release, context });
+  if (release.draft && provenance.imageDigest !== "pending") {
+    console.info(
+      "Compatible draft already contains complete image provenance.",
+    );
+  }
+
+  await writeOutputs([
+    ["release_id", release.id],
+    ["published", !release.draft],
+  ]);
+};
+
+const commandInspectImage = async () => {
+  const context = releaseContextFromEnv();
+  verifyRecordedTagIdentity(context);
+  const release = getRelease(context.repository, context.release.tag);
+  if (!release)
+    throw new Error("Draft release must exist before image inspection.");
+  const { provenance } = validateReleaseIdentity({ release, context });
+  const exactReference = `${context.imageRepository}:${context.release.tag}`;
+  const inspected = inspectImage(exactReference, { allowMissing: true });
+  if (!inspected) {
+    if (!release.draft || provenance.imageDigest !== "pending") {
+      throw new Error(
+        "Recorded or published release image is missing from GHCR.",
+      );
+    }
+    await writeOutput("exists", false);
+    await writeOutput("digest", "");
+    return;
+  }
+
+  const expectedDigest =
+    provenance.imageDigest === "pending" ? undefined : provenance.imageDigest;
+  const immutableReference = `${exactReference}@${inspected.digest}`;
+  const observed = readObservedImage(immutableReference);
+  const state = classifyImageState({
+    observed,
+    expected: {
+      digest: expectedDigest,
+      version: context.release.tag,
+      revision: context.releaseSha,
+      source: context.sourceUrl,
+    },
+  });
+  if (state.status !== "matching") {
+    throw new Error(`Existing image conflicts:\n${state.reasons.join("\n")}`);
+  }
+
+  await writeOutputs([
+    ["exists", true],
+    ["digest", observed.digest],
+  ]);
+};
+
+const commandVerifyImage = async () => {
+  const context = releaseContextFromEnv();
+  verifyRecordedTagIdentity(context);
+  const digest = requiredEnv("IMAGE_DIGEST");
+  const { immutableReference } = verifyImage({ context, digest });
+  await writeOutput("immutable_reference", immutableReference);
+};
+
+const commandGenerateAssets = async () => {
+  const context = releaseContextFromEnv();
+  const imageDigest = requiredEnv("IMAGE_DIGEST");
+  verifyImage({ context, digest: imageDigest });
+  const directory = assetDirectory();
+  await rm(directory, { recursive: true, force: true });
+  await mkdir(directory, { recursive: true });
+
+  const versionReference = `${context.release.tag}@${imageDigest}`;
+  const compose = renderReleaseCompose({
+    source: await readFile(path.join(ROOT, "docker-compose.yml"), "utf8"),
+    imageRepository: context.imageRepository,
+    versionReference,
+  });
+  const environment = renderReleaseEnv({
+    source: await readFile(path.join(ROOT, "example.env"), "utf8"),
+    versionReference,
+  });
+  const manifest = serializeReleaseManifest(
+    buildReleaseManifest({
+      release: context.release,
+      repository: context.repository,
+      commit: context.releaseSha,
+      tagObject: context.tagObject,
+      tagType: context.tagType,
+      imageRepository: context.imageRepository,
+      imageDigest,
+    }),
+  );
+  const checksums = buildAssetChecksums({
+    "docker-compose.yml": compose,
+    "example.env": environment,
+    "release-manifest.json": manifest,
+  });
+  const sums = serializeSha256Sums(checksums);
+
+  await Promise.all([
+    writeFile(path.join(directory, "docker-compose.yml"), compose),
+    writeFile(path.join(directory, "example.env"), environment),
+    writeFile(path.join(directory, "release-manifest.json"), manifest),
+    writeFile(path.join(directory, "SHA256SUMS"), sums),
+  ]);
+  validateRenderedAssets({
+    directory,
+    imageRepository: context.imageRepository,
+    immutableReference: `${context.imageRepository}:${versionReference}`,
+  });
+  if (compose.includes(`${context.imageRepository}:latest`)) {
+    throw new Error("Generated Compose contains mutable latest image.");
+  }
+};
+
+const reconcileDraftProvenance = ({
+  context,
+  release,
+  provenance,
+  complete,
+}) => {
+  if (provenance.imageDigest === "pending") {
+    const body = replaceReleaseProvenance({
+      body: release.body ?? "",
+      expected: provenance,
+      next: complete,
+    });
+    return patchRelease(context.repository, release.id, { body });
+  }
+  if (JSON.stringify(provenance) !== JSON.stringify(complete)) {
+    throw new Error(
+      "Draft release provenance conflicts with generated assets.",
+    );
+  }
+  return release;
+};
+
+const uploadMissingDraftAssets = async ({ context, release, localAssets }) => {
+  const plan = planReleaseAssets({
+    expected: expectedAssetDigests(localAssets),
+    observed: await observedAssetsWithDigests(context.repository, release.id),
+    published: false,
+  });
+  if (plan.conflicts.length > 0) {
+    throw new Error(`Draft assets conflict:\n${plan.conflicts.join("\n")}`);
+  }
+  for (const name of plan.upload) {
+    run("gh", [
+      "release",
+      "upload",
+      context.release.tag,
+      path.join(assetDirectory(), name),
+      "--repo",
+      context.repository,
+    ]);
+  }
+  const refreshed = getRelease(context.repository, context.release.tag);
+  if (!refreshed)
+    throw new Error("Draft release disappeared after asset upload.");
+  return refreshed;
+};
+
+const reconcileDraftRelease = async ({
+  context,
+  release,
+  provenance,
+  complete,
+  localAssets,
+}) => {
+  const updated = reconcileDraftProvenance({
+    context,
+    release,
+    provenance,
+    complete,
+  });
+  return uploadMissingDraftAssets({
+    context,
+    release: updated,
+    localAssets,
+  });
+};
+
+const verifyCompleteProvenance = ({ provenance, complete, published }) => {
+  if (JSON.stringify(provenance) === JSON.stringify(complete)) return;
+  throw new Error(
+    `${published ? "Published" : "Draft"} release provenance conflicts with generated assets.`,
+  );
+};
+
+const commandReconcileRelease = async () => {
+  const context = releaseContextFromEnv();
+  const imageDigest = requiredEnv("IMAGE_DIGEST");
+  verifyRecordedTagIdentity(context);
+  const localAssets = await generatedAssets();
+  let release = getRelease(context.repository, context.release.tag);
+  if (!release) throw new Error("Draft release is missing.");
+  const { provenance } = validateReleaseIdentity({ release, context });
+  const complete = expectedCompleteProvenance({
+    context,
+    imageDigest,
+    assets: localAssets,
+  });
+
+  if (release.draft) {
+    release = await reconcileDraftRelease({
+      context,
+      release,
+      provenance,
+      complete,
+      localAssets,
+    });
+  } else {
+    verifyCompleteProvenance({ provenance, complete, published: true });
+  }
+  await verifyRemoteAssets({ context, release, localAssets });
+};
+
+const commandPublish = async () => {
+  const context = releaseContextFromEnv();
+  const imageDigest = requiredEnv("IMAGE_DIGEST");
+  verifyRecordedTagIdentity(context);
+  verifyImage({ context, digest: imageDigest });
+  const localAssets = await generatedAssets();
+  let release = getRelease(context.repository, context.release.tag);
+  if (!release) throw new Error("Release is missing before publication.");
+  const { provenance } = validateReleaseIdentity({ release, context });
+  const complete = expectedCompleteProvenance({
+    context,
+    imageDigest,
+    assets: localAssets,
+  });
+  if (JSON.stringify(provenance) !== JSON.stringify(complete)) {
+    throw new Error("Release provenance is incomplete before publication.");
+  }
+  await verifyRemoteAssets({ context, release, localAssets });
+  verifyRecordedTagIdentity(context);
+
+  if (release.draft) {
+    release = patchRelease(context.repository, release.id, {
+      draft: false,
+      prerelease: context.release.prerelease,
+      make_latest: "false",
+    });
+  }
+  if (release.draft) throw new Error("GitHub Release remained a draft.");
+  validateReleaseIdentity({ release, context });
+  await verifyRemoteAssets({ context, release, localAssets });
+  verifyRecordedTagIdentity(context);
+};
+
+const handlePrereleaseLatest = async ({ context, imageDigest }) => {
+  const plan = planLatestPromotion({
+    candidateVersion: context.release.version,
+    candidateDigest: imageDigest,
+    candidateRevision: context.releaseSha,
+    latest: null,
+  });
+  if (plan.action !== "skip-prerelease") {
+    throw new Error("Prerelease unexpectedly reached latest promotion.");
+  }
+  await writeSummary("## Docker `latest`\n\nPrerelease: promotion prohibited.");
+};
+
+const requirePublishedRelease = (context) => {
+  const release = getRelease(context.repository, context.release.tag);
+  if (!release || release.draft) {
+    throw new Error("Stable GitHub Release must be published before latest.");
+  }
+  validateReleaseIdentity({ release, context });
+  return release;
+};
+
+const toLatestImage = (inspected) =>
+  inspected
+    ? {
+        digest: inspected.digest,
+        version: inspected.labels["org.opencontainers.image.version"] ?? null,
+        revision: inspected.labels["org.opencontainers.image.revision"] ?? null,
+      }
+    : null;
+
+const applyLatestPlan = ({
+  plan,
+  latestReference,
+  imageRepository,
+  imageDigest,
+}) => {
+  if (plan.action === "conflict") throw new Error(plan.reason);
+  if (plan.action !== "promote") return;
+  run("docker", [
+    "buildx",
+    "imagetools",
+    "create",
+    "--tag",
+    latestReference,
+    `${imageRepository}@${imageDigest}`,
+  ]);
+};
+
+const verifyLatestResult = ({
+  plan,
+  previousLatest,
+  finalLatest,
+  imageDigest,
+}) => {
+  const expectedDigest =
+    plan.action === "superseded" ? previousLatest?.digest : imageDigest;
+  if (finalLatest.digest !== expectedDigest) {
+    throw new Error(
+      `Latest resolves to ${finalLatest.digest}; expected ${expectedDigest}.`,
+    );
+  }
+};
+
+const markGitHubReleaseLatest = ({ context, release, plan }) => {
+  if (plan.action === "superseded") return;
+  patchRelease(context.repository, release.id, { make_latest: "true" });
+  const latestRelease = ghApi(`repos/${context.repository}/releases/latest`);
+  if (latestRelease.tag_name !== context.release.tag) {
+    throw new Error(
+      `GitHub latest release is ${latestRelease.tag_name}; expected ${context.release.tag}.`,
+    );
+  }
+};
+
+const promoteStableLatest = async ({ context, imageDigest }) => {
+  verifyRecordedTagIdentity(context);
+  const release = requirePublishedRelease(context);
+  verifyImage({ context, digest: imageDigest });
+
+  const latestReference = `${context.imageRepository}:latest`;
+  const previousLatest = toLatestImage(
+    inspectImage(latestReference, { allowMissing: true }),
+  );
+  const plan = planLatestPromotion({
+    candidateVersion: context.release.version,
+    candidateDigest: imageDigest,
+    candidateRevision: context.releaseSha,
+    latest: previousLatest,
+  });
+  verifyRecordedTagIdentity(context);
+  applyLatestPlan({
+    plan,
+    latestReference,
+    imageRepository: context.imageRepository,
+    imageDigest,
+  });
+  const finalLatest = inspectImage(latestReference);
+  verifyLatestResult({ plan, previousLatest, finalLatest, imageDigest });
+  verifyRecordedTagIdentity(context);
+  markGitHubReleaseLatest({ context, release, plan });
+  verifyRecordedTagIdentity(context);
+  await writeSummary(
+    `## Docker \`latest\`\n\nAction: \`${plan.action}\`\nDigest: \`${finalLatest.digest}\``,
+  );
+};
+
+const commandPromoteLatest = async () => {
+  const context = releaseContextFromEnv();
+  const imageDigest = requiredEnv("IMAGE_DIGEST");
+  return context.release.prerelease
+    ? handlePrereleaseLatest({ context, imageDigest })
+    : promoteStableLatest({ context, imageDigest });
+};
+
+const commandSummary = async () => {
+  const tag = optionalEnv("RELEASE_TAG") || "unknown";
+  const result = optionalEnv("RELEASE_RESULT") || "unknown";
+  await writeSummary(
+    `## Release recovery\n\nResult: **${result}**\n\nTag: \`${tag}\`\n\n- Retry matching partial state with **Run workflow** and the same existing tag.\n- Do not move/delete the tag, clobber assets, or overwrite a conflicting image.\n- Conflicts require manual comparison of reported expected and actual SHA/digest values.`,
+  );
+};
+
+const commands = {
+  preflight: commandPreflight,
+  "verify-tag": commandVerifyTag,
+  "ensure-draft": commandEnsureDraft,
+  "inspect-image": commandInspectImage,
+  "verify-image": commandVerifyImage,
+  "generate-assets": commandGenerateAssets,
+  "reconcile-release": commandReconcileRelease,
+  publish: commandPublish,
+  "promote-latest": commandPromoteLatest,
+  summary: commandSummary,
+};
+
+const command = process.argv[2];
+if (!command || !(command in commands)) {
+  throw new Error(`Unknown release command: ${command ?? "missing"}`);
+}
+
+try {
+  await commands[command]();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  await writeSummary(
+    `## REL-01 failure\n\n\`\`\`text\n${message}\n\`\`\`\n\nRetry matching partial state with **Run workflow** and the same existing tag. Do not move/delete the tag, clobber assets, or overwrite a conflicting image. Conflicts require manual comparison of reported expected and actual SHA/digest values.`,
+  );
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## 🚀 Summary

Implements audit finding REL-01 with a fail-closed, exact-SHA release process.

- Requires successful `CI` main-push validation for the exact tag commit before any remote write.
- Verifies canonical tag/package versions, tag identity, main ancestry, OCI index digest, image labels, and final web/worker runtime versions.
- Reconciles matching partial state while blocking conflicting images, provenance, assets, tags, or published releases.
- Generates release-specific `docker-compose.yml`, `example.env`, `release-manifest.json`, and `SHA256SUMS` assets.
- Publishes GitHub Releases only after image and asset verification.
- Keeps every SemVer prerelease away from both Docker and GitHub latest channels.
- Promotes stable `latest` from the verified digest without rebuilding.

## 📊 Impacts and Changes

Release operations become globally serialized and recoverable through `workflow_dispatch` using the same immutable tag.

Normal installation assets select the exact readable release tag, such as `v1.2.3`. Ordinary upgrades change `STAAASH_VERSION` from the old exact tag to the new exact tag before pulling and restarting.

`release-manifest.json` records the workflow-verified immutable `tag@digest` image reference, while `SHA256SUMS` and digest pinning remain optional for advanced users. Internally, the workflow still verifies the OCI index digest and binds the tag, commit, image metadata, runtime versions, release provenance, and assets to the same release identity.

No schema, auth, application storage, or restore behavior changes. Alpha/beta releases remain unsupported development history requiring fresh installation. STO-02 remains out of scope.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment. (Not applicable: no UI change.)

Additional checks:

- [x] `pnpm format:check`
- [x] `pnpm quality:fallow`
- [x] `git diff --check`
- [x] Release CLI syntax check
- [x] PostgreSQL 18 integration suite: 23/23 passed in isolated Linux Docker
- [x] Web and worker built-runtime version smokes
- [x] Normal exact-tag Compose resolution
- [x] Optional immutable `tag@digest` Compose override
- [x] Read-only review findings resolved

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

Required before closing REL-01 or using this workflow for a production release:

- Run controlled publication and retry rehearsal in a disposable repository with a separate GHCR package.
- Enable a `refs/tags/v*` ruleset that blocks tag updates and deletion.
- Do not run rehearsal tags, images, or releases against `itsmeares/staaash`.

Native Windows PostgreSQL tests hit the existing physical-headroom guard because the host C: drive had 9.35% free space; the same suite passed fully in an isolated Linux Docker filesystem with sufficient headroom.

## 🔗 Linked Issues

REL-01 audit finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)