### PR TITLE
fix(release): upload draft assets by release ID

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -23,21 +23,26 @@ Alpha and beta releases remain unsupported development history. Their prerelease
 
 `.github/workflows/release.yml` globally queues releases and performs:
 
-1. Resolve the tag object and peeled commit; require the commit on current `main`.
-2. Verify all package versions and a successful exact-SHA `CI` main-push run.
-3. Create or verify a hidden draft GitHub Release with generated notes and managed provenance.
-4. Build the exact versioned image once, or reuse a matching existing image.
-5. Capture and remotely verify the top-level OCI index digest, OCI labels, and final web/worker runtime versions.
-6. Generate release-specific `docker-compose.yml`, `example.env`, `release-manifest.json`, and `SHA256SUMS`.
-7. Reconcile missing draft assets without overwriting mismatched assets.
-8. Publish the GitHub Release after every exact artifact check passes.
-9. For stable releases only, copy the verified OCI index digest to `latest` without rebuilding, verify it, then mark the same GitHub Release as latest.
+1. Select immutable tooling and source checkouts. Tag pushes use tooling committed in the release tag. Manual recovery uses the exact reviewed `main` commit that defined the dispatched workflow. Release source always comes from the requested tag.
+2. Resolve the tag object and peeled commit; require the commit on current `main`.
+3. Verify all package versions plus successful exact-SHA `CI` main-push runs for the release commit and, when different during recovery, the tooling commit.
+4. Create or verify a hidden draft GitHub Release with generated notes and managed provenance.
+5. Build the exact versioned image once, or reuse a matching existing image.
+6. Capture and remotely verify the top-level OCI index digest, OCI labels, and final web/worker runtime versions.
+7. Generate release-specific `docker-compose.yml`, `example.env`, `release-manifest.json`, and `SHA256SUMS`.
+8. Reconcile missing draft assets without overwriting mismatched assets.
+9. Publish the GitHub Release after every exact artifact check passes.
+10. For stable releases only, copy the verified OCI index digest to `latest` without rebuilding, verify it, then mark the same GitHub Release as latest.
 
 Every SemVer prerelease skips both latest-channel mutations. A stable release is complete and installable through exact-tag assets before `latest` promotion starts; its verified digest remains recorded in manifest and provenance metadata.
 
 ## Recovery
 
-Use **Actions → Release → Run workflow** with the same existing tag. Never move or recreate the tag to retry.
+Use **Actions → Release → Run workflow** from `main` with the same existing tag. Never dispatch recovery from another branch, and never move or recreate the tag to retry.
+
+Manual recovery records the exact `main` commit selected by GitHub as the recovery-tooling SHA and requires a successful exact-SHA `CI` main-push run for it. The orchestrator and compiled release policy run from that immutable tooling checkout. Package versions, Git identity, templates, Docker build context, generated assets, image labels, and release provenance remain sourced from the separate immutable release-tag checkout. Workflow summaries report both the tag object/peeled release commit and the recovery-tooling commit.
+
+A tag-push release does not substitute newer tooling: its tooling checkout and release source both come from the pushed tag, and preflight requires the tooling commit to equal the peeled release commit.
 
 Matching partial state is resumed:
 
@@ -76,7 +81,7 @@ Release-generated Compose and env files select the exact readable tag:
 ghcr.io/itsmeares/staaash:<tag>
 ```
 
-`release-manifest.json` records tag object, commit SHA, image repository, verified OCI index digest, full immutable reference, platform, and OCI labels. `SHA256SUMS` covers Compose, env, and manifest files. The workflow validates both the normal tag selection and an optional `STAAASH_VERSION=<tag>@sha256:<digest>` override. Source files on `main` remain templates and are never uploaded directly as release assets.
+`release-manifest.json` records tag object, commit SHA, image repository, verified OCI index digest, full immutable reference, platform, and OCI labels. `SHA256SUMS` covers Compose, env, and manifest files. The workflow validates both the normal tag selection and an optional `STAAASH_VERSION=<tag>@sha256:<digest>` override. Source files in the immutable release-tag checkout remain templates and are never uploaded directly as release assets.
 
 ## Controlled rehearsal
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,19 +30,53 @@ jobs:
       tag_object: ${{ steps.preflight.outputs.tag_object }}
       tag_type: ${{ steps.preflight.outputs.tag_type }}
       image_repository: ${{ steps.preflight.outputs.image_repository }}
+      release_ci_run_id: ${{ steps.preflight.outputs.release_ci_run_id }}
+      tooling_sha: ${{ steps.preflight.outputs.tooling_sha }}
+      tooling_ci_run_id: ${{ steps.preflight.outputs.tooling_ci_run_id }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
       EXPECTED_RELEASE_SHA: ${{ github.event_name == 'push' && github.sha || '' }}
       EXPECTED_TAG_OBJECT: ${{ github.event_name == 'push' && github.event.after || '' }}
+      EXPECTED_TOOLING_SHA: ${{ github.event_name == 'workflow_dispatch' && github.sha || '' }}
+      RELEASE_EVENT_NAME: ${{ github.event_name }}
+      RECOVERY_REF: ${{ github.ref }}
+      TOOLING_ROOT: ${{ github.workspace }}/tooling
+      RELEASE_SOURCE_ROOT: ${{ github.workspace }}/release-source
       CI_WAIT_SECONDS: "1800"
       CI_POLL_SECONDS: "15"
 
     steps:
-      - uses: actions/checkout@v7
+      - name: Require recovery dispatch from main
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+        run: |
+          echo "Release recovery must be dispatched from refs/heads/main." >&2
+          exit 1
+
+      - name: Check out exact release tooling
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          path: tooling
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || env.RELEASE_TAG }}
+
+      - name: Check out immutable release source
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          path: release-source
           ref: ${{ env.RELEASE_TAG }}
+
+      - name: Capture exact tooling commit
+        id: tooling
+        shell: bash
+        run: |
+          SHA="$(git -C "$TOOLING_ROOT" rev-parse HEAD)"
+          if [[ ! "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid tooling commit: $SHA" >&2
+            exit 1
+          fi
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-node@v7
         with:
@@ -52,17 +86,22 @@ jobs:
         run: corepack enable
 
       - name: Install pinned pnpm
+        working-directory: tooling
         run: corepack install
 
-      - name: Install dependencies
+      - name: Install tooling dependencies
+        working-directory: tooling
         run: pnpm install --frozen-lockfile
 
       - name: Build release policy
+        working-directory: tooling
         run: pnpm --filter @staaash/config build
 
-      - name: Verify tag, packages, and exact CI
+      - name: Verify tag, packages, tooling, and exact CI
         id: preflight
-        run: node scripts/release/index.mjs preflight
+        env:
+          TOOLING_SHA: ${{ steps.tooling.outputs.sha }}
+        run: node tooling/scripts/release/index.mjs preflight
 
   publish:
     needs: preflight
@@ -81,13 +120,34 @@ jobs:
       TAG_OBJECT_SHA: ${{ needs.preflight.outputs.tag_object }}
       TAG_TYPE: ${{ needs.preflight.outputs.tag_type }}
       IMAGE_REPOSITORY: ${{ needs.preflight.outputs.image_repository }}
-      ASSET_DIR: .release-assets
+      TOOLING_SHA: ${{ needs.preflight.outputs.tooling_sha }}
+      TOOLING_ROOT: ${{ github.workspace }}/tooling
+      RELEASE_SOURCE_ROOT: ${{ github.workspace }}/release-source
+      ASSET_DIR: ${{ github.workspace }}/release-assets
 
     steps:
-      - uses: actions/checkout@v7
+      - name: Check out verified release tooling
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          path: tooling
+          ref: ${{ needs.preflight.outputs.tooling_sha }}
+
+      - name: Check out immutable release source
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          path: release-source
           ref: ${{ env.RELEASE_TAG }}
+
+      - name: Verify exact tooling checkout
+        shell: bash
+        run: |
+          ACTUAL="$(git -C "$TOOLING_ROOT" rev-parse HEAD)"
+          if [[ "$ACTUAL" != "$TOOLING_SHA" ]]; then
+            echo "Tooling checkout is $ACTUAL; expected $TOOLING_SHA." >&2
+            exit 1
+          fi
 
       - uses: actions/setup-node@v7
         with:
@@ -97,19 +157,22 @@ jobs:
         run: corepack enable
 
       - name: Install pinned pnpm
+        working-directory: tooling
         run: corepack install
 
-      - name: Install dependencies
+      - name: Install tooling dependencies
+        working-directory: tooling
         run: pnpm install --frozen-lockfile
 
       - name: Build release policy
+        working-directory: tooling
         run: pnpm --filter @staaash/config build
 
-      - name: Recheck immutable tag identity
-        run: node scripts/release/index.mjs verify-tag
+      - name: Recheck immutable tooling and tag identity
+        run: node tooling/scripts/release/index.mjs verify-tag
 
       - name: Create or verify draft release
-        run: node scripts/release/index.mjs ensure-draft
+        run: node tooling/scripts/release/index.mjs ensure-draft
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -123,14 +186,14 @@ jobs:
 
       - name: Inspect existing versioned image
         id: image
-        run: node scripts/release/index.mjs inspect-image
+        run: node tooling/scripts/release/index.mjs inspect-image
 
       - name: Build and push exact versioned image
         id: build
         if: steps.image.outputs.exists != 'true'
         uses: docker/build-push-action@v7
         with:
-          context: .
+          context: ${{ env.RELEASE_SOURCE_ROOT }}
           push: true
           platforms: linux/amd64
           tags: ${{ env.IMAGE_REPOSITORY }}:${{ env.RELEASE_TAG }}
@@ -162,36 +225,36 @@ jobs:
       - name: Verify exact image digest and runtime versions
         env:
           IMAGE_DIGEST: ${{ steps.digest.outputs.value }}
-        run: node scripts/release/index.mjs verify-image
+        run: node tooling/scripts/release/index.mjs verify-image
 
       - name: Generate release-specific installation assets
         env:
           IMAGE_DIGEST: ${{ steps.digest.outputs.value }}
-        run: node scripts/release/index.mjs generate-assets
+        run: node tooling/scripts/release/index.mjs generate-assets
 
       - name: Reconcile draft notes and assets
         env:
           IMAGE_DIGEST: ${{ steps.digest.outputs.value }}
-        run: node scripts/release/index.mjs reconcile-release
+        run: node tooling/scripts/release/index.mjs reconcile-release
 
       - name: Publish verified GitHub Release
         env:
           IMAGE_DIGEST: ${{ steps.digest.outputs.value }}
-        run: node scripts/release/index.mjs publish
+        run: node tooling/scripts/release/index.mjs publish
 
       - name: Promote stable digest to latest
         env:
           IMAGE_DIGEST: ${{ steps.digest.outputs.value }}
-        run: node scripts/release/index.mjs promote-latest
+        run: node tooling/scripts/release/index.mjs promote-latest
 
       - name: Clean runner release assets
         if: always()
         shell: bash
-        run: rm -rf .release-assets
+        run: rm -rf "$ASSET_DIR"
 
       - name: Write retry and investigation summary
         if: always()
         continue-on-error: true
         env:
           RELEASE_RESULT: ${{ job.status }}
-        run: node scripts/release/index.mjs summary
+        run: node tooling/scripts/release/index.mjs summary

--- a/packages/config/test/release-orchestrator.test.ts
+++ b/packages/config/test/release-orchestrator.test.ts
@@ -1,0 +1,251 @@
+import { createHash } from "node:crypto";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  reconcileReleaseAssets,
+  releaseAssetUploadUrl,
+  uploadMissingDraftAssets,
+  uploadReleaseAsset,
+} from "../../../scripts/release/index.mjs";
+
+const localAssets = {
+  "docker-compose.yml": "compose\n",
+  "example.env": "environment\n",
+  "release-manifest.json": "{}\n",
+  SHA256SUMS: "checksums\n",
+};
+
+const digest = (content: string) =>
+  `sha256:${createHash("sha256").update(content).digest("hex")}`;
+
+const context = {
+  repository: "itsmeares/staaash",
+  release: { tag: "v1.0.0-rc.7" },
+};
+
+const release = {
+  id: 42,
+  draft: true,
+  upload_url:
+    "https://uploads.github.com/repos/itsmeares/staaash/releases/42/assets{?name,label}",
+};
+
+const complete = {
+  tag: "v1.0.0-rc.7",
+  commit: "1".repeat(40),
+  tagObject: "2".repeat(40),
+  imageDigest: `sha256:${"a".repeat(64)}`,
+  immutableImage: `ghcr.io/itsmeares/staaash:v1.0.0-rc.7@sha256:${"a".repeat(64)}`,
+  assetChecksums: {},
+};
+
+describe("release asset upload orchestration", () => {
+  it("constructs a release-specific upload URL with RFC 3986 encoding", () => {
+    expect(
+      releaseAssetUploadUrl({
+        release,
+        name: "release notes +#?%☃!'()*",
+      }),
+    ).toBe(
+      "https://uploads.github.com/repos/itsmeares/staaash/releases/42/assets?name=release%20notes%20%2B%23%3F%25%E2%98%83%21%27%28%29%2A",
+    );
+
+    expect(() =>
+      releaseAssetUploadUrl({
+        release: {
+          ...release,
+          upload_url:
+            "https://uploads.github.com/repos/itsmeares/staaash/releases/41/assets{?name,label}",
+        },
+        name: "asset.txt",
+      }),
+    ).toThrow("invalid asset upload URL");
+    expect(() =>
+      releaseAssetUploadUrl({
+        release: {
+          ...release,
+          upload_url:
+            "https://example.com/repos/itsmeares/staaash/releases/42/assets{?name,label}",
+        },
+        name: "asset.txt",
+      }),
+    ).toThrow("invalid asset upload URL");
+  });
+
+  it("uploads raw bytes with required GitHub headers and verifies response", async () => {
+    const content = Buffer.from("asset bytes");
+    const fetchImpl = vi.fn(async (_url: string, options: RequestInit) => {
+      expect(options).toEqual(
+        expect.objectContaining({
+          method: "POST",
+          body: content,
+          headers: {
+            Accept: "application/vnd.github+json",
+            Authorization: "Bearer token",
+            "Content-Type": "application/octet-stream",
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+        }),
+      );
+      return new Response(
+        JSON.stringify({
+          id: 7,
+          url: "https://api.github.com/repos/itsmeares/staaash/releases/assets/7",
+          name: "asset.bin",
+          state: "uploaded",
+          size: content.byteLength,
+        }),
+        { status: 201 },
+      );
+    });
+
+    await expect(
+      uploadReleaseAsset({
+        release,
+        name: "asset.bin",
+        filePath: "unused",
+        token: "token",
+        fetchImpl,
+        readAsset: async () => content,
+      }),
+    ).resolves.toEqual(expect.objectContaining({ id: 7, name: "asset.bin" }));
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://uploads.github.com/repos/itsmeares/staaash/releases/42/assets?name=asset.bin",
+      expect.any(Object),
+    );
+  });
+
+  it("uploads only missing assets without clobbering or deleting", async () => {
+    const uploaded: string[] = [];
+    const refreshed = { ...release, body: "refreshed" };
+    const uploadAsset = vi.fn(async ({ name }: { name: string }) => {
+      uploaded.push(name);
+    });
+    const refreshRelease = vi.fn(() => refreshed);
+
+    await expect(
+      uploadMissingDraftAssets({
+        context,
+        release,
+        localAssets,
+        observeAssets: async () => [
+          {
+            name: "docker-compose.yml",
+            digest: digest(localAssets["docker-compose.yml"]),
+          },
+          {
+            name: "release-manifest.json",
+            digest: digest(localAssets["release-manifest.json"]),
+          },
+        ],
+        uploadAsset,
+        refreshRelease,
+      }),
+    ).resolves.toBe(refreshed);
+
+    expect(uploaded).toEqual(["example.env", "SHA256SUMS"]);
+    expect(uploadAsset).toHaveBeenCalledTimes(2);
+    expect(refreshRelease).toHaveBeenCalledOnce();
+  });
+
+  it("keeps HTTP upload failures fail-closed with useful diagnostics", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          '{"message":"validation failed"}\nunsafe' +
+            String.fromCharCode(0) +
+            "text",
+          {
+            status: 422,
+            statusText: "Unprocessable Content",
+          },
+        ),
+    );
+
+    await expect(
+      uploadReleaseAsset({
+        release,
+        name: "example.env",
+        filePath: "unused",
+        token: "token",
+        fetchImpl,
+        readAsset: async () => Buffer.from("content"),
+      }),
+    ).rejects.toThrow(
+      'Uploading release asset example.env failed: HTTP 422 {"message":"validation failed"} unsafe text',
+    );
+  });
+
+  it("verifies remote assets after successful missing-asset upload", async () => {
+    const events: string[] = [];
+    const refreshed = { ...release, body: "refreshed" };
+
+    await expect(
+      reconcileReleaseAssets({
+        context,
+        release,
+        provenance: complete,
+        complete,
+        localAssets,
+        uploadOptions: {
+          observeAssets: async () => {
+            events.push("inspect");
+            return Object.entries(localAssets)
+              .filter(([name]) => name !== "example.env")
+              .map(([name, content]) => ({ name, digest: digest(content) }));
+          },
+          uploadAsset: async ({ name }: { name: string }) => {
+            events.push(`upload:${name}`);
+          },
+          refreshRelease: () => {
+            events.push("refresh");
+            return refreshed;
+          },
+        },
+        verifyAssets: async ({ release: verifiedRelease }) => {
+          expect(verifiedRelease).toBe(refreshed);
+          events.push("verify");
+        },
+      }),
+    ).resolves.toBe(refreshed);
+
+    expect(events).toEqual([
+      "inspect",
+      "upload:example.env",
+      "refresh",
+      "verify",
+    ]);
+  });
+
+  it("blocks conflicting assets before upload, refresh, or verification", async () => {
+    const uploadAsset = vi.fn();
+    const refreshRelease = vi.fn();
+    const verifyAssets = vi.fn();
+
+    await expect(
+      reconcileReleaseAssets({
+        context,
+        release,
+        provenance: complete,
+        complete,
+        localAssets,
+        uploadOptions: {
+          observeAssets: async () => [
+            {
+              name: "docker-compose.yml",
+              digest: `sha256:${"f".repeat(64)}`,
+            },
+          ],
+          uploadAsset,
+          refreshRelease,
+        },
+        verifyAssets,
+      }),
+    ).rejects.toThrow("Draft assets conflict");
+
+    expect(uploadAsset).not.toHaveBeenCalled();
+    expect(refreshRelease).not.toHaveBeenCalled();
+    expect(verifyAssets).not.toHaveBeenCalled();
+  });
+});

--- a/packages/config/test/release-orchestrator.test.ts
+++ b/packages/config/test/release-orchestrator.test.ts
@@ -1,12 +1,23 @@
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  assetDirectory,
+  readPackageVersions,
+  readReleaseTemplates,
   reconcileReleaseAssets,
   releaseAssetUploadUrl,
+  resolveTagIdentity,
   uploadMissingDraftAssets,
   uploadReleaseAsset,
+  verifyPreflightToolingIdentity,
+  waitForRequiredCi,
 } from "../../../scripts/release/index.mjs";
 
 const localAssets = {
@@ -39,6 +50,163 @@ const complete = {
   immutableImage: `ghcr.io/itsmeares/staaash:v1.0.0-rc.7@sha256:${"a".repeat(64)}`,
   assetChecksums: {},
 };
+
+const repositoryRoot = fileURLToPath(new URL("../../../", import.meta.url));
+
+const git = (cwd: string, ...args: string[]) => {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  if (result.status !== 0) throw new Error(result.stderr || result.stdout);
+  return result.stdout.trim();
+};
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("release trust roots", () => {
+  it("reads package versions and templates only from release source", async () => {
+    const sourceRoot = await mkdtemp(path.join(os.tmpdir(), "release-source-"));
+    try {
+      const packageFiles = [
+        "package.json",
+        "apps/web/package.json",
+        "apps/worker/package.json",
+        "packages/config/package.json",
+        "packages/db/package.json",
+      ];
+      await Promise.all(
+        packageFiles.map(async (file, index) => {
+          const target = path.join(sourceRoot, file);
+          await mkdir(path.dirname(target), { recursive: true });
+          await writeFile(
+            target,
+            JSON.stringify({ version: `source-${index}` }),
+          );
+        }),
+      );
+      await writeFile(
+        path.join(sourceRoot, "docker-compose.yml"),
+        "source compose\n",
+      );
+      await writeFile(path.join(sourceRoot, "example.env"), "source env\n");
+
+      await expect(readPackageVersions(sourceRoot)).resolves.toEqual({
+        root: "source-0",
+        web: "source-1",
+        worker: "source-2",
+        config: "source-3",
+        db: "source-4",
+      });
+      await expect(readReleaseTemplates(sourceRoot)).resolves.toEqual({
+        compose: "source compose\n",
+        environment: "source env\n",
+      });
+    } finally {
+      await rm(sourceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("runs release Git identity against release source checkout", async () => {
+    const sourceRoot = await mkdtemp(path.join(os.tmpdir(), "release-git-"));
+    try {
+      git(sourceRoot, "init");
+      git(sourceRoot, "config", "user.name", "Release Test");
+      git(sourceRoot, "config", "user.email", "release@example.com");
+      await writeFile(path.join(sourceRoot, "source.txt"), "tagged source\n");
+      git(sourceRoot, "add", "source.txt");
+      git(sourceRoot, "commit", "-m", "tagged source");
+      git(sourceRoot, "tag", "-a", "v1.2.3", "-m", "v1.2.3");
+      vi.stubEnv("RELEASE_SOURCE_ROOT", sourceRoot);
+
+      expect(resolveTagIdentity("v1.2.3")).toEqual({
+        tagObject: git(sourceRoot, "rev-parse", "refs/tags/v1.2.3"),
+        releaseSha: git(sourceRoot, "rev-parse", "HEAD"),
+        tagType: "annotated",
+      });
+    } finally {
+      await rm(sourceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("requires exact CI for release and distinct recovery tooling commits", async () => {
+    const waitForCi = vi.fn(async ({ releaseSha }: { releaseSha: string }) => ({
+      id: releaseSha,
+    }));
+
+    await expect(
+      waitForRequiredCi({
+        repository: "itsmeares/staaash",
+        releaseSha: "1".repeat(40),
+        toolingSha: "2".repeat(40),
+        waitForCi,
+      }),
+    ).resolves.toEqual({
+      releaseCiRun: { id: "1".repeat(40) },
+      toolingCiRun: { id: "2".repeat(40) },
+    });
+    expect(waitForCi).toHaveBeenCalledTimes(2);
+
+    waitForCi.mockClear();
+    await waitForRequiredCi({
+      repository: "itsmeares/staaash",
+      releaseSha: "1".repeat(40),
+      toolingSha: "1".repeat(40),
+      waitForCi,
+    });
+    expect(waitForCi).toHaveBeenCalledOnce();
+  });
+
+  it("requires absolute asset output and exact main recovery tooling", () => {
+    vi.stubEnv("ASSET_DIR", "relative-assets");
+    expect(() => assetDirectory()).toThrow(
+      "ASSET_DIR must be an absolute path",
+    );
+
+    const absoluteAssets = path.join(repositoryRoot, "release-assets");
+    vi.stubEnv("ASSET_DIR", absoluteAssets);
+    expect(assetDirectory()).toBe(path.normalize(absoluteAssets));
+
+    const toolingSha = git(repositoryRoot, "rev-parse", "HEAD");
+    vi.stubEnv("TOOLING_ROOT", repositoryRoot);
+    vi.stubEnv("RELEASE_EVENT_NAME", "workflow_dispatch");
+    vi.stubEnv("RECOVERY_REF", "refs/heads/main");
+    vi.stubEnv("EXPECTED_TOOLING_SHA", toolingSha);
+    expect(() =>
+      verifyPreflightToolingIdentity({
+        toolingSha,
+        releaseSha: "1".repeat(40),
+      }),
+    ).not.toThrow();
+
+    vi.stubEnv("RECOVERY_REF", "refs/heads/hotfix");
+    expect(() =>
+      verifyPreflightToolingIdentity({
+        toolingSha,
+        releaseSha: "1".repeat(40),
+      }),
+    ).toThrow("expected refs/heads/main");
+
+    vi.stubEnv("RECOVERY_REF", "refs/heads/main");
+    vi.stubEnv("EXPECTED_TOOLING_SHA", "2".repeat(40));
+    expect(() =>
+      verifyPreflightToolingIdentity({
+        toolingSha,
+        releaseSha: "1".repeat(40),
+      }),
+    ).toThrow("Recovery tooling is");
+
+    vi.stubEnv("RELEASE_EVENT_NAME", "push");
+    expect(() =>
+      verifyPreflightToolingIdentity({ toolingSha, releaseSha: toolingSha }),
+    ).not.toThrow();
+    expect(() =>
+      verifyPreflightToolingIdentity({
+        toolingSha,
+        releaseSha: "1".repeat(40),
+      }),
+    ).toThrow("Tag-push tooling is");
+  });
+});
 
 describe("release asset upload orchestration", () => {
   it("constructs a release-specific upload URL with RFC 3986 encoding", () => {
@@ -141,6 +309,7 @@ describe("release asset upload orchestration", () => {
         ],
         uploadAsset,
         refreshRelease,
+        assetRoot: () => repositoryRoot,
       }),
     ).resolves.toBe(refreshed);
 
@@ -177,6 +346,46 @@ describe("release asset upload orchestration", () => {
     );
   });
 
+  it("wraps network failures with sanitized asset context", async () => {
+    const token = "secret-token";
+    await expect(
+      uploadReleaseAsset({
+        release,
+        name: "example.env",
+        filePath: "unused",
+        token,
+        fetchImpl: async () => {
+          throw new Error(`socket${String.fromCharCode(0)} failed ${token}`);
+        },
+        readAsset: async () => Buffer.from("content"),
+      }),
+    ).rejects.toThrow(
+      "Uploading release asset example.env failed during network request: socket  failed [redacted]",
+    );
+  });
+
+  it("wraps response body read failures with asset context", async () => {
+    const response = {
+      status: 502,
+      text: async () => {
+        throw new Error("body stream aborted");
+      },
+    } as unknown as Response;
+
+    await expect(
+      uploadReleaseAsset({
+        release,
+        name: "SHA256SUMS",
+        filePath: "unused",
+        token: "token",
+        fetchImpl: async () => response,
+        readAsset: async () => Buffer.from("content"),
+      }),
+    ).rejects.toThrow(
+      "Uploading release asset SHA256SUMS failed during response body read: body stream aborted",
+    );
+  });
+
   it("verifies remote assets after successful missing-asset upload", async () => {
     const events: string[] = [];
     const refreshed = { ...release, body: "refreshed" };
@@ -202,6 +411,7 @@ describe("release asset upload orchestration", () => {
             events.push("refresh");
             return refreshed;
           },
+          assetRoot: () => repositoryRoot,
         },
         verifyAssets: async ({ release: verifiedRelease }) => {
           expect(verifiedRelease).toBe(refreshed);

--- a/packages/config/test/release-workflow.test.ts
+++ b/packages/config/test/release-workflow.test.ts
@@ -1,0 +1,70 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+const workflowUrl = new URL(
+  "../../../.github/workflows/release.yml",
+  import.meta.url,
+);
+
+const readWorkflow = () => readFile(workflowUrl, "utf8");
+
+describe("release workflow recovery topology", () => {
+  it("pins manual recovery tooling to exact main workflow commit", async () => {
+    const workflow = await readWorkflow();
+
+    expect(workflow).toContain(
+      "if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'",
+    );
+    expect(workflow).toContain(
+      "EXPECTED_TOOLING_SHA: ${{ github.event_name == 'workflow_dispatch' && github.sha || '' }}",
+    );
+    expect(workflow).toContain(
+      "ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || env.RELEASE_TAG }}",
+    );
+    expect(workflow).toContain(
+      "ref: ${{ needs.preflight.outputs.tooling_sha }}",
+    );
+    expect(workflow).toContain("TOOLING_SHA: ${{ steps.tooling.outputs.sha }}");
+    expect(workflow).toContain(
+      "tooling_ci_run_id: ${{ steps.preflight.outputs.tooling_ci_run_id }}",
+    );
+  });
+
+  it("keeps release source separate and tied to requested tag", async () => {
+    const workflow = await readWorkflow();
+
+    expect(workflow.match(/path: release-source/gu)).toHaveLength(2);
+    expect(workflow.match(/ref: \$\{\{ env\.RELEASE_TAG \}\}/gu)).toHaveLength(
+      2,
+    );
+    expect(workflow).toContain(
+      "RELEASE_SOURCE_ROOT: ${{ github.workspace }}/release-source",
+    );
+    expect(workflow).toContain("context: ${{ env.RELEASE_SOURCE_ROOT }}");
+    expect(workflow).not.toContain("context: .\n");
+  });
+
+  it("runs only verified tooling orchestrator with explicit roots", async () => {
+    const workflow = await readWorkflow();
+
+    expect(workflow.match(/path: tooling/gu)).toHaveLength(2);
+    expect(workflow).toContain("TOOLING_ROOT: ${{ github.workspace }}/tooling");
+    expect(workflow).toContain(
+      "ASSET_DIR: ${{ github.workspace }}/release-assets",
+    );
+    expect(workflow).toContain(
+      "run: node tooling/scripts/release/index.mjs preflight",
+    );
+    expect(workflow).toContain(
+      "run: node tooling/scripts/release/index.mjs reconcile-release",
+    );
+    expect(workflow).not.toMatch(/run: node scripts\/release\/index\.mjs/u);
+    expect(workflow).toContain(
+      "tooling_sha: ${{ steps.preflight.outputs.tooling_sha }}",
+    );
+    expect(workflow).toContain(
+      "release_ci_run_id: ${{ steps.preflight.outputs.release_ci_run_id }}",
+    );
+  });
+});

--- a/scripts/release/index.mjs
+++ b/scripts/release/index.mjs
@@ -29,7 +29,7 @@ import {
 } from "../../packages/config/dist/release.js";
 
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
-const ROOT = fileURLToPath(new URL("../../", import.meta.url));
+const TOOLING_ROOT = fileURLToPath(new URL("../../", import.meta.url));
 const PACKAGE_FILES = {
   root: "package.json",
   web: "apps/web/package.json",
@@ -58,12 +58,22 @@ const requiredEnv = (name) => {
 
 const optionalEnv = (name) => process.env[name]?.trim() ?? "";
 
+const requiredAbsolutePath = (name) => {
+  const value = requiredEnv(name);
+  if (!path.isAbsolute(value)) {
+    throw new Error(`${name} must be an absolute path.`);
+  }
+  return path.normalize(value);
+};
+
+const releaseSourceRoot = () => requiredAbsolutePath("RELEASE_SOURCE_ROOT");
+
 const run = (
   command,
   args,
   {
     allowFailure = false,
-    cwd = ROOT,
+    cwd = TOOLING_ROOT,
     input,
     encoding = "utf8",
     environment = process.env,
@@ -86,7 +96,11 @@ const run = (
   return result;
 };
 
-const git = (...args) => run("git", args).stdout.trim();
+const gitAt = (cwd, ...args) => run("git", args, { cwd }).stdout.trim();
+
+const git = (...args) => gitAt(releaseSourceRoot(), ...args);
+
+const toolingGit = (...args) => gitAt(TOOLING_ROOT, ...args);
 
 const ghApi = (endpoint, { method = "GET", input } = {}) => {
   const args = ["api", endpoint, "--method", method];
@@ -126,7 +140,29 @@ const writeSummary = async (content) => {
 const sha256 = (content) =>
   `sha256:${createHash("sha256").update(content).digest("hex")}`;
 
+const verifyToolingRoot = () => {
+  const expectedRoot = optionalEnv("TOOLING_ROOT");
+  if (
+    expectedRoot &&
+    path.resolve(expectedRoot) !== path.resolve(TOOLING_ROOT)
+  ) {
+    throw new Error(
+      `Tooling root is ${TOOLING_ROOT}; expected ${path.resolve(expectedRoot)}.`,
+    );
+  }
+};
+
+const verifyToolingCheckout = (toolingSha) => {
+  verifyToolingRoot();
+  const head = toolingGit("rev-parse", "HEAD");
+  if (head !== toolingSha) {
+    throw new Error(`Tooling HEAD is ${head}; expected ${toolingSha}.`);
+  }
+};
+
 const releaseContextFromEnv = () => {
+  const toolingSha = requiredEnv("TOOLING_SHA");
+  verifyToolingCheckout(toolingSha);
   const tag = requiredEnv("RELEASE_TAG");
   const release = parseReleaseTag(tag);
   if (!release) throw new Error(`Invalid release tag: ${tag}`);
@@ -142,15 +178,16 @@ const releaseContextFromEnv = () => {
     releaseSha: requiredEnv("RELEASE_SHA"),
     tagObject: requiredEnv("TAG_OBJECT_SHA"),
     tagType: requiredEnv("TAG_TYPE"),
+    toolingSha,
   };
 };
 
-const readPackageVersions = async () =>
+const readPackageVersions = async (sourceRoot = releaseSourceRoot()) =>
   Object.fromEntries(
     await Promise.all(
       Object.entries(PACKAGE_FILES).map(async ([name, file]) => {
         const metadata = JSON.parse(
-          await readFile(path.join(ROOT, file), "utf8"),
+          await readFile(path.join(sourceRoot, file), "utf8"),
         );
         return [name, metadata.version];
       }),
@@ -158,7 +195,9 @@ const readPackageVersions = async () =>
   );
 
 const readRemoteTagObject = (tag) => {
-  const result = run("git", ["ls-remote", "origin", `refs/tags/${tag}`]);
+  const result = run("git", ["ls-remote", "origin", `refs/tags/${tag}`], {
+    cwd: releaseSourceRoot(),
+  });
   const line = result.stdout.trim();
   if (!line) throw new Error(`Remote tag ${tag} does not exist.`);
   const [objectSha] = line.split(/\s+/u);
@@ -222,11 +261,18 @@ const verifyCheckedOutTag = (releaseSha) => {
 };
 
 const verifyMainAncestry = (releaseSha) => {
-  run("git", ["fetch", "--no-tags", "origin", "main:refs/remotes/origin/main"]);
+  const cwd = releaseSourceRoot();
+  run(
+    "git",
+    ["fetch", "--no-tags", "origin", "main:refs/remotes/origin/main"],
+    {
+      cwd,
+    },
+  );
   const ancestry = run(
     "git",
     ["merge-base", "--is-ancestor", releaseSha, "origin/main"],
-    { allowFailure: true },
+    { allowFailure: true, cwd },
   );
   if (ancestry.status !== 0) {
     throw new Error(`Release commit ${releaseSha} is not on current main.`);
@@ -525,8 +571,7 @@ const verifyImage = ({ context, digest }) => {
   return { observed, immutableReference };
 };
 
-const assetDirectory = () =>
-  path.resolve(ROOT, optionalEnv("ASSET_DIR") || ".release-assets");
+const assetDirectory = () => requiredAbsolutePath("ASSET_DIR");
 
 const generatedAssets = async () => {
   const directory = assetDirectory();
@@ -687,6 +732,16 @@ const uploadFailure = ({ name, status, detail }) =>
       .join(" "),
   );
 
+const uploadNetworkFailure = ({ name, operation, error, token }) => {
+  const rawDetail = error instanceof Error ? error.message : String(error);
+  const detail = safeGitHubResponseText(
+    rawDetail.replaceAll(token, "[redacted]"),
+  );
+  return new Error(
+    `Uploading release asset ${name} failed during ${operation}${detail ? `: ${detail}` : "."}`,
+  );
+};
+
 const hasExpectedUploadMetadata = ({ uploaded, name, size }) => {
   const metadata = Object(uploaded);
   const expected = { name, state: "uploaded", size };
@@ -735,19 +790,41 @@ const uploadReleaseAsset = async ({
   readAsset = readFile,
 }) => {
   const content = await readAsset(filePath);
-  const response = await fetchImpl(releaseAssetUploadUrl({ release, name }), {
-    method: "POST",
-    headers: {
-      Accept: "application/vnd.github+json",
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/octet-stream",
-      "X-GitHub-Api-Version": GITHUB_API_VERSION,
-    },
-    body: content,
-  });
+  let response;
+  try {
+    response = await fetchImpl(releaseAssetUploadUrl({ release, name }), {
+      method: "POST",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/octet-stream",
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+      },
+      body: content,
+    });
+  } catch (error) {
+    throw uploadNetworkFailure({
+      name,
+      operation: "network request",
+      error,
+      token,
+    });
+  }
+
+  let responseText;
+  try {
+    responseText = await response.text();
+  } catch (error) {
+    throw uploadNetworkFailure({
+      name,
+      operation: "response body read",
+      error,
+      token,
+    });
+  }
   return parseUploadedAsset({
     response,
-    responseText: await response.text(),
+    responseText,
     name,
     size: content.byteLength,
   });
@@ -835,21 +912,69 @@ const expectedCompleteProvenance = ({ context, imageDigest, assets }) => {
   });
 };
 
+const verifyPreflightToolingIdentity = ({ toolingSha, releaseSha }) => {
+  verifyToolingCheckout(toolingSha);
+  const eventName = requiredEnv("RELEASE_EVENT_NAME");
+  if (eventName === "push") {
+    if (toolingSha !== releaseSha) {
+      throw new Error(
+        `Tag-push tooling is ${toolingSha}; expected release commit ${releaseSha}.`,
+      );
+    }
+    return;
+  }
+  if (eventName !== "workflow_dispatch") {
+    throw new Error(`Unsupported release event: ${eventName}.`);
+  }
+  const recoveryRef = requiredEnv("RECOVERY_REF");
+  if (recoveryRef !== "refs/heads/main") {
+    throw new Error(
+      `Recovery dispatch ref is ${recoveryRef}; expected refs/heads/main.`,
+    );
+  }
+  const expectedToolingSha = requiredEnv("EXPECTED_TOOLING_SHA");
+  if (toolingSha !== expectedToolingSha) {
+    throw new Error(
+      `Recovery tooling is ${toolingSha}; expected ${expectedToolingSha}.`,
+    );
+  }
+};
+
+const waitForRequiredCi = async ({
+  repository,
+  releaseSha,
+  toolingSha,
+  waitForCi = waitForExactCi,
+}) => {
+  const releaseCiRun = await waitForCi({ repository, releaseSha });
+  const toolingCiRun =
+    toolingSha === releaseSha
+      ? releaseCiRun
+      : await waitForCi({ repository, releaseSha: toolingSha });
+  return { releaseCiRun, toolingCiRun };
+};
+
 const commandPreflight = async () => {
   const tag = requiredEnv("RELEASE_TAG");
   const repository = requiredEnv("GITHUB_REPOSITORY");
+  const toolingSha = requiredEnv("TOOLING_SHA");
   const identity = inspectTagIdentity({
     tag,
     expectedReleaseSha: optionalEnv("EXPECTED_RELEASE_SHA"),
     expectedTagObject: optionalEnv("EXPECTED_TAG_OBJECT"),
   });
+  verifyPreflightToolingIdentity({
+    toolingSha,
+    releaseSha: identity.releaseSha,
+  });
   const packageVersions = await readPackageVersions();
   const errors = findCanonicalReleaseVersionErrors({ tag, packageVersions });
   if (errors.length > 0) throw new Error(errors.join("\n"));
   const release = parseReleaseTag(tag);
-  const ciRun = await waitForExactCi({
+  const { releaseCiRun, toolingCiRun } = await waitForRequiredCi({
     repository,
     releaseSha: identity.releaseSha,
+    toolingSha,
   });
   const imageRepository = `ghcr.io/${repository.toLowerCase()}`;
 
@@ -861,10 +986,12 @@ const commandPreflight = async () => {
     ["tag_object", identity.tagObject],
     ["tag_type", identity.tagType],
     ["image_repository", imageRepository],
-    ["ci_run_id", ciRun.id],
+    ["release_ci_run_id", releaseCiRun.id],
+    ["tooling_sha", toolingSha],
+    ["tooling_ci_run_id", toolingCiRun.id],
   ]);
   await writeSummary(
-    `## REL-01 preflight\n\n- Tag: \`${release.tag}\`\n- Commit: \`${identity.releaseSha}\`\n- Exact CI run: \`${ciRun.id}\`\n- Channel: ${release.prerelease ? "prerelease" : "stable"}`,
+    `## REL-01 preflight\n\n- Tag: \`${release.tag}\`\n- Tag object: \`${identity.tagObject}\`\n- Release commit: \`${identity.releaseSha}\`\n- Release CI run: \`${releaseCiRun.id}\`\n- Tooling commit: \`${toolingSha}\`\n- Tooling CI run: \`${toolingCiRun.id}\`\n- Channel: ${release.prerelease ? "prerelease" : "stable"}`,
   );
 };
 
@@ -949,6 +1076,11 @@ const commandVerifyImage = async () => {
   await writeOutput("immutable_reference", immutableReference);
 };
 
+const readReleaseTemplates = async (sourceRoot = releaseSourceRoot()) => ({
+  compose: await readFile(path.join(sourceRoot, "docker-compose.yml"), "utf8"),
+  environment: await readFile(path.join(sourceRoot, "example.env"), "utf8"),
+});
+
 const commandGenerateAssets = async () => {
   const context = releaseContextFromEnv();
   const imageDigest = requiredEnv("IMAGE_DIGEST");
@@ -957,13 +1089,14 @@ const commandGenerateAssets = async () => {
   await rm(directory, { recursive: true, force: true });
   await mkdir(directory, { recursive: true });
 
+  const templates = await readReleaseTemplates();
   const compose = renderReleaseCompose({
-    source: await readFile(path.join(ROOT, "docker-compose.yml"), "utf8"),
+    source: templates.compose,
     imageRepository: context.imageRepository,
     releaseTag: context.release.tag,
   });
   const environment = renderReleaseEnv({
-    source: await readFile(path.join(ROOT, "example.env"), "utf8"),
+    source: templates.environment,
     releaseTag: context.release.tag,
   });
   const manifestObject = buildReleaseManifest({
@@ -1034,6 +1167,7 @@ const uploadMissingDraftAssets = async ({
   observeAssets = observedAssetsWithDigests,
   uploadAsset = uploadReleaseAsset,
   refreshRelease = getRelease,
+  assetRoot = assetDirectory,
 }) => {
   const plan = planReleaseAssets({
     expected: expectedAssetDigests(localAssets),
@@ -1047,7 +1181,7 @@ const uploadMissingDraftAssets = async ({
     await uploadAsset({
       release,
       name,
-      filePath: path.join(assetDirectory(), name),
+      filePath: path.join(assetRoot(), name),
     });
   }
   const refreshed = refreshRelease(context.repository, context.release.tag);
@@ -1284,9 +1418,12 @@ const commandPromoteLatest = async () => {
 
 const commandSummary = async () => {
   const tag = optionalEnv("RELEASE_TAG") || "unknown";
+  const releaseSha = optionalEnv("RELEASE_SHA") || "unknown";
+  const tagObject = optionalEnv("TAG_OBJECT_SHA") || "unknown";
+  const toolingSha = optionalEnv("TOOLING_SHA") || "unknown";
   const result = optionalEnv("RELEASE_RESULT") || "unknown";
   await writeSummary(
-    `## Release recovery\n\nResult: **${result}**\n\nTag: \`${tag}\`\n\n- Retry matching partial state with **Run workflow** and the same existing tag.\n- Do not move/delete the tag, clobber assets, or overwrite a conflicting image.\n- Conflicts require manual comparison of reported expected and actual SHA/digest values.`,
+    `## Release recovery\n\nResult: **${result}**\n\n- Tag: \`${tag}\`\n- Tag object: \`${tagObject}\`\n- Release commit: \`${releaseSha}\`\n- Tooling commit: \`${toolingSha}\`\n\n- Retry matching partial state with **Run workflow** from \`main\` and the same existing tag.\n- Do not move/delete the tag, clobber assets, or overwrite a conflicting image.\n- Conflicts require manual comparison of reported expected and actual SHA/digest values.`,
   );
 };
 
@@ -1304,10 +1441,17 @@ const commands = {
 };
 
 export {
+  assetDirectory,
+  readPackageVersions,
+  readReleaseTemplates,
   reconcileReleaseAssets,
   releaseAssetUploadUrl,
+  resolveTagIdentity,
   uploadMissingDraftAssets,
   uploadReleaseAsset,
+  verifyPreflightToolingIdentity,
+  waitForRequiredCi,
+  verifyToolingCheckout,
 };
 
 if (process.argv[1] && path.resolve(process.argv[1]) === SCRIPT_PATH) {
@@ -1322,7 +1466,7 @@ if (process.argv[1] && path.resolve(process.argv[1]) === SCRIPT_PATH) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(message);
     await writeSummary(
-      `## REL-01 failure\n\n\`\`\`text\n${message}\n\`\`\`\n\nRetry matching partial state with **Run workflow** and the same existing tag. Do not move/delete the tag, clobber assets, or overwrite a conflicting image. Conflicts require manual comparison of reported expected and actual SHA/digest values.`,
+      `## REL-01 failure\n\n\`\`\`text\n${message}\n\`\`\`\n\nRetry matching partial state with **Run workflow** from \`main\` and the same existing tag. Do not move/delete the tag, clobber assets, or overwrite a conflicting image. Conflicts require manual comparison of reported expected and actual SHA/digest values.`,
     );
     process.exitCode = 1;
   }

--- a/scripts/release/index.mjs
+++ b/scripts/release/index.mjs
@@ -28,6 +28,7 @@ import {
   serializeSha256Sums,
 } from "../../packages/config/dist/release.js";
 
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
 const ROOT = fileURLToPath(new URL("../../", import.meta.url));
 const PACKAGE_FILES = {
   root: "package.json",
@@ -42,6 +43,7 @@ const REQUIRED_ASSET_NAMES = [
   "release-manifest.json",
   "SHA256SUMS",
 ];
+const GITHUB_API_VERSION = "2022-11-28";
 const MISSING_IMAGE_PATTERN =
   /manifest unknown|not found|no such manifest|does not exist/iu;
 
@@ -632,7 +634,7 @@ const fetchAssetBytes = async (asset) => {
     headers: {
       Accept: "application/octet-stream",
       Authorization: `Bearer ${token}`,
-      "X-GitHub-Api-Version": "2022-11-28",
+      "X-GitHub-Api-Version": GITHUB_API_VERSION,
     },
   });
   if (!response.ok) {
@@ -641,6 +643,114 @@ const fetchAssetBytes = async (asset) => {
     );
   }
   return Buffer.from(await response.arrayBuffer());
+};
+
+const encodeQueryValue = (value) =>
+  encodeURIComponent(value).replace(
+    /[!'()*]/gu,
+    (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+
+const isValidReleaseAssetUploadUrl = ({ url, releaseId }) =>
+  [
+    url.protocol === "https:",
+    url.hostname === "uploads.github.com",
+    url.username === "",
+    url.password === "",
+    url.hash === "",
+    url.search === "",
+    url.pathname.endsWith(`/releases/${releaseId}/assets`),
+  ].every(Boolean);
+
+const releaseAssetUploadUrl = ({ release, name }) => {
+  if (!release.upload_url) {
+    throw new Error(`Release ${release.id} has no asset upload URL.`);
+  }
+  const url = new URL(release.upload_url.split("{", 1)[0]);
+  if (!isValidReleaseAssetUploadUrl({ url, releaseId: release.id })) {
+    throw new Error(`Release ${release.id} has an invalid asset upload URL.`);
+  }
+  url.search = `?name=${encodeQueryValue(name)}`;
+  return url.href;
+};
+
+const safeGitHubResponseText = (text) =>
+  text
+    .replace(/\p{Cc}/gu, " ")
+    .trim()
+    .slice(0, 1000);
+
+const uploadFailure = ({ name, status, detail }) =>
+  new Error(
+    [`Uploading release asset ${name} failed: HTTP ${status}`, detail]
+      .filter(Boolean)
+      .join(" "),
+  );
+
+const hasExpectedUploadMetadata = ({ uploaded, name, size }) => {
+  const metadata = Object(uploaded);
+  const expected = { name, state: "uploaded", size };
+  const valuesMatch = Object.entries(expected).every(
+    ([key, value]) => metadata[key] === value,
+  );
+  const identifiersExist = ["id", "url"].every((key) => Boolean(metadata[key]));
+  return valuesMatch && identifiersExist;
+};
+
+const parseUploadedAsset = ({ response, responseText, name, size }) => {
+  if (response.status !== 201) {
+    throw uploadFailure({
+      name,
+      status: response.status,
+      detail: safeGitHubResponseText(responseText),
+    });
+  }
+
+  let uploaded;
+  try {
+    uploaded = JSON.parse(responseText);
+  } catch {
+    throw uploadFailure({
+      name,
+      status: response.status,
+      detail: "returned invalid JSON.",
+    });
+  }
+  if (!hasExpectedUploadMetadata({ uploaded, name, size })) {
+    throw uploadFailure({
+      name,
+      status: response.status,
+      detail: "returned invalid asset metadata.",
+    });
+  }
+  return uploaded;
+};
+
+const uploadReleaseAsset = async ({
+  release,
+  name,
+  filePath,
+  token = requiredEnv("GH_TOKEN"),
+  fetchImpl = fetch,
+  readAsset = readFile,
+}) => {
+  const content = await readAsset(filePath);
+  const response = await fetchImpl(releaseAssetUploadUrl({ release, name }), {
+    method: "POST",
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/octet-stream",
+      "X-GitHub-Api-Version": GITHUB_API_VERSION,
+    },
+    body: content,
+  });
+  return parseUploadedAsset({
+    response,
+    responseText: await response.text(),
+    name,
+    size: content.byteLength,
+  });
 };
 
 const observedAssetsWithDigests = async (repository, releaseId) => {
@@ -917,26 +1027,30 @@ const reconcileDraftProvenance = ({
   return release;
 };
 
-const uploadMissingDraftAssets = async ({ context, release, localAssets }) => {
+const uploadMissingDraftAssets = async ({
+  context,
+  release,
+  localAssets,
+  observeAssets = observedAssetsWithDigests,
+  uploadAsset = uploadReleaseAsset,
+  refreshRelease = getRelease,
+}) => {
   const plan = planReleaseAssets({
     expected: expectedAssetDigests(localAssets),
-    observed: await observedAssetsWithDigests(context.repository, release.id),
+    observed: await observeAssets(context.repository, release.id),
     published: false,
   });
   if (plan.conflicts.length > 0) {
     throw new Error(`Draft assets conflict:\n${plan.conflicts.join("\n")}`);
   }
   for (const name of plan.upload) {
-    run("gh", [
-      "release",
-      "upload",
-      context.release.tag,
-      path.join(assetDirectory(), name),
-      "--repo",
-      context.repository,
-    ]);
+    await uploadAsset({
+      release,
+      name,
+      filePath: path.join(assetDirectory(), name),
+    });
   }
-  const refreshed = getRelease(context.repository, context.release.tag);
+  const refreshed = refreshRelease(context.repository, context.release.tag);
   if (!refreshed)
     throw new Error("Draft release disappeared after asset upload.");
   return refreshed;
@@ -948,6 +1062,7 @@ const reconcileDraftRelease = async ({
   provenance,
   complete,
   localAssets,
+  uploadOptions,
 }) => {
   const updated = reconcileDraftProvenance({
     context,
@@ -959,6 +1074,7 @@ const reconcileDraftRelease = async ({
     context,
     release: updated,
     localAssets,
+    ...uploadOptions,
   });
 };
 
@@ -969,12 +1085,38 @@ const verifyCompleteProvenance = ({ provenance, complete, published }) => {
   );
 };
 
+const reconcileReleaseAssets = async ({
+  context,
+  release,
+  provenance,
+  complete,
+  localAssets,
+  uploadOptions,
+  verifyAssets = verifyRemoteAssets,
+}) => {
+  let reconciled = release;
+  if (release.draft) {
+    reconciled = await reconcileDraftRelease({
+      context,
+      release,
+      provenance,
+      complete,
+      localAssets,
+      uploadOptions,
+    });
+  } else {
+    verifyCompleteProvenance({ provenance, complete, published: true });
+  }
+  await verifyAssets({ context, release: reconciled, localAssets });
+  return reconciled;
+};
+
 const commandReconcileRelease = async () => {
   const context = releaseContextFromEnv();
   const imageDigest = requiredEnv("IMAGE_DIGEST");
   verifyRecordedTagIdentity(context);
   const localAssets = await generatedAssets();
-  let release = getRelease(context.repository, context.release.tag);
+  const release = getRelease(context.repository, context.release.tag);
   if (!release) throw new Error("Draft release is missing.");
   const { provenance } = validateReleaseIdentity({ release, context });
   const complete = expectedCompleteProvenance({
@@ -983,18 +1125,13 @@ const commandReconcileRelease = async () => {
     assets: localAssets,
   });
 
-  if (release.draft) {
-    release = await reconcileDraftRelease({
-      context,
-      release,
-      provenance,
-      complete,
-      localAssets,
-    });
-  } else {
-    verifyCompleteProvenance({ provenance, complete, published: true });
-  }
-  await verifyRemoteAssets({ context, release, localAssets });
+  await reconcileReleaseAssets({
+    context,
+    release,
+    provenance,
+    complete,
+    localAssets,
+  });
 };
 
 const commandPublish = async () => {
@@ -1166,18 +1303,27 @@ const commands = {
   summary: commandSummary,
 };
 
-const command = process.argv[2];
-if (!command || !(command in commands)) {
-  throw new Error(`Unknown release command: ${command ?? "missing"}`);
-}
+export {
+  reconcileReleaseAssets,
+  releaseAssetUploadUrl,
+  uploadMissingDraftAssets,
+  uploadReleaseAsset,
+};
 
-try {
-  await commands[command]();
-} catch (error) {
-  const message = error instanceof Error ? error.message : String(error);
-  console.error(message);
-  await writeSummary(
-    `## REL-01 failure\n\n\`\`\`text\n${message}\n\`\`\`\n\nRetry matching partial state with **Run workflow** and the same existing tag. Do not move/delete the tag, clobber assets, or overwrite a conflicting image. Conflicts require manual comparison of reported expected and actual SHA/digest values.`,
-  );
-  process.exitCode = 1;
+if (process.argv[1] && path.resolve(process.argv[1]) === SCRIPT_PATH) {
+  const command = process.argv[2];
+  if (!command || !(command in commands)) {
+    throw new Error(`Unknown release command: ${command ?? "missing"}`);
+  }
+
+  try {
+    await commands[command]();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    await writeSummary(
+      `## REL-01 failure\n\n\`\`\`text\n${message}\n\`\`\`\n\nRetry matching partial state with **Run workflow** and the same existing tag. Do not move/delete the tag, clobber assets, or overwrite a conflicting image. Conflicts require manual comparison of reported expected and actual SHA/digest values.`,
+    );
+    process.exitCode = 1;
+  }
 }


### PR DESCRIPTION
## Summary

- replace tag-based `gh release upload` with release-specific GitHub REST asset uploads
- send raw asset bytes through resolved draft `upload_url` with required auth, media type, and API version headers
- validate upload URL, percent-encode asset names, verify `201` response metadata, and include safe GitHub error text
- preserve missing-only reconciliation, conflict blocking, remote byte/checksum verification, and both Compose validation modes
- add focused orchestration coverage for URL safety, encoding, missing-only uploads, no clobber/deletion, HTTP failures, post-upload verification, and existing conflicts

## Root cause

`gh release upload <tag>` resolves releases through tag-based lookup. Draft releases are visible through the REST release list but are not reliably resolved by that tag-only upload path, producing `release not found` after draft creation and image verification succeeded.

## Validation

- `pnpm --filter @staaash/config test`
- `pnpm --filter @staaash/config build`
- `node --check scripts/release/index.mjs`
- `pnpm format:check`
- `pnpm lint`
- `pnpm quality:fallow`
- `pnpm test`
- `pnpm test:postgres` using isolated PostgreSQL 18 and Node.js 24.18.0 Linux containers
- `pnpm build`
- web runtime-version smoke
- worker runtime-version smoke
- `git diff --check`

## Production state

No production recovery action performed. Existing `v1.0.0-rc.7` tag, draft GitHub Release, GHCR image, and draft assets remain untouched. Release workflow was not rerun. No assets were uploaded. No `rc.8` was created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
