### PR TITLE
Fix release draft recovery mutations

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -26,7 +26,7 @@ Alpha and beta releases remain unsupported development history. Their prerelease
 1. Select immutable tooling and source checkouts. Tag pushes use tooling committed in the release tag. Manual recovery uses the exact reviewed `main` commit that defined the dispatched workflow. Release source always comes from the requested tag.
 2. Resolve the tag object and peeled commit; require the commit on current `main`.
 3. Verify all package versions plus successful exact-SHA `CI` main-push runs for the release commit and, when different during recovery, the tooling commit.
-4. Create or verify a hidden draft GitHub Release with generated notes and managed provenance.
+4. Create a hidden draft GitHub Release for a tag push, or resolve the exact release ID supplied for manual recovery, then validate managed provenance.
 5. Build the exact versioned image once, or reuse a matching existing image.
 6. Capture and remotely verify the top-level OCI index digest, OCI labels, and final web/worker runtime versions.
 7. Generate release-specific `docker-compose.yml`, `example.env`, `release-manifest.json`, and `SHA256SUMS`.
@@ -38,7 +38,9 @@ Every SemVer prerelease skips both latest-channel mutations. A stable release is
 
 ## Recovery
 
-Use **Actions → Release → Run workflow** from `main` with the same existing tag. Never dispatch recovery from another branch, and never move or recreate the tag to retry.
+Use **Actions → Release → Run workflow** from `main` with the same existing tag and exact existing GitHub Release ID. Never dispatch recovery from another branch, and never move or recreate the tag to retry.
+
+GitHub may expose a draft release through an `untagged-<20 lowercase hex>` placeholder and report `target_commitish` as `main`, including when the real tag already exists. Those draft fields are not release identity. Recovery binds to the explicit numeric release ID, prerelease state, and managed provenance containing the expected tag, peeled commit, and annotated tag object. The workflow does not rewrite draft tag or target metadata; publication lets GitHub expose the real tag, then validates it through the exact release ID.
 
 Manual recovery records the exact `main` commit selected by GitHub as the recovery-tooling SHA and requires a successful exact-SHA `CI` main-push run for it. The orchestrator and compiled release policy run from that immutable tooling checkout. Package versions, Git identity, templates, Docker build context, generated assets, image labels, and release provenance remain sourced from the separate immutable release-tag checkout. Workflow summaries report both the tag object/peeled release commit and the recovery-tooling commit.
 
@@ -71,7 +73,7 @@ Do not use asset clobbering, force-push tags, delete releases, or overwrite imag
 - Publication failure: complete draft remains retryable; `latest` cannot change.
 - Stable `latest` failure: exact GitHub Release remains complete, tag-selected, and digest-verified. Retry performs verification and pending promotion without rebuilding.
 
-Each failed workflow writes retry and investigation guidance to its job summary.
+Each failed workflow writes the exact release ID, when resolved, plus retry and investigation guidance to its job summary.
 
 ## Release assets
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
         required: true
         type: string
       release_id:
-        description: Exact existing draft release ID to resume
+        description: Exact existing release ID to resume
         required: true
         type: string
 
@@ -34,9 +34,7 @@ jobs:
       tag_object: ${{ steps.preflight.outputs.tag_object }}
       tag_type: ${{ steps.preflight.outputs.tag_type }}
       image_repository: ${{ steps.preflight.outputs.image_repository }}
-      release_ci_run_id: ${{ steps.preflight.outputs.release_ci_run_id }}
       tooling_sha: ${{ steps.preflight.outputs.tooling_sha }}
-      tooling_ci_run_id: ${{ steps.preflight.outputs.tooling_ci_run_id }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
@@ -188,9 +186,9 @@ jobs:
       - name: Recheck immutable tooling and tag identity
         run: node tooling/scripts/release/index.mjs verify-tag
 
-      - name: Create or verify draft release
+      - name: Create or resolve release
         id: release
-        run: node tooling/scripts/release/index.mjs ensure-draft
+        run: node tooling/scripts/release/index.mjs ensure-release
 
       - name: Capture exact release ID
         shell: bash

--- a/packages/config/test/release-orchestrator.test.ts
+++ b/packages/config/test/release-orchestrator.test.ts
@@ -15,18 +15,17 @@ import {
 import {
   assetDirectory,
   createDraftInput,
-  draftReleaseInput,
-  ensureDraftRelease,
+  ensureReleaseState,
   getReleaseById,
+  markGitHubReleaseLatest,
   publishDraftRelease,
-  publishedReleaseInput,
   readPackageVersions,
   readReleaseTemplates,
+  reconcileDraftProvenance,
   reconcileReleaseAssets,
   releaseAssetUploadUrl,
   requiredRecoveryReleaseId,
   requiredReleaseId,
-  resolveDraftReleaseById,
   resolvePublishedReleaseById,
   resolveReleaseById,
   resolveTagIdentity,
@@ -308,7 +307,7 @@ describe("exact release resolution", () => {
     ).toThrow(failure);
   });
 
-  it("accepts a strict untagged placeholder only for a compatible draft", () => {
+  it("accepts a strict untagged placeholder without trusting draft target", () => {
     const orphan = {
       ...release,
       tag_name: "untagged-2e5ab47a7bad2083661e",
@@ -320,22 +319,13 @@ describe("exact release resolution", () => {
         release: orphan,
         context,
         releaseId: release.id,
-        allowLegacyTarget: true,
       }),
     ).toEqual(expect.objectContaining({ provenance: complete }));
-    expect(() =>
-      validateResolvedDraftRelease({
-        release: orphan,
-        context,
-        releaseId: release.id,
-      }),
-    ).toThrow(`Draft target is main; expected ${context.releaseSha}.`);
     expect(() =>
       validateResolvedDraftRelease({
         release: { ...orphan, tag_name: "untagged-ABC" },
         context,
         releaseId: release.id,
-        allowLegacyTarget: true,
       }),
     ).toThrow("strict untagged placeholder");
   });
@@ -377,7 +367,7 @@ describe("exact release resolution", () => {
 
   it("validates exact ID, tag, prerelease state, and provenance identity", () => {
     expect(
-      resolveDraftReleaseById({
+      resolveReleaseById({
         context,
         releaseId: release.id,
         fetchRelease: () => release,
@@ -439,46 +429,71 @@ describe("exact release resolution", () => {
     ).toThrow("Release ID is 43; expected 42.");
   });
 
-  it("manual recovery exact-fetches, validates, then normalizes one draft", () => {
+  it("manual recovery exact-fetches and does not mutate one draft", () => {
     const orphan = {
       ...release,
       tag_name: "untagged-2e5ab47a7bad2083661e",
       target_commitish: "main",
     };
-    const normalized = {
-      ...orphan,
-      target_commitish: context.releaseSha,
-    };
     const fetchRelease = vi.fn(() => orphan);
-    const updateRelease = vi.fn(() => normalized);
     const createRelease = vi.fn();
 
     expect(
-      ensureDraftRelease({
+      ensureReleaseState({
         context,
         eventName: "workflow_dispatch",
         provenance: complete,
         recoveryReleaseId: release.id,
         fetchRelease,
-        updateRelease,
         createRelease,
       }),
-    ).toEqual(expect.objectContaining({ release: normalized }));
+    ).toEqual(expect.objectContaining({ release: orphan }));
     expect(fetchRelease).toHaveBeenCalledWith(context.repository, release.id);
     expect(createRelease).not.toHaveBeenCalled();
-    expect(updateRelease).toHaveBeenCalledWith(
-      context.repository,
-      release.id,
-      expect.objectContaining({
-        tag_name: context.release.tag,
-        target_commitish: context.releaseSha,
-        name: context.release.tag,
-        body: orphan.body,
-        draft: true,
-        prerelease: true,
-        make_latest: "false",
+  });
+
+  it("manual recovery accepts an already-published exact release", () => {
+    const published = { ...release, draft: false };
+    const fetchRelease = vi.fn(() => published);
+    const createRelease = vi.fn();
+
+    expect(
+      ensureReleaseState({
+        context,
+        eventName: "workflow_dispatch",
+        provenance: complete,
+        recoveryReleaseId: release.id,
+        fetchRelease,
+        createRelease,
       }),
-    );
+    ).toEqual(expect.objectContaining({ release: published }));
+    expect(fetchRelease).toHaveBeenCalledWith(context.repository, release.id);
+    expect(createRelease).not.toHaveBeenCalled();
+  });
+
+  it("accepts a live-shaped placeholder response after tag-push creation", () => {
+    const placeholder = {
+      ...release,
+      tag_name: "untagged-2e5ab47a7bad2083661e",
+      target_commitish: "main",
+    };
+    const fetchRelease = vi.fn();
+    const createRelease = vi.fn(() => placeholder);
+
+    expect(
+      ensureReleaseState({
+        context,
+        eventName: "push",
+        provenance: complete,
+        fetchRelease,
+        createRelease,
+      }),
+    ).toEqual(expect.objectContaining({ release: placeholder }));
+    expect(createRelease).toHaveBeenCalledWith({
+      context,
+      provenance: complete,
+    });
+    expect(fetchRelease).not.toHaveBeenCalled();
   });
 
   it("fails closed instead of selecting among compatible orphan drafts", () => {
@@ -489,67 +504,79 @@ describe("exact release resolution", () => {
     const fetchRelease = vi.fn((_repository: string, releaseId: number) =>
       compatibleDrafts.find((candidate) => candidate.id === releaseId),
     );
-    const updateRelease = vi.fn();
     const createRelease = vi.fn();
     vi.stubEnv("RECOVERY_RELEASE_ID", "");
 
     expect(() =>
-      ensureDraftRelease({
+      ensureReleaseState({
         context,
         eventName: "workflow_dispatch",
         provenance: complete,
         fetchRelease,
-        updateRelease,
         createRelease,
       }),
     ).toThrow("compatible drafts are never auto-selected");
     expect(fetchRelease).not.toHaveBeenCalled();
-    expect(updateRelease).not.toHaveBeenCalled();
     expect(createRelease).not.toHaveBeenCalled();
   });
 
-  it("creates tag-push drafts against the exact peeled commit", () => {
-    expect(
-      createDraftInput({
-        context,
-        generated: { name: "Release candidate", body: "Notes.\n" },
-        provenance: complete,
-      }),
-    ).toEqual(
+  it("creates tag-push drafts without redundant target or latest fields", () => {
+    const input = createDraftInput({
+      context,
+      generated: { name: "Release candidate", body: "Notes.\n" },
+      provenance: complete,
+    });
+
+    expect(input).toEqual(
       expect.objectContaining({
         tag_name: context.release.tag,
-        target_commitish: context.releaseSha,
         name: "Release candidate",
         draft: true,
         prerelease: true,
-        make_latest: "false",
       }),
     );
+    expect(input).not.toHaveProperty("target_commitish");
+    expect(input).not.toHaveProperty("make_latest");
+    expect(Object.keys(input).sort()).toEqual([
+      "body",
+      "draft",
+      "name",
+      "prerelease",
+      "tag_name",
+    ]);
   });
 
-  it("preserves intended targeting in draft and published PATCH inputs", () => {
-    expect(draftReleaseInput({ context, release })).toEqual(
-      expect.objectContaining({
-        tag_name: context.release.tag,
-        target_commitish: context.releaseSha,
-        name: context.release.tag,
-        body: release.body,
-        draft: true,
-        prerelease: true,
-        make_latest: "false",
-      }),
-    );
-    expect(publishedReleaseInput({ context, release })).toEqual(
-      expect.objectContaining({
-        tag_name: context.release.tag,
-        target_commitish: context.releaseSha,
-        name: context.release.tag,
-        body: release.body,
-        draft: false,
-        prerelease: true,
-        make_latest: "false",
-      }),
-    );
+  it("patches only the body when completing draft provenance", () => {
+    const pending = buildReleaseProvenance({
+      tag: context.release.tag,
+      commit: context.releaseSha,
+      tagObject: context.tagObject,
+      imageDigest: "pending",
+      immutableImage: "pending",
+      assetChecksums: null,
+    });
+    const pendingRelease = {
+      ...release,
+      tag_name: "untagged-2e5ab47a7bad2083661e",
+      target_commitish: "main",
+      body: appendReleaseProvenance({ body: "Notes.\n", provenance: pending }),
+    };
+    const updateRelease = vi.fn((_repository, _releaseId, input) => ({
+      ...pendingRelease,
+      body: input.body,
+    }));
+
+    reconcileDraftProvenance({
+      context,
+      release: pendingRelease,
+      provenance: pending,
+      complete,
+      updateRelease,
+    });
+
+    expect(updateRelease).toHaveBeenCalledWith(context.repository, release.id, {
+      body: expect.any(String),
+    });
   });
 
   it("publishes and exact-fetches the same ID bound to real tag and commit", () => {
@@ -557,7 +584,7 @@ describe("exact release resolution", () => {
       ...release,
       draft: false,
       tag_name: context.release.tag,
-      target_commitish: context.releaseSha,
+      target_commitish: "main",
     };
     const updateRelease = vi.fn(() => published);
     const fetchRelease = vi.fn(() => ({ ...published }));
@@ -570,17 +597,10 @@ describe("exact release resolution", () => {
         fetchRelease,
       }),
     ).toEqual(published);
-    expect(updateRelease).toHaveBeenCalledWith(
-      context.repository,
-      release.id,
-      expect.objectContaining({
-        tag_name: context.release.tag,
-        target_commitish: context.releaseSha,
-        draft: false,
-        prerelease: true,
-        make_latest: "false",
-      }),
-    );
+    expect(updateRelease).toHaveBeenCalledWith(context.repository, release.id, {
+      draft: false,
+      make_latest: "false",
+    });
     expect(fetchRelease).toHaveBeenCalledWith(context.repository, release.id);
     expect(
       resolvePublishedReleaseById({
@@ -617,6 +637,49 @@ describe("exact release resolution", () => {
         fetchRelease: () => placeholder,
       }),
     ).toThrow("Published release tag is untagged-");
+  });
+
+  it("marks a stable published release latest with one minimal field", () => {
+    const stableContext = {
+      ...context,
+      release: { tag: "v1.0.0", prerelease: false },
+    };
+    const stableProvenance = buildReleaseProvenance({
+      tag: stableContext.release.tag,
+      commit: stableContext.releaseSha,
+      tagObject: stableContext.tagObject,
+      imageDigest: `sha256:${"b".repeat(64)}`,
+      immutableImage: `ghcr.io/itsmeares/staaash:v1.0.0@sha256:${"b".repeat(64)}`,
+      assetChecksums: {},
+    });
+    const stableRelease = {
+      ...release,
+      tag_name: stableContext.release.tag,
+      draft: false,
+      prerelease: false,
+      body: appendReleaseProvenance({
+        body: "Stable notes.\n",
+        provenance: stableProvenance,
+      }),
+    };
+    const updateRelease = vi.fn(() => stableRelease);
+    const fetchRelease = vi.fn(() => stableRelease);
+    const fetchLatestRelease = vi.fn(() => stableRelease);
+
+    markGitHubReleaseLatest({
+      context: stableContext,
+      release: stableRelease,
+      plan: { action: "promote" },
+      updateRelease,
+      fetchRelease,
+      fetchLatestRelease,
+    });
+
+    expect(updateRelease).toHaveBeenCalledWith(
+      stableContext.repository,
+      stableRelease.id,
+      { make_latest: "true" },
+    );
   });
 });
 

--- a/packages/config/test/release-workflow.test.ts
+++ b/packages/config/test/release-workflow.test.ts
@@ -31,9 +31,7 @@ describe("release workflow recovery topology", () => {
       "ref: ${{ needs.preflight.outputs.tooling_sha }}",
     );
     expect(workflow).toContain("TOOLING_SHA: ${{ steps.tooling.outputs.sha }}");
-    expect(workflow).toContain(
-      "tooling_ci_run_id: ${{ steps.preflight.outputs.tooling_ci_run_id }}",
-    );
+    expect(workflow).not.toContain("tooling_ci_run_id:");
   });
 
   it("keeps release source separate and tied to requested tag", async () => {
@@ -68,16 +66,12 @@ describe("release workflow recovery topology", () => {
     expect(workflow).toContain(
       "tooling_sha: ${{ steps.preflight.outputs.tooling_sha }}",
     );
-    expect(workflow).toContain(
-      "release_ci_run_id: ${{ steps.preflight.outputs.release_ci_run_id }}",
-    );
+    expect(workflow).not.toContain("release_ci_run_id:");
   });
 
-  it("propagates the resolved draft release ID to every later step", async () => {
+  it("propagates the resolved release ID to every later step", async () => {
     const workflow = await readWorkflow();
-    const ensureDraft = workflow.indexOf(
-      "- name: Create or verify draft release",
-    );
+    const ensureRelease = workflow.indexOf("- name: Create or resolve release");
     const captureReleaseId = workflow.indexOf(
       "- name: Capture exact release ID",
     );
@@ -86,7 +80,7 @@ describe("release workflow recovery topology", () => {
     );
 
     expect(workflow).toContain(
-      "- name: Create or verify draft release\n        id: release",
+      "- name: Create or resolve release\n        id: release",
     );
     expect(workflow).toContain(
       "RESOLVED_RELEASE_ID: ${{ steps.release.outputs.release_id }}",
@@ -97,8 +91,8 @@ describe("release workflow recovery topology", () => {
     expect(workflow).toContain(
       'echo "RELEASE_ID=$RESOLVED_RELEASE_ID" >> "$GITHUB_ENV"',
     );
-    expect(ensureDraft).toBeGreaterThan(-1);
-    expect(captureReleaseId).toBeGreaterThan(ensureDraft);
+    expect(ensureRelease).toBeGreaterThan(-1);
+    expect(captureReleaseId).toBeGreaterThan(ensureRelease);
     expect(inspectImage).toBeGreaterThan(captureReleaseId);
   });
 
@@ -106,7 +100,7 @@ describe("release workflow recovery topology", () => {
     const workflow = await readWorkflow();
 
     expect(workflow).toContain(
-      "release_id:\n        description: Exact existing draft release ID to resume\n        required: true",
+      "release_id:\n        description: Exact existing release ID to resume\n        required: true",
     );
     expect(workflow).toContain(
       "RECOVERY_RELEASE_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.release_id || '' }}",
@@ -127,16 +121,14 @@ describe("release workflow recovery topology", () => {
     expect(orchestrator).not.toContain("getReleases");
     expect(orchestrator).not.toMatch(/releases\?per_page/u);
     expect(orchestrator).toContain(
-      "const resolved = fetchRelease(context.repository, releaseId);",
+      "const release = fetchRelease(context.repository, releaseId);",
     );
     expect(postResolution).not.toContain("findReleaseByTag(");
     expect(postResolution).not.toContain("getReleases(");
     expect(postResolution).toContain(
       "const refreshed = await refreshRelease(context.repository, release.id);",
     );
-    expect(postResolution).toContain(
-      "const { release, provenance } = resolveDraftReleaseById({",
-    );
+    expect(postResolution).toContain("resolveReleaseById({ context })");
     expect(postResolution).toContain(
       "const release = requirePublishedRelease(context, releaseId);",
     );

--- a/scripts/release/index.mjs
+++ b/scripts/release/index.mjs
@@ -450,18 +450,6 @@ const verifyDraftTag = ({ release, context }) => {
   }
 };
 
-const verifyDraftTarget = ({ release, context, allowLegacyTarget }) => {
-  const compatible =
-    release.target_commitish === context.releaseSha ||
-    release.target_commitish === context.release.tag ||
-    (allowLegacyTarget && release.target_commitish === "main");
-  if (!compatible) {
-    throw new Error(
-      `Draft target is ${release.target_commitish}; expected ${context.releaseSha}.`,
-    );
-  }
-};
-
 const requireReleaseProvenance = (body) => {
   const parsed = parseReleaseProvenance(body ?? "");
   if (parsed.status === "valid") return parsed;
@@ -487,19 +475,13 @@ const validateReleaseProvenance = ({ release, context }) => {
   return { parsed, provenance: parsed.provenance };
 };
 
-const validateResolvedDraftRelease = ({
-  release,
-  context,
-  releaseId,
-  allowLegacyTarget = false,
-}) => {
+const validateResolvedDraftRelease = ({ release, context, releaseId }) => {
   verifyResolvedReleaseId({ release, releaseId });
   if (release.draft !== true) {
     throw new Error(`GitHub Release ID ${releaseId} is not a draft.`);
   }
   verifyDraftTag({ release, context });
   verifyReleasePrerelease({ release, context });
-  verifyDraftTarget({ release, context, allowLegacyTarget });
   return validateReleaseProvenance({ release, context });
 };
 
@@ -521,18 +503,12 @@ const validateResolvedPublishedRelease = ({ release, context, releaseId }) => {
   return identity;
 };
 
-const validateResolvedRelease = ({
-  release,
-  context,
-  releaseId,
-  allowLegacyTarget = false,
-}) => {
+const validateResolvedRelease = ({ release, context, releaseId }) => {
   if (release?.draft === true) {
     return validateResolvedDraftRelease({
       release,
       context,
       releaseId,
-      allowLegacyTarget,
     });
   }
   return validateResolvedPublishedRelease({ release, context, releaseId });
@@ -545,22 +521,6 @@ const resolveReleaseById = ({
 }) => {
   const release = fetchRelease(context.repository, releaseId);
   const identity = validateResolvedRelease({ release, context, releaseId });
-  return { release, ...identity };
-};
-
-const resolveDraftReleaseById = ({
-  context,
-  releaseId = requiredReleaseId(),
-  fetchRelease = getReleaseById,
-  allowLegacyTarget = false,
-}) => {
-  const release = fetchRelease(context.repository, releaseId);
-  const identity = validateResolvedDraftRelease({
-    release,
-    context,
-    releaseId,
-    allowLegacyTarget,
-  });
   return { release, ...identity };
 };
 
@@ -586,7 +546,6 @@ const generateReleaseNotes = (repository, tag) =>
 
 const createDraftInput = ({ context, generated, provenance }) => ({
   tag_name: context.release.tag,
-  target_commitish: context.releaseSha,
   name: generated.name || context.release.tag,
   body: appendReleaseProvenance({
     body: generated.body ?? "",
@@ -594,7 +553,6 @@ const createDraftInput = ({ context, generated, provenance }) => ({
   }),
   draft: true,
   prerelease: context.release.prerelease,
-  make_latest: "false",
 });
 
 const createDraft = ({ context, provenance }) => {
@@ -614,38 +572,13 @@ const patchRelease = (repository, releaseId, input) =>
     input,
   });
 
-const draftReleaseInput = ({
-  context,
-  release,
-  body = release.body ?? "",
-}) => ({
-  tag_name: context.release.tag,
-  target_commitish: context.releaseSha,
-  name: release.name || context.release.tag,
-  body,
-  draft: true,
-  prerelease: context.release.prerelease,
-  make_latest: "false",
-});
-
-const publishedReleaseInput = ({ context, release, makeLatest = "false" }) => ({
-  tag_name: context.release.tag,
-  target_commitish: context.releaseSha,
-  name: release.name || context.release.tag,
-  body: release.body ?? "",
-  draft: false,
-  prerelease: context.release.prerelease,
-  make_latest: makeLatest,
-});
-
-const ensureDraftRelease = ({
+const ensureReleaseState = ({
   context,
   eventName,
   provenance,
   recoveryReleaseId,
   fetchRelease = getReleaseById,
   createRelease = createDraft,
-  updateRelease = patchRelease,
 }) => {
   if (eventName === "push") {
     const release = createRelease({ context, provenance });
@@ -661,19 +594,8 @@ const ensureDraftRelease = ({
   }
 
   const releaseId = recoveryReleaseId ?? requiredRecoveryReleaseId();
-  const resolved = fetchRelease(context.repository, releaseId);
-  validateResolvedDraftRelease({
-    release: resolved,
-    context,
-    releaseId,
-    allowLegacyTarget: true,
-  });
-  const release = updateRelease(
-    context.repository,
-    releaseId,
-    draftReleaseInput({ context, release: resolved }),
-  );
-  const identity = validateResolvedDraftRelease({
+  const release = fetchRelease(context.repository, releaseId);
+  const identity = validateResolvedRelease({
     release,
     context,
     releaseId,
@@ -688,11 +610,10 @@ const publishDraftRelease = ({
   fetchRelease = getReleaseById,
 }) => {
   const releaseId = release.id;
-  const updated = updateRelease(
-    context.repository,
-    releaseId,
-    publishedReleaseInput({ context, release }),
-  );
+  const updated = updateRelease(context.repository, releaseId, {
+    draft: false,
+    make_latest: "false",
+  });
   validateResolvedPublishedRelease({
     release: updated,
     context,
@@ -1240,9 +1161,7 @@ const commandPreflight = async () => {
     ["tag_object", identity.tagObject],
     ["tag_type", identity.tagType],
     ["image_repository", imageRepository],
-    ["release_ci_run_id", releaseCiRun.id],
     ["tooling_sha", toolingSha],
-    ["tooling_ci_run_id", toolingCiRun.id],
   ]);
   await writeSummary(
     `## REL-01 preflight\n\n- Tag: \`${release.tag}\`\n- Tag object: \`${identity.tagObject}\`\n- Release commit: \`${identity.releaseSha}\`\n- Release CI run: \`${releaseCiRun.id}\`\n- Tooling commit: \`${toolingSha}\`\n- Tooling CI run: \`${toolingCiRun.id}\`\n- Channel: ${release.prerelease ? "prerelease" : "stable"}`,
@@ -1253,7 +1172,7 @@ const commandVerifyTag = async () => {
   verifyRecordedTagIdentity(releaseContextFromEnv());
 };
 
-const commandEnsureDraft = async () => {
+const commandEnsureRelease = async () => {
   const context = releaseContextFromEnv();
   verifyRecordedTagIdentity(context);
   const pending = buildReleaseProvenance({
@@ -1264,27 +1183,24 @@ const commandEnsureDraft = async () => {
     immutableImage: "pending",
     assetChecksums: null,
   });
-  const { release, provenance } = ensureDraftRelease({
+  const { release, provenance } = ensureReleaseState({
     context,
     eventName: requiredEnv("RELEASE_EVENT_NAME"),
     provenance: pending,
   });
   if (provenance.imageDigest !== "pending") {
     console.info(
-      "Compatible draft already contains complete image provenance.",
+      "Compatible release already contains complete image provenance.",
     );
   }
 
-  await writeOutputs([
-    ["release_id", release.id],
-    ["published", false],
-  ]);
+  await writeOutput("release_id", release.id);
 };
 
 const commandInspectImage = async () => {
   const context = releaseContextFromEnv();
   verifyRecordedTagIdentity(context);
-  const { release, provenance } = resolveDraftReleaseById({ context });
+  const { release, provenance } = resolveReleaseById({ context });
   const exactReference = `${context.imageRepository}:${context.release.tag}`;
   const inspected = inspectImage(exactReference, { allowMissing: true });
   if (!inspected) {
@@ -1396,6 +1312,7 @@ const reconcileDraftProvenance = ({
   release,
   provenance,
   complete,
+  updateRelease = patchRelease,
 }) => {
   if (provenance.imageDigest === "pending") {
     const body = replaceReleaseProvenance({
@@ -1403,11 +1320,7 @@ const reconcileDraftProvenance = ({
       expected: provenance,
       next: complete,
     });
-    const updated = patchRelease(
-      context.repository,
-      release.id,
-      draftReleaseInput({ context, release, body }),
-    );
+    const updated = updateRelease(context.repository, release.id, { body });
     validateResolvedDraftRelease({
       release: updated,
       context,
@@ -1521,7 +1434,7 @@ const commandReconcileRelease = async () => {
   const imageDigest = requiredEnv("IMAGE_DIGEST");
   verifyRecordedTagIdentity(context);
   const localAssets = await generatedAssets();
-  const { release, provenance } = resolveDraftReleaseById({ context });
+  const { release, provenance } = resolveReleaseById({ context });
   const complete = expectedCompleteProvenance({
     context,
     imageDigest,
@@ -1544,7 +1457,7 @@ const commandPublish = async () => {
   verifyImage({ context, digest: imageDigest });
   const localAssets = await generatedAssets();
   const releaseId = requiredReleaseId();
-  const { release, provenance } = resolveDraftReleaseById({
+  const { release, provenance } = resolveReleaseById({
     context,
     releaseId,
   });
@@ -1559,7 +1472,9 @@ const commandPublish = async () => {
   await verifyRemoteAssets({ context, release, localAssets });
   verifyRecordedTagIdentity(context);
 
-  const published = publishDraftRelease({ context, release });
+  const published = release.draft
+    ? publishDraftRelease({ context, release })
+    : release;
   await verifyRemoteAssets({ context, release: published, localAssets });
   verifyImage({ context, digest: imageDigest });
   verifyRecordedTagIdentity(context);
@@ -1625,25 +1540,31 @@ const verifyLatestResult = ({
   }
 };
 
-const markGitHubReleaseLatest = ({ context, release, plan }) => {
+const markGitHubReleaseLatest = ({
+  context,
+  release,
+  plan,
+  updateRelease = patchRelease,
+  fetchRelease = getReleaseById,
+  fetchLatestRelease = (repository) =>
+    ghApi(`repos/${repository}/releases/latest`),
+}) => {
   if (plan.action === "superseded") return;
-  const updated = patchRelease(
-    context.repository,
-    release.id,
-    publishedReleaseInput({ context, release, makeLatest: "true" }),
-  );
+  const updated = updateRelease(context.repository, release.id, {
+    make_latest: "true",
+  });
   validateResolvedPublishedRelease({
     release: updated,
     context,
     releaseId: release.id,
   });
-  const refreshed = getReleaseById(context.repository, release.id);
+  const refreshed = fetchRelease(context.repository, release.id);
   validateResolvedPublishedRelease({
     release: refreshed,
     context,
     releaseId: release.id,
   });
-  const latestRelease = ghApi(`repos/${context.repository}/releases/latest`);
+  const latestRelease = fetchLatestRelease(context.repository);
   if (latestRelease.tag_name !== context.release.tag) {
     throw new Error(
       `GitHub latest release is ${latestRelease.tag_name}; expected ${context.release.tag}.`,
@@ -1692,21 +1613,32 @@ const commandPromoteLatest = async () => {
     : promoteStableLatest({ context, imageDigest, releaseId });
 };
 
+const recoveryRetryGuidance = (releaseId) =>
+  releaseId === "unresolved"
+    ? "- Inspect release inventory, select one exact compatible release ID, then retry with **Run workflow** from `main` and the same existing tag."
+    : "- Retry matching partial state with **Run workflow** from `main`, the same existing tag, and the exact release ID above.";
+
+const summaryReleaseId = () =>
+  optionalEnv("RELEASE_ID") ||
+  optionalEnv("RECOVERY_RELEASE_ID") ||
+  "unresolved";
+
 const commandSummary = async () => {
   const tag = optionalEnv("RELEASE_TAG") || "unknown";
   const releaseSha = optionalEnv("RELEASE_SHA") || "unknown";
   const tagObject = optionalEnv("TAG_OBJECT_SHA") || "unknown";
   const toolingSha = optionalEnv("TOOLING_SHA") || "unknown";
+  const releaseId = summaryReleaseId();
   const result = optionalEnv("RELEASE_RESULT") || "unknown";
   await writeSummary(
-    `## Release recovery\n\nResult: **${result}**\n\n- Tag: \`${tag}\`\n- Tag object: \`${tagObject}\`\n- Release commit: \`${releaseSha}\`\n- Tooling commit: \`${toolingSha}\`\n\n- Retry matching partial state with **Run workflow** from \`main\` and the same existing tag.\n- Do not move/delete the tag, clobber assets, or overwrite a conflicting image.\n- Conflicts require manual comparison of reported expected and actual SHA/digest values.`,
+    `## Release recovery\n\nResult: **${result}**\n\n- Tag: \`${tag}\`\n- Release ID: \`${releaseId}\`\n- Tag object: \`${tagObject}\`\n- Release commit: \`${releaseSha}\`\n- Tooling commit: \`${toolingSha}\`\n\n${recoveryRetryGuidance(releaseId)}\n- Do not move/delete the tag, clobber assets, or overwrite a conflicting image.\n- Conflicts require manual comparison of reported expected and actual SHA/digest values.`,
   );
 };
 
 const commands = {
   preflight: commandPreflight,
   "verify-tag": commandVerifyTag,
-  "ensure-draft": commandEnsureDraft,
+  "ensure-release": commandEnsureRelease,
   "inspect-image": commandInspectImage,
   "verify-image": commandVerifyImage,
   "generate-assets": commandGenerateAssets,
@@ -1719,18 +1651,17 @@ const commands = {
 export {
   assetDirectory,
   createDraftInput,
-  draftReleaseInput,
-  ensureDraftRelease,
+  ensureReleaseState,
   getReleaseById,
+  markGitHubReleaseLatest,
   publishDraftRelease,
-  publishedReleaseInput,
   readPackageVersions,
   readReleaseTemplates,
   reconcileReleaseAssets,
+  reconcileDraftProvenance,
   releaseAssetUploadUrl,
   requiredRecoveryReleaseId,
   requiredReleaseId,
-  resolveDraftReleaseById,
   resolvePublishedReleaseById,
   resolveReleaseById,
   resolveTagIdentity,
@@ -1754,9 +1685,10 @@ if (process.argv[1] && path.resolve(process.argv[1]) === SCRIPT_PATH) {
     await commands[command]();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    const releaseId = summaryReleaseId();
     console.error(message);
     await writeSummary(
-      `## REL-01 failure\n\n\`\`\`text\n${message}\n\`\`\`\n\nRetry matching partial state with **Run workflow** from \`main\` and the same existing tag. Do not move/delete the tag, clobber assets, or overwrite a conflicting image. Conflicts require manual comparison of reported expected and actual SHA/digest values.`,
+      `## REL-01 failure\n\n\`\`\`text\n${message}\n\`\`\`\n\nRelease ID: \`${releaseId}\`\n\n${recoveryRetryGuidance(releaseId)}\n- Do not move/delete the tag, clobber assets, or overwrite a conflicting image.\n- Conflicts require manual comparison of reported expected and actual SHA/digest values.`,
     );
     process.exitCode = 1;
   }


### PR DESCRIPTION
## 🚀 Summary

Fix release recovery by treating GitHub's draft placeholder tag and target metadata as opaque, binding recovery to the exact release ID plus managed provenance, and publishing with the smallest required PATCH.

## 📊 Impacts and Changes

Release retries no longer rewrite `tag_name`, `target_commitish`, name, prerelease state, or body during draft resolution/publication. Tag-push creation omits redundant target/latest fields. Already-published exact releases can be resumed safely. No schema, auth, storage, restore, or UI behavior changes.

## 🧪 Testing Checklist

- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] `pnpm build` successful
- [x] I added or updated tests for behavior changes, or this change does not alter behavior.
- [x] If this PR changes UI or UX behavior, I verified it manually in the local dev environment.

Additional validation: `pnpm format:check`, `pnpm quality:fallow`, focused release tests (39 passed), and `git diff --check`.

## Review Checklist

- [x] I called out schema, auth, storage, or restore behavior changes when they apply.
- [x] I did not commit secrets, runtime data, or generated local storage contents.

## 🧗 Follow-ups or Limitations

After merge and successful `main` CI, resume `v1.0.0-rc.7` using exact release ID `358937700`; verify publication, assets, tag identity, and image digest before removing the two validated empty duplicate drafts.

## 🔗 Linked Issues

None.
