### PR TITLE
fix(release): handle untagged draft identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ on:
         description: Existing release tag to verify or resume
         required: true
         type: string
+      release_id:
+        description: Exact existing draft release ID to resume
+        required: true
+        type: string
 
 concurrency:
   group: staaash-release
@@ -52,6 +56,17 @@ jobs:
         run: |
           echo "Release recovery must be dispatched from refs/heads/main." >&2
           exit 1
+
+      - name: Require exact recovery release ID
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          RECOVERY_RELEASE_ID: ${{ inputs.release_id }}
+        run: |
+          if [[ ! "$RECOVERY_RELEASE_ID" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Recovery release ID must be a canonical positive integer." >&2
+            exit 1
+          fi
 
       - name: Check out exact release tooling
         uses: actions/checkout@v7
@@ -121,6 +136,8 @@ jobs:
       TAG_TYPE: ${{ needs.preflight.outputs.tag_type }}
       IMAGE_REPOSITORY: ${{ needs.preflight.outputs.image_repository }}
       TOOLING_SHA: ${{ needs.preflight.outputs.tooling_sha }}
+      RELEASE_EVENT_NAME: ${{ github.event_name }}
+      RECOVERY_RELEASE_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.release_id || '' }}
       TOOLING_ROOT: ${{ github.workspace }}/tooling
       RELEASE_SOURCE_ROOT: ${{ github.workspace }}/release-source
       ASSET_DIR: ${{ github.workspace }}/release-assets

--- a/packages/config/test/release-orchestrator.test.ts
+++ b/packages/config/test/release-orchestrator.test.ts
@@ -14,16 +14,26 @@ import {
 
 import {
   assetDirectory,
+  createDraftInput,
+  draftReleaseInput,
+  ensureDraftRelease,
   getReleaseById,
+  publishDraftRelease,
+  publishedReleaseInput,
   readPackageVersions,
   readReleaseTemplates,
   reconcileReleaseAssets,
   releaseAssetUploadUrl,
+  requiredRecoveryReleaseId,
   requiredReleaseId,
+  resolveDraftReleaseById,
+  resolvePublishedReleaseById,
   resolveReleaseById,
   resolveTagIdentity,
   uploadMissingDraftAssets,
   uploadReleaseAsset,
+  validateResolvedDraftRelease,
+  validateResolvedPublishedRelease,
   validateResolvedRelease,
   verifyPreflightToolingIdentity,
   waitForRequiredCi,
@@ -58,6 +68,8 @@ const complete = buildReleaseProvenance({
 const release = {
   id: 42,
   tag_name: context.release.tag,
+  target_commitish: context.releaseSha,
+  name: context.release.tag,
   draft: true,
   prerelease: true,
   body: appendReleaseProvenance({
@@ -254,6 +266,18 @@ describe("exact release resolution", () => {
     expect(fetchRelease).not.toHaveBeenCalled();
   });
 
+  it("requires a canonical explicit release ID for manual recovery", () => {
+    vi.stubEnv("RECOVERY_RELEASE_ID", "358962791");
+    expect(requiredRecoveryReleaseId()).toBe(358962791);
+
+    for (const value of ["", "0", "-1", "01", "draft-42"]) {
+      vi.stubEnv("RECOVERY_RELEASE_ID", value);
+      expect(() => requiredRecoveryReleaseId()).toThrow(
+        /RECOVERY_RELEASE_ID|never auto-selected/u,
+      );
+    }
+  });
+
   it("loads the exact release endpoint without collection or tag lookup", () => {
     const request = vi.fn(() => release);
 
@@ -284,9 +308,76 @@ describe("exact release resolution", () => {
     ).toThrow(failure);
   });
 
+  it("accepts a strict untagged placeholder only for a compatible draft", () => {
+    const orphan = {
+      ...release,
+      tag_name: "untagged-2e5ab47a7bad2083661e",
+      target_commitish: "main",
+    };
+
+    expect(
+      validateResolvedDraftRelease({
+        release: orphan,
+        context,
+        releaseId: release.id,
+        allowLegacyTarget: true,
+      }),
+    ).toEqual(expect.objectContaining({ provenance: complete }));
+    expect(() =>
+      validateResolvedDraftRelease({
+        release: orphan,
+        context,
+        releaseId: release.id,
+      }),
+    ).toThrow(`Draft target is main; expected ${context.releaseSha}.`);
+    expect(() =>
+      validateResolvedDraftRelease({
+        release: { ...orphan, tag_name: "untagged-ABC" },
+        context,
+        releaseId: release.id,
+        allowLegacyTarget: true,
+      }),
+    ).toThrow("strict untagged placeholder");
+  });
+
+  it("keeps provenance authoritative when a draft has an exact ID", () => {
+    const placeholder = {
+      ...release,
+      tag_name: "untagged-2e5ab47a7bad2083661e",
+      body: appendReleaseProvenance({
+        body: "Generated release notes.\n",
+        provenance: { ...complete, tagObject: "3".repeat(40) },
+      }),
+    };
+
+    expect(() =>
+      validateResolvedDraftRelease({
+        release: placeholder,
+        context,
+        releaseId: release.id,
+      }),
+    ).toThrow("Release provenance tag identity conflicts with current tag.");
+  });
+
+  it("rejects untagged placeholders after publication", () => {
+    expect(() =>
+      validateResolvedPublishedRelease({
+        release: {
+          ...release,
+          draft: false,
+          tag_name: "untagged-2e5ab47a7bad2083661e",
+        },
+        context,
+        releaseId: release.id,
+      }),
+    ).toThrow(
+      "Published release tag is untagged-2e5ab47a7bad2083661e; expected v1.0.0-rc.7.",
+    );
+  });
+
   it("validates exact ID, tag, prerelease state, and provenance identity", () => {
     expect(
-      resolveReleaseById({
+      resolveDraftReleaseById({
         context,
         releaseId: release.id,
         fetchRelease: () => release,
@@ -306,7 +397,9 @@ describe("exact release resolution", () => {
         releaseId: release.id,
         fetchRelease: () => ({ ...release, tag_name: "v1.0.0-rc.6" }),
       }),
-    ).toThrow("Release tag is v1.0.0-rc.6; expected v1.0.0-rc.7.");
+    ).toThrow(
+      "Draft release tag is v1.0.0-rc.6; expected v1.0.0-rc.7 or a strict untagged placeholder.",
+    );
     expect(() =>
       resolveReleaseById({
         context,
@@ -344,6 +437,186 @@ describe("exact release resolution", () => {
         releaseId: release.id,
       }),
     ).toThrow("Release ID is 43; expected 42.");
+  });
+
+  it("manual recovery exact-fetches, validates, then normalizes one draft", () => {
+    const orphan = {
+      ...release,
+      tag_name: "untagged-2e5ab47a7bad2083661e",
+      target_commitish: "main",
+    };
+    const normalized = {
+      ...orphan,
+      target_commitish: context.releaseSha,
+    };
+    const fetchRelease = vi.fn(() => orphan);
+    const updateRelease = vi.fn(() => normalized);
+    const createRelease = vi.fn();
+
+    expect(
+      ensureDraftRelease({
+        context,
+        eventName: "workflow_dispatch",
+        provenance: complete,
+        recoveryReleaseId: release.id,
+        fetchRelease,
+        updateRelease,
+        createRelease,
+      }),
+    ).toEqual(expect.objectContaining({ release: normalized }));
+    expect(fetchRelease).toHaveBeenCalledWith(context.repository, release.id);
+    expect(createRelease).not.toHaveBeenCalled();
+    expect(updateRelease).toHaveBeenCalledWith(
+      context.repository,
+      release.id,
+      expect.objectContaining({
+        tag_name: context.release.tag,
+        target_commitish: context.releaseSha,
+        name: context.release.tag,
+        body: orphan.body,
+        draft: true,
+        prerelease: true,
+        make_latest: "false",
+      }),
+    );
+  });
+
+  it("fails closed instead of selecting among compatible orphan drafts", () => {
+    const compatibleDrafts = [
+      release,
+      { ...release, id: 43, tag_name: "untagged-aaaaaaaaaaaaaaaaaaaa" },
+    ];
+    const fetchRelease = vi.fn((_repository: string, releaseId: number) =>
+      compatibleDrafts.find((candidate) => candidate.id === releaseId),
+    );
+    const updateRelease = vi.fn();
+    const createRelease = vi.fn();
+    vi.stubEnv("RECOVERY_RELEASE_ID", "");
+
+    expect(() =>
+      ensureDraftRelease({
+        context,
+        eventName: "workflow_dispatch",
+        provenance: complete,
+        fetchRelease,
+        updateRelease,
+        createRelease,
+      }),
+    ).toThrow("compatible drafts are never auto-selected");
+    expect(fetchRelease).not.toHaveBeenCalled();
+    expect(updateRelease).not.toHaveBeenCalled();
+    expect(createRelease).not.toHaveBeenCalled();
+  });
+
+  it("creates tag-push drafts against the exact peeled commit", () => {
+    expect(
+      createDraftInput({
+        context,
+        generated: { name: "Release candidate", body: "Notes.\n" },
+        provenance: complete,
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        tag_name: context.release.tag,
+        target_commitish: context.releaseSha,
+        name: "Release candidate",
+        draft: true,
+        prerelease: true,
+        make_latest: "false",
+      }),
+    );
+  });
+
+  it("preserves intended targeting in draft and published PATCH inputs", () => {
+    expect(draftReleaseInput({ context, release })).toEqual(
+      expect.objectContaining({
+        tag_name: context.release.tag,
+        target_commitish: context.releaseSha,
+        name: context.release.tag,
+        body: release.body,
+        draft: true,
+        prerelease: true,
+        make_latest: "false",
+      }),
+    );
+    expect(publishedReleaseInput({ context, release })).toEqual(
+      expect.objectContaining({
+        tag_name: context.release.tag,
+        target_commitish: context.releaseSha,
+        name: context.release.tag,
+        body: release.body,
+        draft: false,
+        prerelease: true,
+        make_latest: "false",
+      }),
+    );
+  });
+
+  it("publishes and exact-fetches the same ID bound to real tag and commit", () => {
+    const published = {
+      ...release,
+      draft: false,
+      tag_name: context.release.tag,
+      target_commitish: context.releaseSha,
+    };
+    const updateRelease = vi.fn(() => published);
+    const fetchRelease = vi.fn(() => ({ ...published }));
+
+    expect(
+      publishDraftRelease({
+        context,
+        release,
+        updateRelease,
+        fetchRelease,
+      }),
+    ).toEqual(published);
+    expect(updateRelease).toHaveBeenCalledWith(
+      context.repository,
+      release.id,
+      expect.objectContaining({
+        tag_name: context.release.tag,
+        target_commitish: context.releaseSha,
+        draft: false,
+        prerelease: true,
+        make_latest: "false",
+      }),
+    );
+    expect(fetchRelease).toHaveBeenCalledWith(context.repository, release.id);
+    expect(
+      resolvePublishedReleaseById({
+        context,
+        releaseId: release.id,
+        fetchRelease,
+      }).release.id,
+    ).toBe(release.id);
+  });
+
+  it("requires both publication response and subsequent GET to expose real tag", () => {
+    const placeholder = {
+      ...release,
+      draft: false,
+      tag_name: "untagged-2e5ab47a7bad2083661e",
+    };
+    const fetchRelease = vi.fn();
+
+    expect(() =>
+      publishDraftRelease({
+        context,
+        release,
+        updateRelease: () => placeholder,
+        fetchRelease,
+      }),
+    ).toThrow("Published release tag is untagged-");
+    expect(fetchRelease).not.toHaveBeenCalled();
+
+    expect(() =>
+      publishDraftRelease({
+        context,
+        release,
+        updateRelease: () => ({ ...release, draft: false }),
+        fetchRelease: () => placeholder,
+      }),
+    ).toThrow("Published release tag is untagged-");
   });
 });
 

--- a/packages/config/test/release-workflow.test.ts
+++ b/packages/config/test/release-workflow.test.ts
@@ -102,16 +102,32 @@ describe("release workflow recovery topology", () => {
     expect(inspectImage).toBeGreaterThan(captureReleaseId);
   });
 
-  it("uses tag discovery only for ensure-draft, then stays on exact ID", async () => {
+  it("requires an explicit exact ID for manual recovery", async () => {
+    const workflow = await readWorkflow();
+
+    expect(workflow).toContain(
+      "release_id:\n        description: Exact existing draft release ID to resume\n        required: true",
+    );
+    expect(workflow).toContain(
+      "RECOVERY_RELEASE_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.release_id || '' }}",
+    );
+    expect(workflow).toContain(
+      'if [[ ! "$RECOVERY_RELEASE_ID" =~ ^[1-9][0-9]*$ ]]; then',
+    );
+    expect(workflow).toContain("RELEASE_EVENT_NAME: ${{ github.event_name }}");
+  });
+
+  it("never discovers a draft by release collection or tag", async () => {
     const orchestrator = await readOrchestrator();
     const postResolution = orchestrator.slice(
       orchestrator.indexOf("const commandInspectImage"),
     );
 
-    expect(orchestrator.match(/findReleaseByTag\(/gu)).toHaveLength(1);
-    expect(orchestrator).toContain("const findReleaseByTag =");
+    expect(orchestrator).not.toContain("findReleaseByTag");
+    expect(orchestrator).not.toContain("getReleases");
+    expect(orchestrator).not.toMatch(/releases\?per_page/u);
     expect(orchestrator).toContain(
-      "let release = findReleaseByTag(context.repository, context.release.tag);",
+      "const resolved = fetchRelease(context.repository, releaseId);",
     );
     expect(postResolution).not.toContain("findReleaseByTag(");
     expect(postResolution).not.toContain("getReleases(");
@@ -119,7 +135,7 @@ describe("release workflow recovery topology", () => {
       "const refreshed = await refreshRelease(context.repository, release.id);",
     );
     expect(postResolution).toContain(
-      "let { release, provenance } = resolveReleaseById({ context, releaseId });",
+      "const { release, provenance } = resolveDraftReleaseById({",
     );
     expect(postResolution).toContain(
       "const release = requirePublishedRelease(context, releaseId);",

--- a/scripts/release/index.mjs
+++ b/scripts/release/index.mjs
@@ -46,6 +46,7 @@ const REQUIRED_ASSET_NAMES = [
 const GITHUB_API_VERSION = "2022-11-28";
 const MISSING_IMAGE_PATTERN =
   /manifest unknown|not found|no such manifest|does not exist/iu;
+const DRAFT_TAG_PLACEHOLDER_PATTERN = /^untagged-[0-9a-f]{20}$/u;
 
 const sleep = (milliseconds) =>
   new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -58,16 +59,28 @@ const requiredEnv = (name) => {
 
 const optionalEnv = (name) => process.env[name]?.trim() ?? "";
 
-const requiredReleaseId = () => {
-  const value = requiredEnv("RELEASE_ID");
+const parseRequiredReleaseId = (name, value) => {
   if (!/^[1-9][0-9]*$/u.test(value)) {
-    throw new Error("RELEASE_ID must be a canonical positive integer.");
+    throw new Error(`${name} must be a canonical positive integer.`);
   }
   const releaseId = Number(value);
   if (!Number.isSafeInteger(releaseId)) {
-    throw new Error("RELEASE_ID must be a safe positive integer.");
+    throw new Error(`${name} must be a safe positive integer.`);
   }
   return releaseId;
+};
+
+const requiredReleaseId = () =>
+  parseRequiredReleaseId("RELEASE_ID", requiredEnv("RELEASE_ID"));
+
+const requiredRecoveryReleaseId = () => {
+  const value = optionalEnv("RECOVERY_RELEASE_ID");
+  if (!value) {
+    throw new Error(
+      "Manual recovery requires explicit canonical RECOVERY_RELEASE_ID; compatible drafts are never auto-selected.",
+    );
+  }
+  return parseRequiredReleaseId("RECOVERY_RELEASE_ID", value);
 };
 
 const requiredAbsolutePath = (name) => {
@@ -392,19 +405,6 @@ const waitForExactCi = async ({ repository, releaseSha }) => {
   }
 };
 
-const getReleases = (repository) =>
-  ghApiPaginated(`repos/${repository}/releases?per_page=100`);
-
-const findReleaseByTag = (repository, tag) => {
-  const releases = getReleases(repository).filter(
-    (release) => release.tag_name === tag,
-  );
-  if (releases.length > 1) {
-    throw new Error(`Multiple GitHub Releases exist for ${tag}.`);
-  }
-  return releases[0] ?? null;
-};
-
 const getReleaseById = (
   repository,
   releaseId,
@@ -422,15 +422,42 @@ const getReleaseAssets = (repository, releaseId) =>
     `repos/${repository}/releases/${releaseId}/assets?per_page=100`,
   );
 
-const verifyReleaseMetadata = ({ release, context }) => {
-  if (release.tag_name !== context.release.tag) {
-    throw new Error(
-      `Release tag is ${release.tag_name}; expected ${context.release.tag}.`,
-    );
+const verifyResolvedReleaseId = ({ release, releaseId }) => {
+  if (!Number.isSafeInteger(release?.id) || release.id <= 0) {
+    throw new Error("GitHub Release returned an invalid numeric ID.");
   }
-  if (Boolean(release.prerelease) !== context.release.prerelease) {
+  if (release.id !== releaseId) {
+    throw new Error(`Release ID is ${release.id}; expected ${releaseId}.`);
+  }
+};
+
+const verifyReleasePrerelease = ({ release, context }) => {
+  if (release.prerelease !== context.release.prerelease) {
     throw new Error(
       `Release prerelease flag is ${String(release.prerelease)}; expected ${String(context.release.prerelease)}.`,
+    );
+  }
+};
+
+const verifyDraftTag = ({ release, context }) => {
+  if (
+    release.tag_name !== context.release.tag &&
+    !DRAFT_TAG_PLACEHOLDER_PATTERN.test(release.tag_name ?? "")
+  ) {
+    throw new Error(
+      `Draft release tag is ${release.tag_name}; expected ${context.release.tag} or a strict untagged placeholder.`,
+    );
+  }
+};
+
+const verifyDraftTarget = ({ release, context, allowLegacyTarget }) => {
+  const compatible =
+    release.target_commitish === context.releaseSha ||
+    release.target_commitish === context.release.tag ||
+    (allowLegacyTarget && release.target_commitish === "main");
+  if (!compatible) {
+    throw new Error(
+      `Draft target is ${release.target_commitish}; expected ${context.releaseSha}.`,
     );
   }
 };
@@ -454,24 +481,61 @@ const verifyReleaseProvenanceIdentity = ({ provenance, context }) => {
   }
 };
 
-const validateReleaseIdentity = ({ release, context }) => {
-  verifyReleaseMetadata({ release, context });
+const validateReleaseProvenance = ({ release, context }) => {
   const parsed = requireReleaseProvenance(release.body);
   verifyReleaseProvenanceIdentity({ provenance: parsed.provenance, context });
-  if (!release.draft && parsed.provenance.imageDigest === "pending") {
-    throw new Error("Published release still has pending image provenance.");
-  }
   return { parsed, provenance: parsed.provenance };
 };
 
-const validateResolvedRelease = ({ release, context, releaseId }) => {
-  if (!Number.isSafeInteger(release?.id) || release.id <= 0) {
-    throw new Error("GitHub Release returned an invalid numeric ID.");
+const validateResolvedDraftRelease = ({
+  release,
+  context,
+  releaseId,
+  allowLegacyTarget = false,
+}) => {
+  verifyResolvedReleaseId({ release, releaseId });
+  if (release.draft !== true) {
+    throw new Error(`GitHub Release ID ${releaseId} is not a draft.`);
   }
-  if (release.id !== releaseId) {
-    throw new Error(`Release ID is ${release.id}; expected ${releaseId}.`);
+  verifyDraftTag({ release, context });
+  verifyReleasePrerelease({ release, context });
+  verifyDraftTarget({ release, context, allowLegacyTarget });
+  return validateReleaseProvenance({ release, context });
+};
+
+const validateResolvedPublishedRelease = ({ release, context, releaseId }) => {
+  verifyResolvedReleaseId({ release, releaseId });
+  if (release.draft !== false) {
+    throw new Error(`GitHub Release ID ${releaseId} is still a draft.`);
   }
-  return validateReleaseIdentity({ release, context });
+  if (release.tag_name !== context.release.tag) {
+    throw new Error(
+      `Published release tag is ${release.tag_name}; expected ${context.release.tag}.`,
+    );
+  }
+  verifyReleasePrerelease({ release, context });
+  const identity = validateReleaseProvenance({ release, context });
+  if (identity.provenance.imageDigest === "pending") {
+    throw new Error("Published release still has pending image provenance.");
+  }
+  return identity;
+};
+
+const validateResolvedRelease = ({
+  release,
+  context,
+  releaseId,
+  allowLegacyTarget = false,
+}) => {
+  if (release?.draft === true) {
+    return validateResolvedDraftRelease({
+      release,
+      context,
+      releaseId,
+      allowLegacyTarget,
+    });
+  }
+  return validateResolvedPublishedRelease({ release, context, releaseId });
 };
 
 const resolveReleaseById = ({
@@ -484,31 +548,63 @@ const resolveReleaseById = ({
   return { release, ...identity };
 };
 
+const resolveDraftReleaseById = ({
+  context,
+  releaseId = requiredReleaseId(),
+  fetchRelease = getReleaseById,
+  allowLegacyTarget = false,
+}) => {
+  const release = fetchRelease(context.repository, releaseId);
+  const identity = validateResolvedDraftRelease({
+    release,
+    context,
+    releaseId,
+    allowLegacyTarget,
+  });
+  return { release, ...identity };
+};
+
+const resolvePublishedReleaseById = ({
+  context,
+  releaseId = requiredReleaseId(),
+  fetchRelease = getReleaseById,
+}) => {
+  const release = fetchRelease(context.repository, releaseId);
+  const identity = validateResolvedPublishedRelease({
+    release,
+    context,
+    releaseId,
+  });
+  return { release, ...identity };
+};
+
 const generateReleaseNotes = (repository, tag) =>
   ghApi(`repos/${repository}/releases/generate-notes`, {
     method: "POST",
     input: { tag_name: tag },
   });
 
+const createDraftInput = ({ context, generated, provenance }) => ({
+  tag_name: context.release.tag,
+  target_commitish: context.releaseSha,
+  name: generated.name || context.release.tag,
+  body: appendReleaseProvenance({
+    body: generated.body ?? "",
+    provenance,
+  }),
+  draft: true,
+  prerelease: context.release.prerelease,
+  make_latest: "false",
+});
+
 const createDraft = ({ context, provenance }) => {
   const generated = generateReleaseNotes(
     context.repository,
     context.release.tag,
   );
-  const body = appendReleaseProvenance({
-    body: generated.body ?? "",
-    provenance,
-  });
   return ghApi(`repos/${context.repository}/releases`, {
     method: "POST",
-    input: {
-      tag_name: context.release.tag,
-      name: generated.name || context.release.tag,
-      body,
-      draft: true,
-      prerelease: context.release.prerelease,
-      make_latest: "false",
-    },
+    input: createDraftInput({ context, generated, provenance }),
   });
 };
 
@@ -517,6 +613,99 @@ const patchRelease = (repository, releaseId, input) =>
     method: "PATCH",
     input,
   });
+
+const draftReleaseInput = ({
+  context,
+  release,
+  body = release.body ?? "",
+}) => ({
+  tag_name: context.release.tag,
+  target_commitish: context.releaseSha,
+  name: release.name || context.release.tag,
+  body,
+  draft: true,
+  prerelease: context.release.prerelease,
+  make_latest: "false",
+});
+
+const publishedReleaseInput = ({ context, release, makeLatest = "false" }) => ({
+  tag_name: context.release.tag,
+  target_commitish: context.releaseSha,
+  name: release.name || context.release.tag,
+  body: release.body ?? "",
+  draft: false,
+  prerelease: context.release.prerelease,
+  make_latest: makeLatest,
+});
+
+const ensureDraftRelease = ({
+  context,
+  eventName,
+  provenance,
+  recoveryReleaseId,
+  fetchRelease = getReleaseById,
+  createRelease = createDraft,
+  updateRelease = patchRelease,
+}) => {
+  if (eventName === "push") {
+    const release = createRelease({ context, provenance });
+    const identity = validateResolvedDraftRelease({
+      release,
+      context,
+      releaseId: release?.id,
+    });
+    return { release, ...identity };
+  }
+  if (eventName !== "workflow_dispatch") {
+    throw new Error(`Unsupported release event: ${eventName}.`);
+  }
+
+  const releaseId = recoveryReleaseId ?? requiredRecoveryReleaseId();
+  const resolved = fetchRelease(context.repository, releaseId);
+  validateResolvedDraftRelease({
+    release: resolved,
+    context,
+    releaseId,
+    allowLegacyTarget: true,
+  });
+  const release = updateRelease(
+    context.repository,
+    releaseId,
+    draftReleaseInput({ context, release: resolved }),
+  );
+  const identity = validateResolvedDraftRelease({
+    release,
+    context,
+    releaseId,
+  });
+  return { release, ...identity };
+};
+
+const publishDraftRelease = ({
+  context,
+  release,
+  updateRelease = patchRelease,
+  fetchRelease = getReleaseById,
+}) => {
+  const releaseId = release.id;
+  const updated = updateRelease(
+    context.repository,
+    releaseId,
+    publishedReleaseInput({ context, release }),
+  );
+  validateResolvedPublishedRelease({
+    release: updated,
+    context,
+    releaseId,
+  });
+  const published = fetchRelease(context.repository, releaseId);
+  validateResolvedPublishedRelease({
+    release: published,
+    context,
+    releaseId,
+  });
+  return published;
+};
 
 const runImageInspection = (reference, allowMissing) => {
   const result = run(
@@ -1075,17 +1264,12 @@ const commandEnsureDraft = async () => {
     immutableImage: "pending",
     assetChecksums: null,
   });
-  let release = findReleaseByTag(context.repository, context.release.tag);
-  if (!release) release = createDraft({ context, provenance: pending });
-  if (!Number.isSafeInteger(release?.id) || release.id <= 0) {
-    throw new Error("GitHub Release returned an invalid numeric ID.");
-  }
-  const { provenance } = validateResolvedRelease({
-    release,
+  const { release, provenance } = ensureDraftRelease({
     context,
-    releaseId: release.id,
+    eventName: requiredEnv("RELEASE_EVENT_NAME"),
+    provenance: pending,
   });
-  if (release.draft && provenance.imageDigest !== "pending") {
+  if (provenance.imageDigest !== "pending") {
     console.info(
       "Compatible draft already contains complete image provenance.",
     );
@@ -1093,14 +1277,14 @@ const commandEnsureDraft = async () => {
 
   await writeOutputs([
     ["release_id", release.id],
-    ["published", !release.draft],
+    ["published", false],
   ]);
 };
 
 const commandInspectImage = async () => {
   const context = releaseContextFromEnv();
   verifyRecordedTagIdentity(context);
-  const { release, provenance } = resolveReleaseById({ context });
+  const { release, provenance } = resolveDraftReleaseById({ context });
   const exactReference = `${context.imageRepository}:${context.release.tag}`;
   const inspected = inspectImage(exactReference, { allowMissing: true });
   if (!inspected) {
@@ -1219,8 +1403,12 @@ const reconcileDraftProvenance = ({
       expected: provenance,
       next: complete,
     });
-    const updated = patchRelease(context.repository, release.id, { body });
-    validateResolvedRelease({
+    const updated = patchRelease(
+      context.repository,
+      release.id,
+      draftReleaseInput({ context, release, body }),
+    );
+    validateResolvedDraftRelease({
       release: updated,
       context,
       releaseId: release.id,
@@ -1265,7 +1453,7 @@ const uploadMissingDraftAssets = async ({
       `GitHub Release ID ${release.id} is missing after asset upload.`,
     );
   }
-  validateResolvedRelease({
+  validateResolvedDraftRelease({
     release: refreshed,
     context,
     releaseId: release.id,
@@ -1333,7 +1521,7 @@ const commandReconcileRelease = async () => {
   const imageDigest = requiredEnv("IMAGE_DIGEST");
   verifyRecordedTagIdentity(context);
   const localAssets = await generatedAssets();
-  const { release, provenance } = resolveReleaseById({ context });
+  const { release, provenance } = resolveDraftReleaseById({ context });
   const complete = expectedCompleteProvenance({
     context,
     imageDigest,
@@ -1356,7 +1544,10 @@ const commandPublish = async () => {
   verifyImage({ context, digest: imageDigest });
   const localAssets = await generatedAssets();
   const releaseId = requiredReleaseId();
-  let { release, provenance } = resolveReleaseById({ context, releaseId });
+  const { release, provenance } = resolveDraftReleaseById({
+    context,
+    releaseId,
+  });
   const complete = expectedCompleteProvenance({
     context,
     imageDigest,
@@ -1368,16 +1559,9 @@ const commandPublish = async () => {
   await verifyRemoteAssets({ context, release, localAssets });
   verifyRecordedTagIdentity(context);
 
-  if (release.draft) {
-    release = patchRelease(context.repository, release.id, {
-      draft: false,
-      prerelease: context.release.prerelease,
-      make_latest: "false",
-    });
-  }
-  if (release.draft) throw new Error("GitHub Release remained a draft.");
-  validateResolvedRelease({ release, context, releaseId });
-  await verifyRemoteAssets({ context, release, localAssets });
+  const published = publishDraftRelease({ context, release });
+  await verifyRemoteAssets({ context, release: published, localAssets });
+  verifyImage({ context, digest: imageDigest });
   verifyRecordedTagIdentity(context);
 };
 
@@ -1395,10 +1579,7 @@ const handlePrereleaseLatest = async ({ context, imageDigest }) => {
 };
 
 const requirePublishedRelease = (context, releaseId) => {
-  const { release } = resolveReleaseById({ context, releaseId });
-  if (release.draft) {
-    throw new Error("Stable GitHub Release must be published before latest.");
-  }
+  const { release } = resolvePublishedReleaseById({ context, releaseId });
   return release;
 };
 
@@ -1446,11 +1627,19 @@ const verifyLatestResult = ({
 
 const markGitHubReleaseLatest = ({ context, release, plan }) => {
   if (plan.action === "superseded") return;
-  const updated = patchRelease(context.repository, release.id, {
-    make_latest: "true",
-  });
-  validateResolvedRelease({
+  const updated = patchRelease(
+    context.repository,
+    release.id,
+    publishedReleaseInput({ context, release, makeLatest: "true" }),
+  );
+  validateResolvedPublishedRelease({
     release: updated,
+    context,
+    releaseId: release.id,
+  });
+  const refreshed = getReleaseById(context.repository, release.id);
+  validateResolvedPublishedRelease({
+    release: refreshed,
     context,
     releaseId: release.id,
   });
@@ -1529,16 +1718,26 @@ const commands = {
 
 export {
   assetDirectory,
+  createDraftInput,
+  draftReleaseInput,
+  ensureDraftRelease,
   getReleaseById,
+  publishDraftRelease,
+  publishedReleaseInput,
   readPackageVersions,
   readReleaseTemplates,
   reconcileReleaseAssets,
   releaseAssetUploadUrl,
+  requiredRecoveryReleaseId,
   requiredReleaseId,
+  resolveDraftReleaseById,
+  resolvePublishedReleaseById,
   resolveReleaseById,
   resolveTagIdentity,
   uploadMissingDraftAssets,
   uploadReleaseAsset,
+  validateResolvedDraftRelease,
+  validateResolvedPublishedRelease,
   validateResolvedRelease,
   verifyPreflightToolingIdentity,
   waitForRequiredCi,


### PR DESCRIPTION
## 🚀 Summary

Fix REL-01 recovery for GitHub draft releases whose API `tag_name` is a strict `untagged-<hex>` placeholder.

- Separate draft and published identity contracts.
- Make managed provenance authoritative for draft identity.
- Require manual recovery to supply one exact release ID.
- Bind creation, metadata reconciliation, publication, and latest promotion to the intended tag and peeled commit.
- Keep matching partial assets; reject conflicts before publication.

Read-only production inventory found 3 managed-provenance matching orphan drafts for `v1.0.0-rc.7`:

- `358875474`: `untagged-396ff8396dbbf3237cfe`; name `v1.0.0-rc.7`; draft/prerelease; target `main`; created `2026-07-23T18:24:57Z`; updated `2026-07-23T18:32:39Z`; no assets.
- `358937700`: `untagged-bea735233c6cf5fc799e`; name `v1.0.0-rc.7`; draft/prerelease; target `main`; created `2026-07-23T18:24:57Z`; updated `2026-07-23T20:30:51Z`; all 4 required assets present, uploaded, and byte/checksum-compatible.
- `358962791`: `untagged-2e5ab47a7bad2083661e`; name `v1.0.0-rc.7`; draft/prerelease; target `main`; created `2026-07-23T18:24:57Z`; updated `2026-07-23T21:23:43Z`; no assets.

All 3 have exact managed tag, release commit, tag object, image digest, and expected asset checksum provenance. No candidate was selected or modified during inventory.

## 📊 Impacts and Changes

Operational release behavior only. Manual recovery must be dispatched from `main` with a canonical positive `release_id`. Normal tag pushes create a draft against the exact peeled commit and retain its returned ID.

Drafts accept either the real tag or strict 20-character lowercase-hex `untagged-*` placeholder, but only with exact ID, prerelease state, managed provenance, tag object, and peeled commit identity. Published releases require the real tag. Publication PATCH explicitly sends the real tag, exact commit, `draft: false`, prerelease state, and `make_latest: false`; both PATCH response and subsequent exact GET must validate.

Schema/auth/storage/restore behavior: none.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] UI/UX unchanged; manual UI verification is not applicable.

Additional validation:

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm db:generate`
- [x] `pnpm --filter @staaash/db build`
- [x] Focused release tests: 36 passed
- [x] `pnpm format:check`
- [x] `pnpm quality:fallow`: no issues in changed files
- [x] `pnpm test:postgres`: 23 passed using isolated PostgreSQL 18; exact container removed
- [x] `git diff --check`

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

No automated candidate selection by design. Operator must inspect inventory and explicitly choose the intended release ID before manual recovery. This PR does not run recovery or modify production release state.

Local `actionlint` was unavailable; workflow regression tests and Prettier YAML validation passed.

## 🔗 Linked Issues

REL-01