### PR TITLE
fix(release): pin recovery to release ID

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,19 @@ jobs:
         run: node tooling/scripts/release/index.mjs verify-tag
 
       - name: Create or verify draft release
+        id: release
         run: node tooling/scripts/release/index.mjs ensure-draft
+
+      - name: Capture exact release ID
+        shell: bash
+        env:
+          RESOLVED_RELEASE_ID: ${{ steps.release.outputs.release_id }}
+        run: |
+          if [[ ! "$RESOLVED_RELEASE_ID" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Invalid release ID: $RESOLVED_RELEASE_ID" >&2
+            exit 1
+          fi
+          echo "RELEASE_ID=$RESOLVED_RELEASE_ID" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/packages/config/test/release-orchestrator.test.ts
+++ b/packages/config/test/release-orchestrator.test.ts
@@ -8,14 +8,23 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  appendReleaseProvenance,
+  buildReleaseProvenance,
+} from "../src/release.js";
+
+import {
   assetDirectory,
+  getReleaseById,
   readPackageVersions,
   readReleaseTemplates,
   reconcileReleaseAssets,
   releaseAssetUploadUrl,
+  requiredReleaseId,
+  resolveReleaseById,
   resolveTagIdentity,
   uploadMissingDraftAssets,
   uploadReleaseAsset,
+  validateResolvedRelease,
   verifyPreflightToolingIdentity,
   waitForRequiredCi,
 } from "../../../scripts/release/index.mjs";
@@ -32,23 +41,31 @@ const digest = (content: string) =>
 
 const context = {
   repository: "itsmeares/staaash",
-  release: { tag: "v1.0.0-rc.7" },
-};
-
-const release = {
-  id: 42,
-  draft: true,
-  upload_url:
-    "https://uploads.github.com/repos/itsmeares/staaash/releases/42/assets{?name,label}",
-};
-
-const complete = {
-  tag: "v1.0.0-rc.7",
-  commit: "1".repeat(40),
+  release: { tag: "v1.0.0-rc.7", prerelease: true },
+  releaseSha: "1".repeat(40),
   tagObject: "2".repeat(40),
+};
+
+const complete = buildReleaseProvenance({
+  tag: "v1.0.0-rc.7",
+  commit: context.releaseSha,
+  tagObject: context.tagObject,
   imageDigest: `sha256:${"a".repeat(64)}`,
   immutableImage: `ghcr.io/itsmeares/staaash:v1.0.0-rc.7@sha256:${"a".repeat(64)}`,
   assetChecksums: {},
+});
+
+const release = {
+  id: 42,
+  tag_name: context.release.tag,
+  draft: true,
+  prerelease: true,
+  body: appendReleaseProvenance({
+    body: "Generated release notes.\n",
+    provenance: complete,
+  }),
+  upload_url:
+    "https://uploads.github.com/repos/itsmeares/staaash/releases/42/assets{?name,label}",
 };
 
 const repositoryRoot = fileURLToPath(new URL("../../../", import.meta.url));
@@ -208,6 +225,128 @@ describe("release trust roots", () => {
   });
 });
 
+describe("exact release resolution", () => {
+  it("accepts only canonical safe positive RELEASE_ID values", () => {
+    vi.stubEnv("RELEASE_ID", "42");
+    expect(requiredReleaseId()).toBe(42);
+
+    for (const value of [
+      "",
+      "0",
+      "-1",
+      "01",
+      "1.5",
+      "release-42",
+      "9".repeat(20),
+    ]) {
+      vi.stubEnv("RELEASE_ID", value);
+      expect(() => requiredReleaseId()).toThrow(/RELEASE_ID/u);
+    }
+  });
+
+  it("rejects an invalid RELEASE_ID before any exact lookup", () => {
+    const fetchRelease = vi.fn();
+    vi.stubEnv("RELEASE_ID", "0042");
+
+    expect(() => resolveReleaseById({ context, fetchRelease })).toThrow(
+      "RELEASE_ID must be a canonical positive integer.",
+    );
+    expect(fetchRelease).not.toHaveBeenCalled();
+  });
+
+  it("loads the exact release endpoint without collection or tag lookup", () => {
+    const request = vi.fn(() => release);
+
+    expect(getReleaseById(context.repository, release.id, { request })).toBe(
+      release,
+    );
+    expect(request).toHaveBeenCalledOnce();
+    expect(request).toHaveBeenCalledWith("repos/itsmeares/staaash/releases/42");
+  });
+
+  it("reports a missing exact-ID release clearly", () => {
+    expect(() =>
+      getReleaseById(context.repository, release.id, {
+        request: () => null,
+      }),
+    ).toThrow("GitHub Release ID 42 is missing.");
+  });
+
+  it("preserves non-missing API failures", () => {
+    const failure = new Error("GitHub API failed with HTTP 500");
+
+    expect(() =>
+      getReleaseById(context.repository, release.id, {
+        request: () => {
+          throw failure;
+        },
+      }),
+    ).toThrow(failure);
+  });
+
+  it("validates exact ID, tag, prerelease state, and provenance identity", () => {
+    expect(
+      resolveReleaseById({
+        context,
+        releaseId: release.id,
+        fetchRelease: () => release,
+      }),
+    ).toEqual(expect.objectContaining({ release, provenance: complete }));
+
+    expect(() =>
+      resolveReleaseById({
+        context,
+        releaseId: release.id,
+        fetchRelease: () => ({ ...release, id: 43 }),
+      }),
+    ).toThrow("Release ID is 43; expected 42.");
+    expect(() =>
+      resolveReleaseById({
+        context,
+        releaseId: release.id,
+        fetchRelease: () => ({ ...release, tag_name: "v1.0.0-rc.6" }),
+      }),
+    ).toThrow("Release tag is v1.0.0-rc.6; expected v1.0.0-rc.7.");
+    expect(() =>
+      resolveReleaseById({
+        context,
+        releaseId: release.id,
+        fetchRelease: () => ({ ...release, prerelease: false }),
+      }),
+    ).toThrow("Release prerelease flag is false; expected true.");
+    expect(() =>
+      resolveReleaseById({
+        context,
+        releaseId: release.id,
+        fetchRelease: () => ({
+          ...release,
+          body: appendReleaseProvenance({
+            body: "Generated release notes.\n",
+            provenance: { ...complete, commit: "3".repeat(40) },
+          }),
+        }),
+      }),
+    ).toThrow("Release provenance tag identity conflicts with current tag.");
+  });
+
+  it("rejects invalid and switched IDs in mutation responses", () => {
+    expect(() =>
+      validateResolvedRelease({
+        release: { ...release, id: "42" },
+        context,
+        releaseId: release.id,
+      }),
+    ).toThrow("GitHub Release returned an invalid numeric ID.");
+    expect(() =>
+      validateResolvedRelease({
+        release: { ...release, id: 43 },
+        context,
+        releaseId: release.id,
+      }),
+    ).toThrow("Release ID is 43; expected 42.");
+  });
+});
+
 describe("release asset upload orchestration", () => {
   it("constructs a release-specific upload URL with RFC 3986 encoding", () => {
     expect(
@@ -286,7 +425,7 @@ describe("release asset upload orchestration", () => {
 
   it("uploads only missing assets without clobbering or deleting", async () => {
     const uploaded: string[] = [];
-    const refreshed = { ...release, body: "refreshed" };
+    const refreshed = { ...release };
     const uploadAsset = vi.fn(async ({ name }: { name: string }) => {
       uploaded.push(name);
     });
@@ -316,6 +455,7 @@ describe("release asset upload orchestration", () => {
     expect(uploaded).toEqual(["example.env", "SHA256SUMS"]);
     expect(uploadAsset).toHaveBeenCalledTimes(2);
     expect(refreshRelease).toHaveBeenCalledOnce();
+    expect(refreshRelease).toHaveBeenCalledWith(context.repository, release.id);
   });
 
   it("keeps HTTP upload failures fail-closed with useful diagnostics", async () => {
@@ -388,7 +528,7 @@ describe("release asset upload orchestration", () => {
 
   it("verifies remote assets after successful missing-asset upload", async () => {
     const events: string[] = [];
-    const refreshed = { ...release, body: "refreshed" };
+    const refreshed = { ...release };
 
     await expect(
       reconcileReleaseAssets({
@@ -426,6 +566,42 @@ describe("release asset upload orchestration", () => {
       "refresh",
       "verify",
     ]);
+  });
+
+  it("resumes safely when every asset already exists on an unpublished draft", async () => {
+    const uploadAsset = vi.fn();
+    const refreshRelease = vi.fn(() => ({ ...release }));
+    const verifyAssets = vi.fn();
+
+    await expect(
+      reconcileReleaseAssets({
+        context,
+        release,
+        provenance: complete,
+        complete,
+        localAssets,
+        uploadOptions: {
+          observeAssets: async () =>
+            Object.entries(localAssets).map(([name, content]) => ({
+              name,
+              digest: digest(content),
+            })),
+          uploadAsset,
+          refreshRelease,
+        },
+        verifyAssets,
+      }),
+    ).resolves.toEqual(release);
+
+    expect(uploadAsset).not.toHaveBeenCalled();
+    expect(refreshRelease).toHaveBeenCalledOnce();
+    expect(refreshRelease).toHaveBeenCalledWith(context.repository, release.id);
+    expect(verifyAssets).toHaveBeenCalledOnce();
+    expect(verifyAssets).toHaveBeenCalledWith({
+      context,
+      release: expect.objectContaining({ id: release.id, draft: true }),
+      localAssets,
+    });
   });
 
   it("blocks conflicting assets before upload, refresh, or verification", async () => {

--- a/packages/config/test/release-workflow.test.ts
+++ b/packages/config/test/release-workflow.test.ts
@@ -6,8 +6,13 @@ const workflowUrl = new URL(
   "../../../.github/workflows/release.yml",
   import.meta.url,
 );
+const orchestratorUrl = new URL(
+  "../../../scripts/release/index.mjs",
+  import.meta.url,
+);
 
 const readWorkflow = () => readFile(workflowUrl, "utf8");
+const readOrchestrator = () => readFile(orchestratorUrl, "utf8");
 
 describe("release workflow recovery topology", () => {
   it("pins manual recovery tooling to exact main workflow commit", async () => {
@@ -66,5 +71,59 @@ describe("release workflow recovery topology", () => {
     expect(workflow).toContain(
       "release_ci_run_id: ${{ steps.preflight.outputs.release_ci_run_id }}",
     );
+  });
+
+  it("propagates the resolved draft release ID to every later step", async () => {
+    const workflow = await readWorkflow();
+    const ensureDraft = workflow.indexOf(
+      "- name: Create or verify draft release",
+    );
+    const captureReleaseId = workflow.indexOf(
+      "- name: Capture exact release ID",
+    );
+    const inspectImage = workflow.indexOf(
+      "- name: Inspect existing versioned image",
+    );
+
+    expect(workflow).toContain(
+      "- name: Create or verify draft release\n        id: release",
+    );
+    expect(workflow).toContain(
+      "RESOLVED_RELEASE_ID: ${{ steps.release.outputs.release_id }}",
+    );
+    expect(workflow).toContain(
+      'if [[ ! "$RESOLVED_RELEASE_ID" =~ ^[1-9][0-9]*$ ]]; then',
+    );
+    expect(workflow).toContain(
+      'echo "RELEASE_ID=$RESOLVED_RELEASE_ID" >> "$GITHUB_ENV"',
+    );
+    expect(ensureDraft).toBeGreaterThan(-1);
+    expect(captureReleaseId).toBeGreaterThan(ensureDraft);
+    expect(inspectImage).toBeGreaterThan(captureReleaseId);
+  });
+
+  it("uses tag discovery only for ensure-draft, then stays on exact ID", async () => {
+    const orchestrator = await readOrchestrator();
+    const postResolution = orchestrator.slice(
+      orchestrator.indexOf("const commandInspectImage"),
+    );
+
+    expect(orchestrator.match(/findReleaseByTag\(/gu)).toHaveLength(1);
+    expect(orchestrator).toContain("const findReleaseByTag =");
+    expect(orchestrator).toContain(
+      "let release = findReleaseByTag(context.repository, context.release.tag);",
+    );
+    expect(postResolution).not.toContain("findReleaseByTag(");
+    expect(postResolution).not.toContain("getReleases(");
+    expect(postResolution).toContain(
+      "const refreshed = await refreshRelease(context.repository, release.id);",
+    );
+    expect(postResolution).toContain(
+      "let { release, provenance } = resolveReleaseById({ context, releaseId });",
+    );
+    expect(postResolution).toContain(
+      "const release = requirePublishedRelease(context, releaseId);",
+    );
+    expect(orchestrator.match(/releases\/latest/gu)).toHaveLength(1);
   });
 });

--- a/scripts/release/index.mjs
+++ b/scripts/release/index.mjs
@@ -58,6 +58,18 @@ const requiredEnv = (name) => {
 
 const optionalEnv = (name) => process.env[name]?.trim() ?? "";
 
+const requiredReleaseId = () => {
+  const value = requiredEnv("RELEASE_ID");
+  if (!/^[1-9][0-9]*$/u.test(value)) {
+    throw new Error("RELEASE_ID must be a canonical positive integer.");
+  }
+  const releaseId = Number(value);
+  if (!Number.isSafeInteger(releaseId)) {
+    throw new Error("RELEASE_ID must be a safe positive integer.");
+  }
+  return releaseId;
+};
+
 const requiredAbsolutePath = (name) => {
   const value = requiredEnv(name);
   if (!path.isAbsolute(value)) {
@@ -110,6 +122,27 @@ const ghApi = (endpoint, { method = "GET", input } = {}) => {
   });
   const output = result.stdout.trim();
   return output ? JSON.parse(output) : null;
+};
+
+const parseGhApiOutput = (stdout) => {
+  const output = stdout.trim();
+  if (!output) return null;
+  return JSON.parse(output);
+};
+
+const ghFailureDetail = (result) => {
+  const stderr = String(result.stderr).trim();
+  if (stderr) return stderr;
+  return String(result.stdout).trim();
+};
+
+const ghApiAllowNotFound = (endpoint) => {
+  const args = ["api", endpoint, "--method", "GET"];
+  const result = run("gh", args, { allowFailure: true });
+  if (result.status === 0) return parseGhApiOutput(result.stdout);
+  const detail = ghFailureDetail(result);
+  if (/\bHTTP 404\b/u.test(detail)) return null;
+  throw new Error(`gh ${args.join(" ")} failed: ${detail}`);
 };
 
 const ghApiPaginated = (endpoint) => {
@@ -362,7 +395,7 @@ const waitForExactCi = async ({ repository, releaseSha }) => {
 const getReleases = (repository) =>
   ghApiPaginated(`repos/${repository}/releases?per_page=100`);
 
-const getRelease = (repository, tag) => {
+const findReleaseByTag = (repository, tag) => {
   const releases = getReleases(repository).filter(
     (release) => release.tag_name === tag,
   );
@@ -370,6 +403,18 @@ const getRelease = (repository, tag) => {
     throw new Error(`Multiple GitHub Releases exist for ${tag}.`);
   }
   return releases[0] ?? null;
+};
+
+const getReleaseById = (
+  repository,
+  releaseId,
+  { request = ghApiAllowNotFound } = {},
+) => {
+  const release = request(`repos/${repository}/releases/${releaseId}`);
+  if (!release) {
+    throw new Error(`GitHub Release ID ${releaseId} is missing.`);
+  }
+  return release;
 };
 
 const getReleaseAssets = (repository, releaseId) =>
@@ -417,6 +462,26 @@ const validateReleaseIdentity = ({ release, context }) => {
     throw new Error("Published release still has pending image provenance.");
   }
   return { parsed, provenance: parsed.provenance };
+};
+
+const validateResolvedRelease = ({ release, context, releaseId }) => {
+  if (!Number.isSafeInteger(release?.id) || release.id <= 0) {
+    throw new Error("GitHub Release returned an invalid numeric ID.");
+  }
+  if (release.id !== releaseId) {
+    throw new Error(`Release ID is ${release.id}; expected ${releaseId}.`);
+  }
+  return validateReleaseIdentity({ release, context });
+};
+
+const resolveReleaseById = ({
+  context,
+  releaseId = requiredReleaseId(),
+  fetchRelease = getReleaseById,
+}) => {
+  const release = fetchRelease(context.repository, releaseId);
+  const identity = validateResolvedRelease({ release, context, releaseId });
+  return { release, ...identity };
 };
 
 const generateReleaseNotes = (repository, tag) =>
@@ -1010,9 +1075,16 @@ const commandEnsureDraft = async () => {
     immutableImage: "pending",
     assetChecksums: null,
   });
-  let release = getRelease(context.repository, context.release.tag);
+  let release = findReleaseByTag(context.repository, context.release.tag);
   if (!release) release = createDraft({ context, provenance: pending });
-  const { provenance } = validateReleaseIdentity({ release, context });
+  if (!Number.isSafeInteger(release?.id) || release.id <= 0) {
+    throw new Error("GitHub Release returned an invalid numeric ID.");
+  }
+  const { provenance } = validateResolvedRelease({
+    release,
+    context,
+    releaseId: release.id,
+  });
   if (release.draft && provenance.imageDigest !== "pending") {
     console.info(
       "Compatible draft already contains complete image provenance.",
@@ -1028,10 +1100,7 @@ const commandEnsureDraft = async () => {
 const commandInspectImage = async () => {
   const context = releaseContextFromEnv();
   verifyRecordedTagIdentity(context);
-  const release = getRelease(context.repository, context.release.tag);
-  if (!release)
-    throw new Error("Draft release must exist before image inspection.");
-  const { provenance } = validateReleaseIdentity({ release, context });
+  const { release, provenance } = resolveReleaseById({ context });
   const exactReference = `${context.imageRepository}:${context.release.tag}`;
   const inspected = inspectImage(exactReference, { allowMissing: true });
   if (!inspected) {
@@ -1150,7 +1219,13 @@ const reconcileDraftProvenance = ({
       expected: provenance,
       next: complete,
     });
-    return patchRelease(context.repository, release.id, { body });
+    const updated = patchRelease(context.repository, release.id, { body });
+    validateResolvedRelease({
+      release: updated,
+      context,
+      releaseId: release.id,
+    });
+    return updated;
   }
   if (JSON.stringify(provenance) !== JSON.stringify(complete)) {
     throw new Error(
@@ -1166,7 +1241,7 @@ const uploadMissingDraftAssets = async ({
   localAssets,
   observeAssets = observedAssetsWithDigests,
   uploadAsset = uploadReleaseAsset,
-  refreshRelease = getRelease,
+  refreshRelease = getReleaseById,
   assetRoot = assetDirectory,
 }) => {
   const plan = planReleaseAssets({
@@ -1184,9 +1259,17 @@ const uploadMissingDraftAssets = async ({
       filePath: path.join(assetRoot(), name),
     });
   }
-  const refreshed = refreshRelease(context.repository, context.release.tag);
-  if (!refreshed)
-    throw new Error("Draft release disappeared after asset upload.");
+  const refreshed = await refreshRelease(context.repository, release.id);
+  if (!refreshed) {
+    throw new Error(
+      `GitHub Release ID ${release.id} is missing after asset upload.`,
+    );
+  }
+  validateResolvedRelease({
+    release: refreshed,
+    context,
+    releaseId: release.id,
+  });
   return refreshed;
 };
 
@@ -1250,9 +1333,7 @@ const commandReconcileRelease = async () => {
   const imageDigest = requiredEnv("IMAGE_DIGEST");
   verifyRecordedTagIdentity(context);
   const localAssets = await generatedAssets();
-  const release = getRelease(context.repository, context.release.tag);
-  if (!release) throw new Error("Draft release is missing.");
-  const { provenance } = validateReleaseIdentity({ release, context });
+  const { release, provenance } = resolveReleaseById({ context });
   const complete = expectedCompleteProvenance({
     context,
     imageDigest,
@@ -1274,9 +1355,8 @@ const commandPublish = async () => {
   verifyRecordedTagIdentity(context);
   verifyImage({ context, digest: imageDigest });
   const localAssets = await generatedAssets();
-  let release = getRelease(context.repository, context.release.tag);
-  if (!release) throw new Error("Release is missing before publication.");
-  const { provenance } = validateReleaseIdentity({ release, context });
+  const releaseId = requiredReleaseId();
+  let { release, provenance } = resolveReleaseById({ context, releaseId });
   const complete = expectedCompleteProvenance({
     context,
     imageDigest,
@@ -1296,7 +1376,7 @@ const commandPublish = async () => {
     });
   }
   if (release.draft) throw new Error("GitHub Release remained a draft.");
-  validateReleaseIdentity({ release, context });
+  validateResolvedRelease({ release, context, releaseId });
   await verifyRemoteAssets({ context, release, localAssets });
   verifyRecordedTagIdentity(context);
 };
@@ -1314,12 +1394,11 @@ const handlePrereleaseLatest = async ({ context, imageDigest }) => {
   await writeSummary("## Docker `latest`\n\nPrerelease: promotion prohibited.");
 };
 
-const requirePublishedRelease = (context) => {
-  const release = getRelease(context.repository, context.release.tag);
-  if (!release || release.draft) {
+const requirePublishedRelease = (context, releaseId) => {
+  const { release } = resolveReleaseById({ context, releaseId });
+  if (release.draft) {
     throw new Error("Stable GitHub Release must be published before latest.");
   }
-  validateReleaseIdentity({ release, context });
   return release;
 };
 
@@ -1367,7 +1446,14 @@ const verifyLatestResult = ({
 
 const markGitHubReleaseLatest = ({ context, release, plan }) => {
   if (plan.action === "superseded") return;
-  patchRelease(context.repository, release.id, { make_latest: "true" });
+  const updated = patchRelease(context.repository, release.id, {
+    make_latest: "true",
+  });
+  validateResolvedRelease({
+    release: updated,
+    context,
+    releaseId: release.id,
+  });
   const latestRelease = ghApi(`repos/${context.repository}/releases/latest`);
   if (latestRelease.tag_name !== context.release.tag) {
     throw new Error(
@@ -1376,9 +1462,9 @@ const markGitHubReleaseLatest = ({ context, release, plan }) => {
   }
 };
 
-const promoteStableLatest = async ({ context, imageDigest }) => {
+const promoteStableLatest = async ({ context, imageDigest, releaseId }) => {
   verifyRecordedTagIdentity(context);
-  const release = requirePublishedRelease(context);
+  const release = requirePublishedRelease(context, releaseId);
   verifyImage({ context, digest: imageDigest });
 
   const latestReference = `${context.imageRepository}:latest`;
@@ -1411,9 +1497,10 @@ const promoteStableLatest = async ({ context, imageDigest }) => {
 const commandPromoteLatest = async () => {
   const context = releaseContextFromEnv();
   const imageDigest = requiredEnv("IMAGE_DIGEST");
+  const releaseId = requiredReleaseId();
   return context.release.prerelease
     ? handlePrereleaseLatest({ context, imageDigest })
-    : promoteStableLatest({ context, imageDigest });
+    : promoteStableLatest({ context, imageDigest, releaseId });
 };
 
 const commandSummary = async () => {
@@ -1442,13 +1529,17 @@ const commands = {
 
 export {
   assetDirectory,
+  getReleaseById,
   readPackageVersions,
   readReleaseTemplates,
   reconcileReleaseAssets,
   releaseAssetUploadUrl,
+  requiredReleaseId,
+  resolveReleaseById,
   resolveTagIdentity,
   uploadMissingDraftAssets,
   uploadReleaseAsset,
+  validateResolvedRelease,
   verifyPreflightToolingIdentity,
   waitForRequiredCi,
   verifyToolingCheckout,


### PR DESCRIPTION
## 🚀 Summary

Pins all post-resolution REL-01 recovery operations to the exact GitHub Release ID emitted by `ensure-draft`.

Root cause: the recovery workflow discarded `release_id`, then `uploadMissingDraftAssets()` refreshed through the releases collection and a tag filter. After all asset uploads succeeded, that collection lookup transiently returned no matching draft and raised `Draft release disappeared after asset upload.`

The workflow now validates and exports one `RELEASE_ID`. Image inspection, reconciliation, post-upload refresh, publication, and stable latest promotion resolve and validate that exact ID. Tag-based collection discovery remains only in the initial `ensure-draft` operation.

## 📊 Impacts and Changes

- Same-tag recovery remains idempotent after partial asset upload.
- Matching assets are preserved and not uploaded again.
- Conflicting assets still fail closed before publication.
- Exact-ID responses must retain the expected numeric ID, tag, prerelease state, managed provenance, tag object, and release commit.
- No schema, auth, storage, restore, product API, or user-facing behavior changes.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

Additional validation:

- `pnpm install --frozen-lockfile`
- `pnpm db:generate`
- `pnpm --filter @staaash/db build`
- Focused release tests: 25 passed
- `pnpm format:check`
- `pnpm quality:fallow`
- `git diff --check`

`pnpm test:postgres` created an isolated PostgreSQL 18 database and applied all migrations, but local upload-admission cases hit the intentional physical-capacity guard because the host C: drive has 8.12% free space, below the required 10% safety floor. GitHub CI provides the authoritative clean-runner integration result.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

None.

## 🔗 Linked Issues

None.
