### PR TITLE
chore(release): bump version to 1.0.0-rc.7

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.7",
   "private": true,
   "scripts": {
     "build:deps": "pnpm --filter @staaash/config build && pnpm --filter @staaash/db build",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worker",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "staaash",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.7",
   "description": "Self-hosted personal cloud drive monorepo.",
   "private": true,
   "license": "AGPL-3.0-only",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@staaash/config",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.7",
   "private": true,
   "type": "module",
   "files": [

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@staaash/db",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.7",
   "private": true,
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary

- bump normalized release version from `1.0.0-rc.6` to `1.0.0-rc.7`
- update only five canonical package version files
- leave lockfile and release architecture unchanged

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm format:check`
- `pnpm lint`
- `pnpm quality:fallow`
- `pnpm test`
- `pnpm test:postgres`
- `pnpm build`
- web runtime-version smoke
- worker runtime-version smoke
- exact canonical-version assertion
- `git diff --check`

PostgreSQL tests passed with temporary storage on WSL filesystem because host C: volume had 8.33% free space, below application 10% safety floor.

No tag, GitHub Release, GHCR image, or manual Release workflow run created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)